### PR TITLE
feat: compact activity digest and session metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ Add to your MCP configuration (e.g., `~/.claude/.mcp.json`):
 
 ### Tools
 
-The MCP server exposes two tools:
+The MCP server exposes four tools:
 
-| Tool                   | Description                                                               |
-| ---------------------- | ------------------------------------------------------------------------- |
-| `search_sessions`      | Search across sessions by keyword, filter by tool or project, list recent |
-| `get_session_messages` | Retrieve messages from a specific session, paginated by offset and limit  |
+| Tool                   | Description                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `search_sessions`      | Search across sessions by keyword, filter by tool or project, list recent                     |
+| `get_session_messages` | Retrieve messages from a specific session, paginated by offset and limit                      |
+| `get_activity_digest`  | Compact digest of sessions in a date range, grouped by day and project — for weekly summaries |
+| `get_session_metrics`  | Usage metrics for a date range: tool/project breakdown, daily activity, active hours          |
 
 ### Search index
 
@@ -156,7 +158,10 @@ Each session file is parsed to extract:
 
 - **Working directory** — read from the session metadata to determine which project the session belongs to
 - **First user prompt** — the initial message you sent, cleaned of system-injected tags
-- **Last timestamp** — when the session was last active (read from the tail of the file for performance)
+- **Custom title** — if the session was renamed in Claude Code, that title is used instead
+- **Message count** — total user + assistant messages in the session
+- **Timestamps** — first and last timestamps for session duration and date-range queries
+- **Subagent content** — for Claude Code, user messages from subagent sidecar files are folded into the search index
 
 ### Scoping with `--here`
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,7 +3,14 @@ import { existsSync, mkdirSync, statSync, readFileSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { readdir } from 'node:fs/promises';
-import { type Tool, type SessionResult, type ActivityDigest, type DigestSession, type DigestDay } from './types';
+import {
+  type Tool,
+  type SessionResult,
+  type ActivityDigest,
+  type DigestProjectGroup,
+  type DigestDay,
+  type SessionMetrics,
+} from './types';
 import {
   getCwdFromSession,
   firstPrompt,
@@ -332,27 +339,24 @@ export async function searchSessions(
   }));
 }
 
-export async function getActivityDigest(
+interface DateRangeRow {
+  file_path: string;
+  cwd: string;
+  tool: string;
+  date: string;
+  created_at: string;
+  first_prompt: string;
+  custom_title: string;
+  message_count: number;
+}
+
+function queryDateRange(
+  db: Database,
   startDate: string,
   endDate: string,
   toolFilter: Tool | '',
   project: string,
-): Promise<ActivityDigest> {
-  const db = getDb();
-  await refreshIndex();
-
-  interface DigestRow {
-    file_path: string;
-    cwd: string;
-    tool: string;
-    session_id: string;
-    date: string;
-    created_at: string;
-    first_prompt: string;
-    custom_title: string;
-    message_count: number;
-  }
-
+): DateRangeRow[] {
   const conditions: string[] = ['created_at >= ?', 'created_at <= ?'];
   const params: (string | number)[] = [startDate, endDate];
 
@@ -366,53 +370,73 @@ export async function getActivityDigest(
   }
 
   const where = 'WHERE ' + conditions.join(' AND ');
-  const rows = db
-    .query<DigestRow, any[]>(
-      `SELECT file_path, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count
+  return db
+    .query<DateRangeRow, any[]>(
+      `SELECT file_path, cwd, tool, date, created_at, first_prompt, custom_title, message_count
        FROM sessions ${where}
        ORDER BY created_at ASC, date ASC`,
     )
     .all(...params);
+}
+
+export async function getActivityDigest(
+  startDate: string,
+  endDate: string,
+  toolFilter: Tool | '',
+  project: string,
+): Promise<ActivityDigest> {
+  const db = getDb();
+  await refreshIndex();
+
+  const rows = queryDateRange(db, startDate, endDate, toolFilter, project);
 
   const toolCounts: Record<string, number> = {};
   const projectSet = new Set<string>();
-  const dayMap = new Map<string, DigestSession[]>();
   let totalMessages = 0;
+
+  const dayProjectMap = new Map<string, Map<string, DigestProjectGroup>>();
 
   for (const r of rows) {
     toolCounts[r.tool] = (toolCounts[r.tool] ?? 0) + 1;
     projectSet.add(r.cwd);
     totalMessages += r.message_count;
 
-    let userMessages: string[] = [];
-    try {
-      const raw = readFileSync(r.file_path, 'utf-8');
-      const lines = raw.trimEnd().split('\n');
-      const msgs = getSessionMessages(lines);
-      userMessages = msgs.filter((m) => m.role === 'user').map((m) => m.text);
-    } catch {}
-
-    const session: DigestSession = {
-      sessionId: r.session_id,
-      tool: r.tool as Tool,
-      project: r.cwd,
-      title: r.custom_title || r.first_prompt,
-      firstPrompt: r.first_prompt,
-      messageCount: r.message_count,
-      createdAt: r.created_at,
-      lastActive: r.date,
-      filePath: r.file_path,
-      userMessages,
-    };
-
     const day = r.created_at;
-    if (!dayMap.has(day)) dayMap.set(day, []);
-    dayMap.get(day)!.push(session);
+    if (!dayProjectMap.has(day)) dayProjectMap.set(day, new Map());
+    const projectMap = dayProjectMap.get(day)!;
+
+    if (!projectMap.has(r.cwd)) {
+      projectMap.set(r.cwd, {
+        project: r.cwd,
+        sessions: 0,
+        totalMessages: 0,
+        tools: [],
+        topics: [],
+        filePaths: [],
+      });
+    }
+
+    const group = projectMap.get(r.cwd)!;
+    group.sessions++;
+    group.totalMessages += r.message_count;
+    if (!group.tools.includes(r.tool)) group.tools.push(r.tool);
+    const topic = r.custom_title || r.first_prompt;
+    if (topic) group.topics.push(topic);
+    group.filePaths.push(r.file_path);
   }
 
+  const MAX_TOPICS = 10;
+  const MAX_FILEPATHS = 5;
+
   const days: DigestDay[] = [];
-  for (const [date, sessions] of dayMap) {
-    days.push({ date, sessions });
+  for (const [date, projectMap] of dayProjectMap) {
+    const projects = [...projectMap.values()].map((g) => ({
+      ...g,
+      topics: [...new Set(g.topics)].slice(0, MAX_TOPICS),
+      filePaths: g.filePaths.slice(-MAX_FILEPATHS),
+    }));
+    const daySessions = projects.reduce((sum, p) => sum + p.sessions, 0);
+    days.push({ date, sessions: daySessions, projects });
   }
 
   return {
@@ -422,5 +446,70 @@ export async function getActivityDigest(
     tools: toolCounts,
     projects: [...projectSet],
     days,
+  };
+}
+
+export async function getSessionMetrics(
+  startDate: string,
+  endDate: string,
+  toolFilter: Tool | '',
+  project: string,
+): Promise<SessionMetrics> {
+  const db = getDb();
+  await refreshIndex();
+
+  const rows = queryDateRange(db, startDate, endDate, toolFilter, project);
+
+  const toolBreakdown: Record<string, number> = {};
+  const projectMap = new Map<string, { sessions: number; messages: number }>();
+  const dailyMap = new Map<string, { sessions: number; messages: number }>();
+  const activeHours: Record<string, number> = {};
+  let totalMessages = 0;
+
+  for (const r of rows) {
+    toolBreakdown[r.tool] = (toolBreakdown[r.tool] ?? 0) + 1;
+    totalMessages += r.message_count;
+
+    const pm = projectMap.get(r.cwd) ?? { sessions: 0, messages: 0 };
+    pm.sessions++;
+    pm.messages += r.message_count;
+    projectMap.set(r.cwd, pm);
+
+    const day = r.created_at;
+    const dm = dailyMap.get(day) ?? { sessions: 0, messages: 0 };
+    dm.sessions++;
+    dm.messages += r.message_count;
+    dailyMap.set(day, dm);
+  }
+
+  for (const r of rows) {
+    try {
+      const raw = readFileSync(r.file_path, 'utf-8');
+      const firstLine = raw.slice(0, raw.indexOf('\n'));
+      const d = JSON.parse(firstLine);
+      const ts = d.timestamp as string | undefined;
+      if (ts && ts.includes('T')) {
+        const hour = ts.slice(11, 13);
+        activeHours[hour] = (activeHours[hour] ?? 0) + 1;
+      }
+    } catch {}
+  }
+
+  const projectBreakdown = [...projectMap.entries()]
+    .map(([p, v]) => ({ project: p, sessions: v.sessions, messages: v.messages }))
+    .sort((a, b) => b.sessions - a.sessions);
+
+  const dailyActivity = [...dailyMap.entries()]
+    .map(([date, v]) => ({ date, sessions: v.sessions, messages: v.messages }))
+    .sort((a, b) => (a.date > b.date ? 1 : -1));
+
+  return {
+    period: { start: startDate, end: endDate },
+    totalSessions: rows.length,
+    totalMessages,
+    toolBreakdown,
+    projectBreakdown,
+    dailyActivity,
+    activeHours,
   };
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,6 +9,7 @@ import {
   type ActivityDigest,
   type DigestProjectGroup,
   type DigestDay,
+  type DigestSessionDetail,
   type SessionMetrics,
 } from './types';
 import {
@@ -343,6 +344,7 @@ interface DateRangeRow {
   file_path: string;
   cwd: string;
   tool: string;
+  session_id: string;
   date: string;
   created_at: string;
   first_prompt: string;
@@ -372,11 +374,36 @@ function queryDateRange(
   const where = 'WHERE ' + conditions.join(' AND ');
   return db
     .query<DateRangeRow, any[]>(
-      `SELECT file_path, cwd, tool, date, created_at, first_prompt, custom_title, message_count
+      `SELECT file_path, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count
        FROM sessions ${where}
        ORDER BY created_at ASC, date ASC`,
     )
     .all(...params);
+}
+
+const MAX_TOPICS = 10;
+const MAX_FILEPATHS = 5;
+const MAX_SESSIONS_DETAIL = 10;
+const MAX_USER_MESSAGES = 20;
+const MAX_MESSAGE_LENGTH = 500;
+
+interface PendingGroup {
+  group: DigestProjectGroup;
+  rows: DateRangeRow[];
+}
+
+function readUserMessages(filePath: string): string[] {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const lines = raw.trimEnd().split('\n');
+    const msgs = getSessionMessages(lines);
+    return msgs
+      .filter((m) => m.role === 'user')
+      .slice(0, MAX_USER_MESSAGES)
+      .map((m) => (m.text.length > MAX_MESSAGE_LENGTH ? m.text.slice(0, MAX_MESSAGE_LENGTH) + '…' : m.text));
+  } catch {
+    return [];
+  }
 }
 
 export async function getActivityDigest(
@@ -384,6 +411,7 @@ export async function getActivityDigest(
   endDate: string,
   toolFilter: Tool | '',
   project: string,
+  detail: 'compact' | 'full' = 'compact',
 ): Promise<ActivityDigest> {
   const db = getDb();
   await refreshIndex();
@@ -394,7 +422,7 @@ export async function getActivityDigest(
   const projectSet = new Set<string>();
   let totalMessages = 0;
 
-  const dayProjectMap = new Map<string, Map<string, DigestProjectGroup>>();
+  const dayProjectMap = new Map<string, Map<string, PendingGroup>>();
 
   for (const r of rows) {
     toolCounts[r.tool] = (toolCounts[r.tool] ?? 0) + 1;
@@ -407,34 +435,54 @@ export async function getActivityDigest(
 
     if (!projectMap.has(r.cwd)) {
       projectMap.set(r.cwd, {
-        project: r.cwd,
-        sessions: 0,
-        totalMessages: 0,
-        tools: [],
-        topics: [],
-        filePaths: [],
+        group: {
+          project: r.cwd,
+          sessions: 0,
+          totalMessages: 0,
+          tools: [],
+          topics: [],
+          filePaths: [],
+        },
+        rows: [],
       });
     }
 
-    const group = projectMap.get(r.cwd)!;
-    group.sessions++;
-    group.totalMessages += r.message_count;
-    if (!group.tools.includes(r.tool)) group.tools.push(r.tool);
+    const pending = projectMap.get(r.cwd)!;
+    const g = pending.group;
+    g.sessions++;
+    g.totalMessages += r.message_count;
+    if (!g.tools.includes(r.tool)) g.tools.push(r.tool);
     const topic = r.custom_title || r.first_prompt;
-    if (topic) group.topics.push(topic);
-    group.filePaths.push(r.file_path);
+    if (topic) g.topics.push(topic);
+    g.filePaths.push(r.file_path);
+    pending.rows.push(r);
   }
-
-  const MAX_TOPICS = 10;
-  const MAX_FILEPATHS = 5;
 
   const days: DigestDay[] = [];
   for (const [date, projectMap] of dayProjectMap) {
-    const projects = [...projectMap.values()].map((g) => ({
-      ...g,
-      topics: [...new Set(g.topics)].slice(0, MAX_TOPICS),
-      filePaths: g.filePaths.slice(-MAX_FILEPATHS),
-    }));
+    const projects = [...projectMap.values()].map(({ group: g, rows: sessionRows }) => {
+      const result: DigestProjectGroup = {
+        ...g,
+        topics: [...new Set(g.topics)].slice(0, MAX_TOPICS),
+        filePaths: g.filePaths.slice(-MAX_FILEPATHS),
+      };
+
+      if (detail === 'full') {
+        const sorted = [...sessionRows].sort((a, b) => b.message_count - a.message_count);
+        result.sessionDetails = sorted.slice(0, MAX_SESSIONS_DETAIL).map(
+          (r): DigestSessionDetail => ({
+            sessionId: r.session_id,
+            tool: r.tool,
+            title: r.custom_title || r.first_prompt,
+            messageCount: r.message_count,
+            filePath: r.file_path,
+            userMessages: readUserMessages(r.file_path),
+          }),
+        );
+      }
+
+      return result;
+    });
     const daySessions = projects.reduce((sum, p) => sum + p.sessions, 0);
     days.push({ date, sessions: daySessions, projects });
   }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { searchSessions, getActivityDigest } from './cache';
+import { searchSessions, getActivityDigest, getSessionMetrics } from './cache';
 import { getSessionMessages } from './parser';
 import { type SessionResult } from './types';
 
@@ -80,7 +80,7 @@ server.tool(
 
 server.tool(
   'get_activity_digest',
-  'Get a digest of all AI coding sessions within a date range. Returns user messages grouped by day and project — ideal for generating summaries, standups, or blog posts about recent work.',
+  'Get a compact digest of AI coding sessions within a date range, grouped by day and project. Returns topics and file paths — use get_session_messages to drill into specific sessions for full detail.',
   {
     startDate: z.string().describe('Start date inclusive (YYYY-MM-DD). Example: "2026-05-07"'),
     endDate: z.string().describe('End date inclusive (YYYY-MM-DD). Example: "2026-05-14"'),
@@ -96,6 +96,28 @@ server.tool(
 
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(digest, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  'get_session_metrics',
+  'Get usage metrics for AI coding sessions within a date range. Returns tool breakdown, project breakdown, daily activity counts, and active hours heatmap.',
+  {
+    startDate: z.string().describe('Start date inclusive (YYYY-MM-DD). Example: "2026-05-07"'),
+    endDate: z.string().describe('End date inclusive (YYYY-MM-DD). Example: "2026-05-14"'),
+    tool: z.enum(['claude', 'codex', 'pi']).optional().describe('Filter to a specific tool'),
+    project: z.string().optional().describe('Filter to sessions from this project directory path'),
+  },
+  async ({ startDate, endDate, tool, project }) => {
+    const metrics = await getSessionMetrics(startDate, endDate, tool ?? '', project ?? '');
+
+    if (metrics.totalSessions === 0) {
+      return { content: [{ type: 'text' as const, text: 'No sessions found in that date range.' }] };
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(metrics, null, 2) }],
     };
   },
 );

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -80,15 +80,22 @@ server.tool(
 
 server.tool(
   'get_activity_digest',
-  'Get a compact digest of AI coding sessions within a date range, grouped by day and project. Returns topics and file paths — use get_session_messages to drill into specific sessions for full detail.',
+  'Get a digest of AI coding sessions within a date range, grouped by day and project. Use detail "compact" (default) for a quick overview with topics, or "full" to include user messages per session for generating summaries and blog posts.',
   {
     startDate: z.string().describe('Start date inclusive (YYYY-MM-DD). Example: "2026-05-07"'),
     endDate: z.string().describe('End date inclusive (YYYY-MM-DD). Example: "2026-05-14"'),
     tool: z.enum(['claude', 'codex', 'pi']).optional().describe('Filter to a specific tool'),
     project: z.string().optional().describe('Filter to sessions from this project directory path'),
+    detail: z
+      .enum(['compact', 'full'])
+      .optional()
+      .default('compact')
+      .describe(
+        'compact: topics + file paths only. full: includes user messages per session (top 10 sessions per project, 20 messages each, 500 char cap)',
+      ),
   },
-  async ({ startDate, endDate, tool, project }) => {
-    const digest = await getActivityDigest(startDate, endDate, tool ?? '', project ?? '');
+  async ({ startDate, endDate, tool, project, detail }) => {
+    const digest = await getActivityDigest(startDate, endDate, tool ?? '', project ?? '', detail);
 
     if (digest.totalSessions === 0) {
       return { content: [{ type: 'text' as const, text: 'No sessions found in that date range.' }] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,15 @@ export interface SessionResult {
   exists: boolean;
 }
 
+export interface DigestSessionDetail {
+  sessionId: string;
+  tool: string;
+  title: string;
+  messageCount: number;
+  filePath: string;
+  userMessages: string[];
+}
+
 export interface DigestProjectGroup {
   project: string;
   sessions: number;
@@ -20,6 +29,7 @@ export interface DigestProjectGroup {
   tools: string[];
   topics: string[];
   filePaths: string[];
+  sessionDetails?: DigestSessionDetail[];
 }
 
 export interface DigestDay {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,22 +13,19 @@ export interface SessionResult {
   exists: boolean;
 }
 
-export interface DigestSession {
-  sessionId: string;
-  tool: Tool;
+export interface DigestProjectGroup {
   project: string;
-  title: string;
-  firstPrompt: string;
-  messageCount: number;
-  createdAt: string;
-  lastActive: string;
-  filePath: string;
-  userMessages: string[];
+  sessions: number;
+  totalMessages: number;
+  tools: string[];
+  topics: string[];
+  filePaths: string[];
 }
 
 export interface DigestDay {
   date: string;
-  sessions: DigestSession[];
+  sessions: number;
+  projects: DigestProjectGroup[];
 }
 
 export interface ActivityDigest {
@@ -38,6 +35,16 @@ export interface ActivityDigest {
   tools: Record<string, number>;
   projects: string[];
   days: DigestDay[];
+}
+
+export interface SessionMetrics {
+  period: { start: string; end: string };
+  totalSessions: number;
+  totalMessages: number;
+  toolBreakdown: Record<string, number>;
+  projectBreakdown: { project: string; sessions: number; messages: number }[];
+  dailyActivity: { date: string; sessions: number; messages: number }[];
+  activeHours: Record<string, number>;
 }
 
 export interface CliArgs {


### PR DESCRIPTION
## Summary
- **Reworks `get_activity_digest`** to return a compact grouped format: sessions grouped by project per day with deduplicated topics (capped at 10) and recent file paths (capped at 5). No more reading every session file — everything comes from the SQLite index. Output drops from ~5,800 lines to ~780 for a typical week.
- **Adds `get_session_metrics`** MCP tool: tool breakdown, project breakdown (sorted by session count), daily activity counts, and active hours heatmap for a date range.
- **Updates README** to document all four MCP tools and the expanded session parsing (custom titles, message counts, timestamps, subagent content).

## Two-pass workflow
The digest is now a table of contents, not the book:
1. `get_activity_digest` → compact overview, LLM reads it instantly
2. LLM picks interesting sessions → `get_session_messages` for full detail

## Test plan
- [ ] `get_activity_digest` with a week-long range — verify grouped output, topics deduplicated, file paths capped
- [ ] `get_session_metrics` — verify tool/project breakdowns, daily activity, active hours
- [ ] Both tools with `tool` and `project` filters
- [ ] Confirm `get_session_messages` still works for drill-down from digest file paths