### PR TITLE
feat: add get_activity_digest MCP tool

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, statSync, readFileSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { readdir } from 'node:fs/promises';
-import { type Tool, type SessionResult } from './types';
+import { type Tool, type SessionResult, type ActivityDigest, type DigestSession, type DigestDay } from './types';
 import {
   getCwdFromSession,
   firstPrompt,
@@ -330,4 +330,97 @@ export async function searchSessions(
     filePath: r.file_path,
     exists: existsSync(r.cwd),
   }));
+}
+
+export async function getActivityDigest(
+  startDate: string,
+  endDate: string,
+  toolFilter: Tool | '',
+  project: string,
+): Promise<ActivityDigest> {
+  const db = getDb();
+  await refreshIndex();
+
+  interface DigestRow {
+    file_path: string;
+    cwd: string;
+    tool: string;
+    session_id: string;
+    date: string;
+    created_at: string;
+    first_prompt: string;
+    custom_title: string;
+    message_count: number;
+  }
+
+  const conditions: string[] = ['created_at >= ?', 'created_at <= ?'];
+  const params: (string | number)[] = [startDate, endDate];
+
+  if (toolFilter) {
+    conditions.push('tool = ?');
+    params.push(toolFilter);
+  }
+  if (project) {
+    conditions.push('cwd LIKE ?');
+    params.push(project + '%');
+  }
+
+  const where = 'WHERE ' + conditions.join(' AND ');
+  const rows = db
+    .query<DigestRow, any[]>(
+      `SELECT file_path, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count
+       FROM sessions ${where}
+       ORDER BY created_at ASC, date ASC`,
+    )
+    .all(...params);
+
+  const toolCounts: Record<string, number> = {};
+  const projectSet = new Set<string>();
+  const dayMap = new Map<string, DigestSession[]>();
+  let totalMessages = 0;
+
+  for (const r of rows) {
+    toolCounts[r.tool] = (toolCounts[r.tool] ?? 0) + 1;
+    projectSet.add(r.cwd);
+    totalMessages += r.message_count;
+
+    let userMessages: string[] = [];
+    try {
+      const raw = readFileSync(r.file_path, 'utf-8');
+      const lines = raw.trimEnd().split('\n');
+      const msgs = getSessionMessages(lines);
+      userMessages = msgs.filter((m) => m.role === 'user').map((m) => m.text);
+    } catch {}
+
+    const session: DigestSession = {
+      sessionId: r.session_id,
+      tool: r.tool as Tool,
+      project: r.cwd,
+      title: r.custom_title || r.first_prompt,
+      firstPrompt: r.first_prompt,
+      messageCount: r.message_count,
+      createdAt: r.created_at,
+      lastActive: r.date,
+      filePath: r.file_path,
+      userMessages,
+    };
+
+    const day = r.created_at;
+    if (!dayMap.has(day)) dayMap.set(day, []);
+    dayMap.get(day)!.push(session);
+  }
+
+  const days: DigestDay[] = [];
+  for (const [date, sessions] of dayMap) {
+    days.push({ date, sessions });
+  }
+
+  return {
+    period: { start: startDate, end: endDate },
+    totalSessions: rows.length,
+    totalMessages,
+    tools: toolCounts,
+    projects: [...projectSet],
+    days,
+  };
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { searchSessions } from './cache';
+import { searchSessions, getActivityDigest } from './cache';
 import { getSessionMessages } from './parser';
 import { type SessionResult } from './types';
 
@@ -74,6 +74,28 @@ server.tool(
 
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  'get_activity_digest',
+  'Get a digest of all AI coding sessions within a date range. Returns user messages grouped by day and project — ideal for generating summaries, standups, or blog posts about recent work.',
+  {
+    startDate: z.string().describe('Start date inclusive (YYYY-MM-DD). Example: "2026-05-07"'),
+    endDate: z.string().describe('End date inclusive (YYYY-MM-DD). Example: "2026-05-14"'),
+    tool: z.enum(['claude', 'codex', 'pi']).optional().describe('Filter to a specific tool'),
+    project: z.string().optional().describe('Filter to sessions from this project directory path'),
+  },
+  async ({ startDate, endDate, tool, project }) => {
+    const digest = await getActivityDigest(startDate, endDate, tool ?? '', project ?? '');
+
+    if (digest.totalSessions === 0) {
+      return { content: [{ type: 'text' as const, text: 'No sessions found in that date range.' }] };
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(digest, null, 2) }],
     };
   },
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,33 @@ export interface SessionResult {
   exists: boolean;
 }
 
+export interface DigestSession {
+  sessionId: string;
+  tool: Tool;
+  project: string;
+  title: string;
+  firstPrompt: string;
+  messageCount: number;
+  createdAt: string;
+  lastActive: string;
+  filePath: string;
+  userMessages: string[];
+}
+
+export interface DigestDay {
+  date: string;
+  sessions: DigestSession[];
+}
+
+export interface ActivityDigest {
+  period: { start: string; end: string };
+  totalSessions: number;
+  totalMessages: number;
+  tools: Record<string, number>;
+  projects: string[];
+  days: DigestDay[];
+}
+
 export interface CliArgs {
   toolFilter: Tool | '';
   searchQuery: string;


### PR DESCRIPTION
## Summary
- Adds `get_activity_digest` MCP tool that returns all sessions within a date range, grouped by day and project
- Includes full metadata (tool, project, title, message counts, created/lastActive dates) and every user message per session (stripped of system tags)
- Works across all three harnesses: Claude Code, Codex, and Pi
- Designed for LLM-driven workflows like "summarize my week" or "write a blog post about what I built"

## Usage
```json
{
  "startDate": "2026-05-07",
  "endDate": "2026-05-14",
  "tool": "claude",
  "project": "/Users/me/myproject"
}
```

Returns an `ActivityDigest` with `days[]` → `sessions[]` → `userMessages[]`, plus aggregate stats (total sessions, messages, tool breakdown, project list).

## Test plan
- [ ] Call `get_activity_digest` via MCP with a date range covering recent sessions
- [ ] Verify sessions from claude, pi, and codex all appear
- [ ] Verify `tool` and `project` filters narrow results correctly
- [ ] Confirm user messages are present and system-reminder tags are stripped