### PR TITLE
feat: add custom titles, message counts, and subagent indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Add to your MCP configuration (e.g., `~/.claude/.mcp.json`):
 
 The MCP server exposes two tools:
 
-| Tool                   | Description                                                                 |
-| ---------------------- | --------------------------------------------------------------------------- |
-| `search_sessions`      | Search across sessions by keyword, filter by tool or project, list recent   |
-| `get_session_messages`  | Retrieve messages from a specific session, paginated by offset and limit    |
+| Tool                   | Description                                                               |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `search_sessions`      | Search across sessions by keyword, filter by tool or project, list recent |
+| `get_session_messages` | Retrieve messages from a specific session, paginated by offset and limit  |
 
 ### Search index
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,7 +4,15 @@ import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { readdir } from 'node:fs/promises';
 import { type Tool, type SessionResult } from './types';
-import { getCwdFromSession, firstPrompt, lastTimestamp, getSessionMessages } from './parser';
+import {
+  getCwdFromSession,
+  firstPrompt,
+  lastTimestamp,
+  getSessionMessages,
+  customTitle,
+  firstTimestamp,
+  messageCount,
+} from './parser';
 
 const CACHE_DIR = join(homedir(), '.cache', 'sessions');
 const DB_PATH = join(CACHE_DIR, 'index.db');
@@ -14,13 +22,17 @@ const CLAUDE_DIR = join(home, '.claude/projects');
 const PI_DIR = join(home, '.pi/agent/sessions');
 const CODEX_DIR = join(home, '.codex/sessions');
 
+const SCHEMA_VERSION = 2;
 let _db: Database | null = null;
 
 export function clearCache(): void {
   const files = [DB_PATH, DB_PATH + '-wal', DB_PATH + '-shm'];
   let cleared = false;
   for (const f of files) {
-    try { require('node:fs').unlinkSync(f); cleared = true; } catch {}
+    try {
+      require('node:fs').unlinkSync(f);
+      cleared = true;
+    } catch {}
   }
   process.stderr.write(cleared ? 'Cache cleared. It will rebuild on next use.\n' : 'No cache to clear.\n');
 }
@@ -29,9 +41,17 @@ function getDb(): Database {
   if (_db) return _db;
   mkdirSync(CACHE_DIR, { recursive: true });
   const db = new Database(DB_PATH);
-  db.exec('PRAGMA journal_mode=WAL');
-  db.exec('PRAGMA synchronous=NORMAL');
-  db.exec(`
+  db.run('PRAGMA journal_mode=WAL');
+  db.run('PRAGMA synchronous=NORMAL');
+
+  const row = db.query<{ user_version: number }, []>('PRAGMA user_version').get();
+  if (!row || row.user_version !== SCHEMA_VERSION) {
+    db.run('DROP TABLE IF EXISTS sessions');
+    db.run('DROP TABLE IF EXISTS session_fts');
+    db.run(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+  }
+
+  db.run(`
     CREATE TABLE IF NOT EXISTS sessions (
       file_path TEXT PRIMARY KEY,
       mtime REAL NOT NULL,
@@ -40,10 +60,13 @@ function getDb(): Database {
       tool TEXT NOT NULL,
       session_id TEXT NOT NULL,
       date TEXT NOT NULL,
-      first_prompt TEXT NOT NULL
+      created_at TEXT NOT NULL DEFAULT '?',
+      first_prompt TEXT NOT NULL,
+      custom_title TEXT NOT NULL DEFAULT '',
+      message_count INTEGER NOT NULL DEFAULT 0
     )
   `);
-  db.exec(`
+  db.run(`
     CREATE VIRTUAL TABLE IF NOT EXISTS session_fts USING fts5(
       file_path UNINDEXED,
       user_content
@@ -63,7 +86,11 @@ async function discoverFiles(): Promise<FileEntry[]> {
 
   if (existsSync(CLAUDE_DIR)) {
     let dirs: string[];
-    try { dirs = await readdir(CLAUDE_DIR); } catch { dirs = []; }
+    try {
+      dirs = await readdir(CLAUDE_DIR);
+    } catch {
+      dirs = [];
+    }
     for (const dirname of dirs) {
       const dirpath = join(CLAUDE_DIR, dirname);
       const glob = new Bun.Glob('*.jsonl');
@@ -75,7 +102,11 @@ async function discoverFiles(): Promise<FileEntry[]> {
 
   if (existsSync(PI_DIR)) {
     let dirs: string[];
-    try { dirs = await readdir(PI_DIR); } catch { dirs = []; }
+    try {
+      dirs = await readdir(PI_DIR);
+    } catch {
+      dirs = [];
+    }
     for (const dirname of dirs) {
       const dirpath = join(PI_DIR, dirname);
       const glob = new Bun.Glob('*.jsonl');
@@ -95,20 +126,50 @@ async function discoverFiles(): Promise<FileEntry[]> {
   return entries;
 }
 
+function collectSubagentContent(filePath: string): string {
+  const dir = join(filePath.replace(/\.jsonl$/, ''), 'subagents');
+  if (!existsSync(dir)) return '';
+
+  const parts: string[] = [];
+  try {
+    const files = require('node:fs').readdirSync(dir) as string[];
+    for (const f of files) {
+      if (!f.endsWith('.jsonl')) continue;
+      try {
+        const raw = readFileSync(join(dir, f), 'utf-8');
+        const lines = raw.trimEnd().split('\n');
+        const msgs = getSessionMessages(lines);
+        for (const m of msgs) {
+          if (m.role === 'user') parts.push(m.text);
+        }
+      } catch {}
+    }
+  } catch {}
+  return parts.join('\n');
+}
+
 function indexFile(db: Database, filePath: string, tool: Tool): boolean {
   let stat;
-  try { stat = statSync(filePath); } catch { return false; }
+  try {
+    stat = statSync(filePath);
+  } catch {
+    return false;
+  }
 
-  const existing = db.query<{ mtime: number; size: number }, [string]>(
-    'SELECT mtime, size FROM sessions WHERE file_path = ?'
-  ).get(filePath);
+  const existing = db
+    .query<{ mtime: number; size: number }, [string]>('SELECT mtime, size FROM sessions WHERE file_path = ?')
+    .get(filePath);
 
   if (existing && existing.mtime === stat.mtimeMs && existing.size === stat.size) {
     return false;
   }
 
   let raw: string;
-  try { raw = readFileSync(filePath, 'utf-8'); } catch { return false; }
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch {
+    return false;
+  }
   const lines = raw.trimEnd().split('\n');
   if (lines.length === 0) return false;
 
@@ -118,7 +179,10 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
 
   const sessionId = basename(filePath).replace('.jsonl', '');
   const prompt = firstPrompt(lines, tool);
+  const title = customTitle(lines);
   const date = lastTimestamp(raw);
+  const createdAt = firstTimestamp(lines);
+  const msgCount = messageCount(lines);
 
   const messages = getSessionMessages(lines);
   const userContent = messages
@@ -126,18 +190,18 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
     .map((m) => m.text)
     .join('\n');
 
+  const subagentContent = tool === 'claude' ? collectSubagentContent(filePath) : '';
+  const fullContent = subagentContent ? userContent + '\n' + subagentContent : userContent;
+
   if (existing) {
     db.run('DELETE FROM session_fts WHERE file_path = ?', [filePath]);
   }
   db.run(
-    `INSERT OR REPLACE INTO sessions (file_path, mtime, size, cwd, tool, session_id, date, first_prompt)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    [filePath, stat.mtimeMs, stat.size, cwd, tool, sessionId, date, prompt]
+    `INSERT OR REPLACE INTO sessions (file_path, mtime, size, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [filePath, stat.mtimeMs, stat.size, cwd, tool, sessionId, date, createdAt, prompt, title, msgCount],
   );
-  db.run(
-    'INSERT INTO session_fts (file_path, user_content) VALUES (?, ?)',
-    [filePath, userContent]
-  );
+  db.run('INSERT INTO session_fts (file_path, user_content) VALUES (?, ?)', [filePath, fullContent]);
   return true;
 }
 
@@ -181,18 +245,27 @@ export async function searchSessions(
   const db = getDb();
   await refreshIndex();
 
-  let rows: Array<{
+  interface SessionRow {
     file_path: string;
     cwd: string;
     tool: string;
     session_id: string;
     date: string;
+    created_at: string;
     first_prompt: string;
+    custom_title: string;
+    message_count: number;
     snippet: string | null;
-  }>;
+  }
+
+  let rows: SessionRow[];
 
   if (query) {
-    const ftsQuery = query.replace(/['"]/g, '').split(/\s+/).map((w) => `"${w}"`).join(' ');
+    const ftsQuery = query
+      .replace(/['"]/g, '')
+      .split(/\s+/)
+      .map((w) => `"${w}"`)
+      .join(' ');
     const conditions: string[] = [];
     const params: (string | number)[] = [ftsQuery];
 
@@ -207,8 +280,10 @@ export async function searchSessions(
     params.push(limit);
 
     const extra = conditions.length > 0 ? 'AND ' + conditions.join(' AND ') : '';
-    rows = db.query<any, any[]>(`
-      SELECT s.file_path, s.cwd, s.tool, s.session_id, s.date, s.first_prompt,
+    rows = db
+      .query<SessionRow, any[]>(`
+      SELECT s.file_path, s.cwd, s.tool, s.session_id, s.date, s.created_at, s.first_prompt,
+             s.custom_title, s.message_count,
              snippet(session_fts, 1, '', '', '…', 32) as snippet
       FROM session_fts f
       JOIN sessions s ON s.file_path = f.file_path
@@ -216,7 +291,8 @@ export async function searchSessions(
       ${extra}
       ORDER BY s.date DESC
       LIMIT ?
-    `).all(...params);
+    `)
+      .all(...params);
   } else {
     const conditions: string[] = [];
     const params: (string | number)[] = [];
@@ -232,19 +308,25 @@ export async function searchSessions(
     params.push(limit);
 
     const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : '';
-    rows = db.query<any, any[]>(`
-      SELECT file_path, cwd, tool, session_id, date, first_prompt, NULL as snippet
+    rows = db
+      .query<SessionRow, any[]>(`
+      SELECT file_path, cwd, tool, session_id, date, created_at, first_prompt,
+             custom_title, message_count, NULL as snippet
       FROM sessions ${where}
       ORDER BY date DESC LIMIT ?
-    `).all(...params);
+    `)
+      .all(...params);
   }
 
   return rows.map((r) => ({
     date: r.date,
+    createdAt: r.created_at,
     cwd: r.cwd,
     tool: r.tool as Tool,
     sessionId: r.session_id,
-    displayText: r.snippet ?? r.first_prompt,
+    displayText: r.snippet ?? (r.custom_title || r.first_prompt),
+    customTitle: r.custom_title,
+    messageCount: r.message_count,
     filePath: r.file_path,
     exists: existsSync(r.cwd),
   }));

--- a/src/display.ts
+++ b/src/display.ts
@@ -27,11 +27,12 @@ export function formatLine(r: SessionResult, cols: number): string {
   const tc = toolColor[r.tool] ?? '';
   const toolBadge = `${tc}${r.tool}${C.reset}`;
   const rel = relativeDate(r.date);
+  const msgs = r.messageCount > 0 ? `${C.dim}${r.messageCount}msg${C.reset}` : '';
 
-  const maxPrompt = Math.max(20, cols - 40);
+  const maxPrompt = Math.max(20, cols - 50);
   const truncated = prompt.length > maxPrompt ? prompt.slice(0, maxPrompt - 1) + '…' : prompt;
 
-  const display = `${dot} ${C.bold}${dirName}${C.reset}  ${toolBadge}  ${C.dim}${rel}${C.reset}  ${truncated}`;
+  const display = `${dot} ${C.bold}${dirName}${C.reset}  ${toolBadge}  ${C.dim}${rel}${C.reset}  ${msgs ? msgs + '  ' : ''}${truncated}`;
 
   // tab-separated: cwd, tool, sessionId, exists, prompt, display
   return `${r.cwd}\t${r.tool}\t${r.sessionId}\t${r.exists ? 'exists' : 'deleted'}\t${prompt}\t${display}`;

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { searchSessions, refreshIndex } from './cache';
+import { searchSessions } from './cache';
 import { getSessionMessages } from './parser';
 import { type SessionResult } from './types';
 
@@ -30,8 +30,11 @@ server.tool(
       sessionId: r.sessionId,
       tool: r.tool,
       date: r.date,
+      createdAt: r.createdAt,
       project: r.cwd,
+      title: r.customTitle || null,
       snippet: r.displayText,
+      messageCount: r.messageCount,
       exists: r.exists,
       filePath: r.filePath,
     }));

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,0 +1,244 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  customTitle,
+  firstTimestamp,
+  messageCount,
+  firstPrompt,
+  getSessionMessages,
+  lastTimestamp,
+  contentMatches,
+  findMatchContext,
+  getCwdFromSession,
+} from './parser';
+
+function jsonl(...objs: Record<string, unknown>[]): string[] {
+  return objs.map((o) => JSON.stringify(o));
+}
+
+describe('customTitle', () => {
+  test('returns empty string when no custom-title row exists', () => {
+    const lines = jsonl({ type: 'user', message: { content: 'hello' } });
+    expect(customTitle(lines)).toBe('');
+  });
+
+  test('returns the title from a custom-title row', () => {
+    const lines = jsonl(
+      { type: 'user', message: { content: 'hello' }, timestamp: '2026-01-01T00:00:00Z' },
+      { type: 'custom-title', customTitle: 'My Session', sessionId: 'abc', timestamp: '2026-01-01T00:01:00Z' },
+    );
+    expect(customTitle(lines)).toBe('My Session');
+  });
+
+  test('uses the last custom-title if renamed multiple times', () => {
+    const lines = jsonl(
+      { type: 'custom-title', customTitle: 'First Name' },
+      { type: 'custom-title', customTitle: 'Second Name' },
+      { type: 'custom-title', customTitle: 'Final Name' },
+    );
+    expect(customTitle(lines)).toBe('Final Name');
+  });
+});
+
+describe('firstTimestamp', () => {
+  test('returns the first timestamp found', () => {
+    const lines = jsonl(
+      { type: 'user', timestamp: '2026-03-15T10:00:00Z' },
+      { type: 'assistant', timestamp: '2026-03-15T10:01:00Z' },
+    );
+    expect(firstTimestamp(lines)).toBe('2026-03-15');
+  });
+
+  test('returns ? when no timestamp exists', () => {
+    const lines = jsonl({ type: 'user', message: { content: 'hi' } });
+    expect(firstTimestamp(lines)).toBe('?');
+  });
+
+  test('skips non-date timestamps', () => {
+    const lines = jsonl({ type: 'user', timestamp: 'not-a-date' }, { type: 'user', timestamp: '2026-05-01T12:00:00Z' });
+    expect(firstTimestamp(lines)).toBe('2026-05-01');
+  });
+});
+
+describe('messageCount', () => {
+  test('counts user and assistant messages', () => {
+    const lines = jsonl(
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      { type: 'assistant', message: { content: 'hello' } },
+      { type: 'user', message: { role: 'user', content: 'bye' } },
+      { type: 'assistant', message: { content: 'goodbye' } },
+    );
+    expect(messageCount(lines)).toBe(4);
+  });
+
+  test('ignores system and other row types', () => {
+    const lines = jsonl(
+      { type: 'system' },
+      { type: 'user', message: { role: 'user', content: 'hi' } },
+      { type: 'custom-title', customTitle: 'test' },
+      { type: 'tag', tag: 'v1' },
+    );
+    expect(messageCount(lines)).toBe(1);
+  });
+
+  test('counts pi/codex style message rows', () => {
+    const lines = jsonl(
+      { type: 'message', message: { role: 'user', content: 'q' } },
+      { type: 'message', message: { role: 'assistant', content: 'a' } },
+    );
+    expect(messageCount(lines)).toBe(2);
+  });
+
+  test('returns 0 for empty lines', () => {
+    expect(messageCount([])).toBe(0);
+  });
+});
+
+describe('firstPrompt', () => {
+  test('extracts first user prompt for claude sessions', () => {
+    const lines = jsonl(
+      { type: 'system', cwd: '/tmp' },
+      { type: 'user', message: { content: [{ type: 'text', text: 'Refactor auth middleware' }] } },
+    );
+    expect(firstPrompt(lines, 'claude')).toBe('Refactor auth middleware');
+  });
+
+  test('strips system-reminder tags from prompt', () => {
+    const lines = jsonl({
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'Do the thing <system-reminder>ignore this</system-reminder>' }] },
+    });
+    expect(firstPrompt(lines, 'claude')).toBe('Do the thing');
+  });
+
+  test('extracts first user prompt for pi sessions', () => {
+    const lines = jsonl(
+      { type: 'session', cwd: '/tmp' },
+      { type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'Help me debug' }] } },
+    );
+    expect(firstPrompt(lines, 'pi')).toBe('Help me debug');
+  });
+
+  test('extracts first user prompt for codex sessions', () => {
+    const lines = jsonl(
+      { type: 'session_meta', payload: { cwd: '/tmp' } },
+      { type: 'message', message: { role: 'user', content: [{ type: 'input_text', text: 'Add tests' }] } },
+    );
+    expect(firstPrompt(lines, 'codex')).toBe('Add tests');
+  });
+
+  test('truncates long prompts to 100 chars', () => {
+    const longText = 'A'.repeat(200);
+    const lines = jsonl({ type: 'user', message: { content: [{ type: 'text', text: longText }] } });
+    expect(firstPrompt(lines, 'claude').length).toBeLessThanOrEqual(100);
+  });
+
+  test('returns empty for no user messages', () => {
+    const lines = jsonl({ type: 'system', cwd: '/tmp' });
+    expect(firstPrompt(lines, 'claude')).toBe('');
+  });
+});
+
+describe('lastTimestamp', () => {
+  test('returns the last timestamp from content', () => {
+    const content = [
+      JSON.stringify({ type: 'user', timestamp: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ type: 'assistant', timestamp: '2026-01-01T12:00:00Z' }),
+      JSON.stringify({ type: 'user', timestamp: '2026-01-02T08:00:00Z' }),
+    ].join('\n');
+    expect(lastTimestamp(content)).toBe('2026-01-02');
+  });
+
+  test('returns ? for no timestamps', () => {
+    const content = JSON.stringify({ type: 'user' });
+    expect(lastTimestamp(content)).toBe('?');
+  });
+});
+
+describe('getCwdFromSession', () => {
+  test('extracts cwd from claude session', () => {
+    const lines = jsonl({ type: 'user', cwd: '/Users/me/project' });
+    expect(getCwdFromSession(lines, 'claude')).toBe('/Users/me/project');
+  });
+
+  test('extracts cwd from pi session', () => {
+    const lines = jsonl({ type: 'session', cwd: '/Users/me/project' });
+    expect(getCwdFromSession(lines, 'pi')).toBe('/Users/me/project');
+  });
+
+  test('extracts cwd from codex session', () => {
+    const lines = jsonl({ type: 'session_meta', payload: { cwd: '/Users/me/project' } });
+    expect(getCwdFromSession(lines, 'codex')).toBe('/Users/me/project');
+  });
+
+  test('returns empty string when no cwd found', () => {
+    const lines = jsonl({ type: 'user', message: { content: 'hi' } });
+    expect(getCwdFromSession(lines, 'claude')).toBe('');
+  });
+});
+
+describe('getSessionMessages', () => {
+  test('extracts user and assistant messages in order', () => {
+    const lines = jsonl(
+      { type: 'user', message: { content: [{ type: 'text', text: 'What is 2+2?' }] } },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'The answer is 4.' }] } },
+    );
+    const msgs = getSessionMessages(lines);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.role).toBe('user');
+    expect(msgs[0]!.text).toContain('2+2');
+    expect(msgs[1]!.role).toBe('assistant');
+    expect(msgs[1]!.text).toContain('4');
+  });
+
+  test('skips rows with empty text', () => {
+    const lines = jsonl(
+      { type: 'user', message: { content: [{ type: 'text', text: '' }] } },
+      { type: 'user', message: { content: [{ type: 'text', text: 'real question' }] } },
+    );
+    const msgs = getSessionMessages(lines);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.text).toContain('real question');
+  });
+
+  test('handles pi/codex message format', () => {
+    const lines = jsonl(
+      { type: 'message', message: { role: 'user', content: 'hello' } },
+      { type: 'message', message: { role: 'assistant', content: 'hi there' } },
+    );
+    const msgs = getSessionMessages(lines);
+    expect(msgs).toHaveLength(2);
+  });
+});
+
+describe('contentMatches', () => {
+  test('matches case-insensitively in user messages', () => {
+    const lines = jsonl({ type: 'user', message: { content: [{ type: 'text', text: 'Fix the Authentication bug' }] } });
+    expect(contentMatches(lines, 'authentication')).toBe(true);
+  });
+
+  test('does not match assistant messages', () => {
+    const lines = jsonl({ type: 'assistant', message: { content: [{ type: 'text', text: 'authentication fixed' }] } });
+    expect(contentMatches(lines, 'authentication')).toBe(false);
+  });
+
+  test('returns false when no match', () => {
+    const lines = jsonl({ type: 'user', message: { content: [{ type: 'text', text: 'hello world' }] } });
+    expect(contentMatches(lines, 'foobar')).toBe(false);
+  });
+});
+
+describe('findMatchContext', () => {
+  test('returns snippet around match', () => {
+    const lines = jsonl({
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'Please fix the authentication middleware in the server' }] },
+    });
+    const ctx = findMatchContext(lines, 'authentication');
+    expect(ctx).toContain('authentication');
+  });
+
+  test('returns empty string when no match', () => {
+    const lines = jsonl({ type: 'user', message: { content: [{ type: 'text', text: 'hello' }] } });
+    expect(findMatchContext(lines, 'nonexistent')).toBe('');
+  });
+});

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -130,6 +130,42 @@ export function firstPrompt(lines: string[], tool: Tool): string {
   return '';
 }
 
+export function customTitle(lines: string[]): string {
+  let title = '';
+  for (const line of lines) {
+    const d = tryParseJson(line);
+    if (!d) continue;
+    if (d.type === 'custom-title') {
+      title = ((d as Record<string, unknown>).customTitle as string) ?? '';
+    }
+  }
+  return title;
+}
+
+export function firstTimestamp(lines: string[]): string {
+  for (const line of lines) {
+    const d = tryParseJson(line);
+    if (!d) continue;
+    const ts = d.timestamp as string | undefined;
+    if (ts && ts[0] === '2') return ts.slice(0, 10);
+  }
+  return '?';
+}
+
+export function messageCount(lines: string[]): number {
+  let count = 0;
+  for (const line of lines) {
+    const d = tryParseJson(line);
+    if (!d) continue;
+    if (isUserMessage(d) || d.type === 'assistant') count++;
+    else if (d.type === 'message') {
+      const msg = d.message;
+      if (typeof msg === 'object' && msg !== null && (msg as Record<string, unknown>).role === 'assistant') count++;
+    }
+  }
+  return count;
+}
+
 export function lastTimestamp(content: string): string {
   const lines = content.trimEnd().split('\n');
   for (let i = lines.length - 1; i >= Math.max(0, lines.length - 200); i--) {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -3,7 +3,16 @@ import { join, basename } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { type Tool, type SessionResult } from './types';
-import { getCwdFromSession, firstPrompt, lastTimestamp, contentMatches, findMatchContext } from './parser';
+import {
+  getCwdFromSession,
+  firstPrompt,
+  lastTimestamp,
+  contentMatches,
+  findMatchContext,
+  customTitle,
+  firstTimestamp,
+  messageCount,
+} from './parser';
 
 const home = homedir();
 const CLAUDE_DIR = join(home, '.claude/projects');
@@ -36,16 +45,41 @@ async function processSession(
 
   const sessionId = basename(filePath).replace('.jsonl', '');
 
+  const date = lastTimestamp(raw);
+  const createdAt = firstTimestamp(lines);
+  const title = customTitle(lines);
+  const msgCount = messageCount(lines);
+
   if (searchQuery) {
     if (!contentMatches(lines, searchQuery)) return null;
     const displayText = findMatchContext(lines, searchQuery);
-    const date = lastTimestamp(raw);
-    return { date, cwd, tool, sessionId, displayText, filePath, exists: existsSync(cwd) };
+    return {
+      date,
+      createdAt,
+      cwd,
+      tool,
+      sessionId,
+      displayText,
+      customTitle: title,
+      messageCount: msgCount,
+      filePath,
+      exists: existsSync(cwd),
+    };
   }
 
-  const displayText = firstPrompt(lines, tool);
-  const date = lastTimestamp(raw);
-  return { date, cwd, tool, sessionId, displayText, filePath, exists: existsSync(cwd) };
+  const displayText = title || firstPrompt(lines, tool);
+  return {
+    date,
+    createdAt,
+    cwd,
+    tool,
+    sessionId,
+    displayText,
+    customTitle: title,
+    messageCount: msgCount,
+    filePath,
+    exists: existsSync(cwd),
+  };
 }
 
 async function scanDir(

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,10 +2,13 @@ export type Tool = 'claude' | 'pi' | 'codex';
 
 export interface SessionResult {
   date: string;
+  createdAt: string;
   cwd: string;
   tool: Tool;
   sessionId: string;
   displayText: string;
+  customTitle: string;
+  messageCount: number;
   filePath: string;
   exists: boolean;
 }


### PR DESCRIPTION
## Summary

- **Custom titles**: Sessions with a `custom-title` JSONL row now display their title instead of the first prompt in fzf and MCP results
- **Message count + createdAt**: `SessionResult` now carries `messageCount` and `createdAt`; message count is shown in the fzf listing (e.g. `42msg`)
- **Subagent indexing**: Claude Code subagent transcripts (`<session>/subagents/agent-*.jsonl`) are folded into the parent session's FTS5 index, so searching for terms discussed by subagents surfaces the parent session
- **MCP enrichment**: `search_sessions` results now include `createdAt`, `title`, and `messageCount`
- **Schema versioning**: Cache DB uses `PRAGMA user_version` to auto-drop and rebuild on schema changes (v1 → v2)
- **Tests**: 30 unit tests for parser functions via `bun:test`

Inspired by patterns in [dexhorthy/shannon](https://github.com/dexhorthy/shannon).

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format:check` — all files formatted
- [x] `bun test src/parser.test.ts` — 30/30 pass
- [x] Verified new parser functions against real session data
- [x] Full cache rebuild with new schema (3319 sessions indexed)
- [x] FTS search returns subagent content matches
- [ ] Manual: `bun run dev` — confirm message counts visible in fzf
- [ ] Manual: `bun run dev "search term"` — confirm subagent hits