### PR TITLE
feat: plugin with skills and `sessions setup` command

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "sessions",
+  "owner": {
+    "name": "Nick Nisi",
+    "email": "nick@nisi.org"
+  },
+  "plugins": [
+    {
+      "name": "sessions",
+      "source": {
+        "source": "local",
+        "path": "./plugin"
+      },
+      "description": "Weekly summaries, standups, recall, and metrics for AI coding sessions across Claude Code, Codex, and Pi.",
+      "interface": {
+        "displayName": "Sessions",
+        "shortDescription": "Summarize and recall AI coding sessions"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "sessions",
+  "owner": {
+    "name": "Nick Nisi",
+    "email": "nick@nisi.org"
+  },
+  "metadata": {
+    "description": "Skills for summarizing and recalling AI coding sessions",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "sessions",
+      "source": "./plugin",
+      "description": "Weekly summaries, standups, recall, and metrics for AI coding sessions across Claude Code, Codex, and Pi."
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "sessions",
+  "owner": {
+    "name": "Nick Nisi",
+    "email": "nick@nisi.org"
+  },
+  "metadata": {
+    "description": "Skills for summarizing and recalling AI coding sessions",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "sessions",
+      "source": "./plugin",
+      "description": "Weekly summaries, standups, recall, and metrics for AI coding sessions across Claude Code, Codex, and Pi."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ sessions --tool claude       # Filter to Claude Code sessions only
 
 ### Options
 
-| Flag            | Description                                           |
+| Flag / Command  | Description                                           |
 | --------------- | ----------------------------------------------------- |
+| `setup`         | Install plugin and configure MCP for detected tools   |
+| `uninstall`     | Remove plugin and MCP config from all tools           |
 | `--here`        | Scope to the current git repo (default: all projects) |
 | `--tool <name>` | Filter by tool: `claude`, `codex`, or `pi`            |
 | `--mcp`         | Start as an MCP server (stdio transport)              |
@@ -102,13 +104,65 @@ When you pick a session, `sessions` displays the resume command and copies it to
 
 For Claude Code sessions, the command includes `--resume <session-id>`. For Pi and Codex sessions, it navigates to the project directory (these tools don't support direct session resume).
 
+## Quick Setup
+
+After installing, run:
+
+```sh
+sessions setup
+```
+
+This automatically:
+
+1. Copies the plugin and skills to `~/.local/share/sessions/plugin/`
+2. Detects which AI tools you have installed (Claude Code, Cursor, Codex)
+3. Adds the MCP server config to each tool
+4. Registers the plugin so skills are discoverable
+
+```
+❯ sessions setup
+
+sessions setup
+
+  ✓ Plugin installed to ~/.local/share/sessions/plugin/
+  ✓ MCP server added to Claude Code
+  ✓ Plugin registered with Claude Code
+  ✓ MCP server added to Cursor
+  ✓ Plugin registered with Cursor
+
+  Skills available:
+    /weekly-summary    Summarize your past week's AI sessions
+    /standup           Yesterday + today activity for standups
+    /recall            What did I do on a specific project?
+    /session-metrics   Usage dashboard with tool breakdown
+
+  Run `sessions setup` again after upgrading to update skills.
+```
+
+After upgrading sessions (e.g., `brew upgrade sessions`), run `sessions setup` again to update the skills to the latest version.
+
+To remove everything: `sessions uninstall`
+
+## Skills
+
+The plugin ships four skills that compose the MCP tools into repeatable workflows:
+
+| Skill              | Trigger                                     | What it does                                                      |
+| ------------------ | ------------------------------------------- | ----------------------------------------------------------------- |
+| `/weekly-summary`  | "summarize my week", "weekly recap"         | Fetches full digest for the past 7 days, writes structured report |
+| `/standup`         | "standup", "what did I do yesterday"        | Yesterday + today in compact format, terse bullets for Slack      |
+| `/recall`          | "what did I do on [project]"                | Searches sessions by project/topic, shows chronological history   |
+| `/session-metrics` | "session stats", "which tool do I use most" | Tool/project breakdown, daily activity, active hours heatmap      |
+
+Skills work with Claude Code, Cursor, Codex, and any agent that supports the skills.sh format.
+
 ## MCP Server
 
-`sessions` can run as an [MCP](https://modelcontextprotocol.io/) server, giving AI agents searchable access to your past conversations. This lets Claude, Codex, or any MCP-compatible client recall how you solved problems, what decisions you made, and what tools you used — across all three AI coding tools.
+`sessions` includes an [MCP](https://modelcontextprotocol.io/) server that gives AI agents searchable access to your past conversations. The MCP server is configured automatically by `sessions setup`, but you can also set it up manually.
 
-### Setup
+### Manual MCP Setup
 
-Add to your MCP configuration (e.g., `~/.claude/.mcp.json`):
+If you prefer to configure the MCP server yourself, add to your MCP configuration (e.g., `~/.claude/.mcp.json`):
 
 ```json
 {
@@ -131,6 +185,8 @@ The MCP server exposes four tools:
 | `get_session_messages` | Retrieve messages from a specific session, paginated by offset and limit                      |
 | `get_activity_digest`  | Compact digest of sessions in a date range, grouped by day and project — for weekly summaries |
 | `get_session_metrics`  | Usage metrics for a date range: tool/project breakdown, daily activity, active hours          |
+
+The `get_activity_digest` tool supports a `detail` parameter: `"compact"` (default) returns topics and file paths only, while `"full"` includes user messages per session for generating rich summaries like blog posts.
 
 ### Search index
 

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,18 @@ if (Bun.argv.includes('--mcp')) {
   await new Promise(() => {});
 }
 
+if (Bun.argv.includes('setup')) {
+  const { runSetup } = await import('./src/setup');
+  runSetup();
+  process.exit(0);
+}
+
+if (Bun.argv.includes('uninstall')) {
+  const { runUninstall } = await import('./src/setup');
+  runUninstall();
+  process.exit(0);
+}
+
 const args = parseArgs(Bun.argv.slice(2));
 const repoRoot = getRepoRoot(args.scopeHere);
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "sessions",
+  "description": "Skills for summarizing and recalling AI coding sessions across Claude Code, Codex, and Pi.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Nick Nisi",
+    "email": "nick@nisi.org"
+  },
+  "homepage": "https://github.com/nicknisi/sessions",
+  "repository": "https://github.com/nicknisi/sessions",
+  "license": "MIT",
+  "keywords": ["sessions", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"]
+}

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "sessions",
+  "description": "Skills for summarizing and recalling AI coding sessions across Claude Code, Codex, and Pi.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Nick Nisi",
+    "email": "nick@nisi.org"
+  },
+  "homepage": "https://github.com/nicknisi/sessions",
+  "repository": "https://github.com/nicknisi/sessions",
+  "license": "MIT",
+  "keywords": ["sessions", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Sessions",
+    "shortDescription": "Summarize and recall AI coding sessions",
+    "category": "Productivity"
+  }
+}

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "sessions",
+  "description": "Skills for summarizing and recalling AI coding sessions across Claude Code, Codex, and Pi.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Nick Nisi",
+    "email": "nick@nisi.org"
+  },
+  "homepage": "https://github.com/nicknisi/sessions",
+  "repository": "https://github.com/nicknisi/sessions",
+  "license": "MIT",
+  "keywords": ["sessions", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sessions": {
+      "command": "sessions",
+      "args": ["--mcp"]
+    }
+  }
+}

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: recall
+description: >-
+  Recall what was done on a specific project or topic. Use when the user says
+  "what did I do on [project]", "recall [topic]", "history of [project]",
+  "when did I last work on [thing]", or wants to remember past work on a
+  specific codebase or feature.
+argument-hint: project name or path
+---
+
+Recall past work on a specific project or topic.
+
+## Steps
+
+1. **Identify the target.** The user's argument is a project name, path, or topic. If it looks like a path, use it directly. If it's a name, search for it.
+
+2. **Search sessions.** Call `search_sessions` with:
+   - `query`: the topic/keyword if searching by content
+   - `project`: the path if filtering by project directory
+   - `limit`: 20
+
+3. **Get context for top results.** For the most relevant sessions (up to 5), call `get_session_messages` with:
+   - `filePath`: from the search results
+   - `limit`: 20
+
+4. **Summarize the history.** Write a chronological summary:
+
+   ### Sessions on {project/topic}
+
+   For each relevant session:
+   - **{date}** ({tool}) — What was worked on, key decisions made, outcome
+
+   **Overall arc:** How the work evolved across sessions.
+
+## Guidelines
+
+- Order chronologically (oldest first) to show the arc of work.
+- If the user gives a vague name, try both `search_sessions` (keyword search) and `get_activity_digest` (project path filter) to find matches.
+- Focus on decisions and outcomes, not implementation details.
+- If there are many sessions, group by phase or milestone rather than listing each one.

--- a/plugin/skills/session-metrics/SKILL.md
+++ b/plugin/skills/session-metrics/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: session-metrics
+description: >-
+  Show usage metrics and analytics for AI coding sessions. Use when the user
+  asks "how much have I been coding", "session stats", "show me metrics",
+  "tool usage", "which tool do I use most", "active hours", or wants
+  analytics about their AI coding tool usage.
+argument-hint: time period (e.g., "past week", "may", "past month")
+---
+
+Show session usage metrics and analytics.
+
+## Steps
+
+1. **Parse the time period.** Convert the user's argument to a date range (YYYY-MM-DD). Default to the past 7 days if no period specified. Common inputs: "past week", "this month", "past 30 days", "may 2026".
+
+2. **Fetch metrics.** Call `get_session_metrics` with:
+   - `startDate` and `endDate` from the parsed range
+
+3. **Format the dashboard:**
+
+   ### Session Metrics: {start} to {end}
+
+   **Overview**
+   - {total sessions} sessions | {total messages} messages
+   - Tools: {breakdown with counts}
+
+   **Top Projects** (table: project, sessions, messages)
+   List the top 10 by session count.
+
+   **Daily Activity** (table or mini-chart: date, sessions, messages)
+   Show each day in the range.
+
+   **Active Hours**
+   Render the hours heatmap as a simple bar chart or table showing which hours of the day have the most sessions. Convert to local time labels (e.g., "9am", "2pm").
+
+## Guidelines
+
+- Round percentages to whole numbers.
+- For active hours, group into time blocks if the data is sparse (morning/afternoon/evening/night).
+- If a tool has zero sessions, omit it from the breakdown.
+- Keep the formatting clean — this should be pasteable into a document or message.

--- a/plugin/skills/standup/SKILL.md
+++ b/plugin/skills/standup/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: standup
+description: >-
+  Generate a quick standup summary of yesterday and today's AI coding sessions.
+  Use when the user says "standup", "what did I do yesterday", "daily summary",
+  "what have I been working on", or needs a quick recap for a standup meeting.
+---
+
+Generate a brief standup-style summary.
+
+## Steps
+
+1. **Calculate dates.** Yesterday and today in YYYY-MM-DD format.
+
+2. **Fetch the digest.** Call `get_activity_digest` with:
+   - `startDate`: yesterday
+   - `endDate`: today
+   - `detail`: `"compact"`
+
+3. **Format as a standup.** Write three sections, each 2-4 bullets max:
+
+   **Yesterday:**
+   - What was accomplished (project: brief description)
+
+   **Today (so far):**
+   - What's been started or is in progress
+
+   **Carrying forward:**
+   - Anything that spans both days or is unfinished
+
+## Guidelines
+
+- Keep it terse. Each bullet should be one line.
+- Group by project if multiple sessions touched the same project.
+- Skip noise — only mention substantive sessions.
+- If yesterday had no sessions, say so and focus on today.
+- Format for pasting into Slack or a standup thread.

--- a/plugin/skills/weekly-summary/SKILL.md
+++ b/plugin/skills/weekly-summary/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: weekly-summary
+description: >-
+  Generate a comprehensive summary of AI coding sessions from the past week.
+  Use when the user says "weekly summary", "what did I do this week",
+  "summarize my week", "weekly recap", "week in review", or asks for a
+  summary of recent work across projects.
+---
+
+Generate a weekly summary of the user's AI coding sessions.
+
+## Steps
+
+1. **Get the date range.** Calculate the start date (7 days ago) and end date (today) in YYYY-MM-DD format.
+
+2. **Fetch the digest.** Call the `get_activity_digest` MCP tool with:
+   - `startDate`: 7 days ago
+   - `endDate`: today
+   - `detail`: `"full"` (includes user messages for rich context)
+
+3. **Scan the digest.** For each day, review the project groups. Identify:
+   - Which projects were worked on and what was accomplished
+   - Key decisions, pivots, or discoveries (found in user messages)
+   - Recurring themes across projects
+
+4. **Write the summary.** Structure it as:
+
+   ### Week of {start} - {end}
+
+   **By the numbers:** {total sessions} sessions, {total messages} messages across {project count} projects.
+
+   **Day-by-day:**
+   For each day with activity, write 2-4 bullet points capturing the most significant work. Be specific — name projects, features, and outcomes. Skip days with no meaningful activity.
+
+   **Highlights:** The 3-5 most significant accomplishments across the entire week.
+
+   **Themes:** Recurring work streams or focus areas (e.g., "SDK development", "infrastructure", "bug fixes").
+
+## Guidelines
+
+- Be specific. Quote project names, feature descriptions, and tool names.
+- Capture pivots and discoveries, not just starting intents. The user messages reveal what actually happened, not just what was planned.
+- Skip noise — 1-message sessions and test sessions are not worth mentioning.
+- If a project appears across multiple days, note the arc of progress.
+- Write for the user to review, not for a third party. Use "you" not "the user".

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,10 @@ ${C.bold}Options:${C.reset}
   --clear-cache    Remove the search index (rebuilds on next use)
   -h, --help       Show this help
 
+${C.bold}Commands:${C.reset}
+  setup            Install plugin and configure MCP for detected tools
+  uninstall        Remove plugin and MCP config from all tools
+
 ${C.bold}Search:${C.reset}
   With no argument, opens fzf with session summaries.
   With an argument, greps across session content for matching

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,200 @@
+import { existsSync, mkdirSync, writeFileSync, readFileSync, statSync, cpSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { C } from './colors';
+
+const home = homedir();
+const PLUGIN_DEST = join(home, '.local', 'share', 'sessions', 'plugin');
+
+interface ToolConfig {
+  name: string;
+  detected: boolean;
+  mcpConfigPath: string;
+  pluginDir: string;
+}
+
+function detectTools(): ToolConfig[] {
+  return [
+    {
+      name: 'Claude Code',
+      detected: existsSync(join(home, '.claude')),
+      mcpConfigPath: join(home, '.claude', '.mcp.json'),
+      pluginDir: join(home, '.claude', 'plugins'),
+    },
+    {
+      name: 'Cursor',
+      detected: existsSync(join(home, '.cursor')),
+      mcpConfigPath: join(home, '.cursor', '.mcp.json'),
+      pluginDir: join(home, '.cursor', 'plugins', 'local'),
+    },
+    {
+      name: 'Codex',
+      detected: existsSync(join(home, '.codex')),
+      mcpConfigPath: join(home, '.codex', '.mcp.json'),
+      pluginDir: join(home, '.codex', 'plugins'),
+    },
+  ];
+}
+
+function findPluginSource(): string {
+  const candidates = [
+    join(dirname(Bun.main), 'plugin'),
+    join(dirname(Bun.main), '..', 'plugin'),
+    join(dirname(Bun.main), '..', 'share', 'sessions', 'plugin'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(join(c, '.mcp.json'))) return c;
+  }
+  return '';
+}
+
+function copyDir(src: string, dest: string): void {
+  cpSync(src, dest, { recursive: true, force: true });
+}
+
+function installPlugin(source: string): boolean {
+  try {
+    mkdirSync(dirname(PLUGIN_DEST), { recursive: true });
+    copyDir(source, PLUGIN_DEST);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sessionsCommand(): string {
+  try {
+    const result = Bun.spawnSync(['which', 'sessions']);
+    const path = new TextDecoder().decode(result.stdout).trim();
+    if (path) return path;
+  } catch {}
+  return 'sessions';
+}
+
+function configureMcp(tool: ToolConfig): boolean {
+  try {
+    const cmd = sessionsCommand();
+    let config: Record<string, unknown> = {};
+
+    if (existsSync(tool.mcpConfigPath)) {
+      try {
+        config = JSON.parse(readFileSync(tool.mcpConfigPath, 'utf-8'));
+      } catch {}
+    }
+
+    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
+    servers.sessions = {
+      command: cmd,
+      args: ['--mcp'],
+    };
+    config.mcpServers = servers;
+
+    mkdirSync(dirname(tool.mcpConfigPath), { recursive: true });
+    writeFileSync(tool.mcpConfigPath, JSON.stringify(config, null, 2) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function registerPlugin(tool: ToolConfig): boolean {
+  try {
+    const dest = join(tool.pluginDir, 'sessions');
+    mkdirSync(tool.pluginDir, { recursive: true });
+
+    try {
+      const stat = statSync(dest);
+      if (stat.isSymbolicLink() || stat.isDirectory()) {
+        require('node:fs').rmSync(dest, { recursive: true, force: true });
+      }
+    } catch {}
+
+    require('node:fs').symlinkSync(PLUGIN_DEST, dest);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function runSetup(): void {
+  const w = (s: string) => process.stderr.write(s);
+
+  w(`\n${C.bold}sessions setup${C.reset}\n\n`);
+
+  const source = findPluginSource();
+  if (!source) {
+    w(
+      `${C.red}error:${C.reset} Could not find plugin files. Make sure you're running the sessions binary or are in the repo directory.\n`,
+    );
+    process.exit(1);
+  }
+
+  if (installPlugin(source)) {
+    w(`  ${C.green}✓${C.reset} Plugin installed to ${C.dim}${PLUGIN_DEST}${C.reset}\n`);
+  } else {
+    w(`  ${C.red}✗${C.reset} Failed to install plugin to ${PLUGIN_DEST}\n`);
+    process.exit(1);
+  }
+
+  const tools = detectTools();
+  const detected = tools.filter((t) => t.detected);
+
+  if (detected.length === 0) {
+    w(`\n  ${C.dim}No AI tools detected. Install Claude Code, Cursor, or Codex first.${C.reset}\n\n`);
+    process.exit(0);
+  }
+
+  for (const tool of detected) {
+    if (configureMcp(tool)) {
+      w(`  ${C.green}✓${C.reset} MCP server added to ${C.dim}${tool.name}${C.reset}\n`);
+    } else {
+      w(`  ${C.red}✗${C.reset} Failed to configure MCP for ${tool.name}\n`);
+    }
+
+    if (registerPlugin(tool)) {
+      w(`  ${C.green}✓${C.reset} Plugin registered with ${C.dim}${tool.name}${C.reset}\n`);
+    } else {
+      w(`  ${C.red}✗${C.reset} Failed to register plugin with ${tool.name}\n`);
+    }
+  }
+
+  w(`\n  ${C.bold}Skills available:${C.reset}\n`);
+  w(`    ${C.cyan}/weekly-summary${C.reset}    Summarize your past week's AI sessions\n`);
+  w(`    ${C.cyan}/standup${C.reset}           Yesterday + today activity for standups\n`);
+  w(`    ${C.cyan}/recall${C.reset}            What did I do on a specific project?\n`);
+  w(`    ${C.cyan}/session-metrics${C.reset}   Usage dashboard with tool breakdown\n`);
+  w(`\n  ${C.dim}Run \`sessions setup\` again after upgrading to update skills.${C.reset}\n\n`);
+}
+
+export function runUninstall(): void {
+  const w = (s: string) => process.stderr.write(s);
+
+  w(`\n${C.bold}sessions uninstall${C.reset}\n\n`);
+
+  const tools = detectTools();
+  for (const tool of tools.filter((t) => t.detected)) {
+    const link = join(tool.pluginDir, 'sessions');
+    try {
+      require('node:fs').rmSync(link, { recursive: true, force: true });
+      w(`  ${C.green}✓${C.reset} Removed plugin from ${C.dim}${tool.name}${C.reset}\n`);
+    } catch {}
+
+    try {
+      if (existsSync(tool.mcpConfigPath)) {
+        const config = JSON.parse(readFileSync(tool.mcpConfigPath, 'utf-8'));
+        if (config.mcpServers?.sessions) {
+          delete config.mcpServers.sessions;
+          writeFileSync(tool.mcpConfigPath, JSON.stringify(config, null, 2) + '\n');
+          w(`  ${C.green}✓${C.reset} Removed MCP config from ${C.dim}${tool.name}${C.reset}\n`);
+        }
+      }
+    } catch {}
+  }
+
+  try {
+    require('node:fs').rmSync(PLUGIN_DEST, { recursive: true, force: true });
+    w(`  ${C.green}✓${C.reset} Removed ${C.dim}${PLUGIN_DEST}${C.reset}\n`);
+  } catch {}
+
+  w(`\n  ${C.dim}Done. Plugin and MCP config removed.${C.reset}\n\n`);
+}


### PR DESCRIPTION
## Summary
- Ships a plugin with 4 skills that compose the MCP tools into repeatable workflows
- Adds `sessions setup` command for dead-simple installation across AI tools
- Adds `sessions uninstall` for clean removal
- Follows the skills.sh marketplace pattern (Claude Code, Cursor, Codex manifests)

## Setup UX

```sh
brew install nicknisi/formulae/sessions
sessions setup
# Done. MCP configured, plugin registered, skills available.
```

## Skills

| Skill | What it does |
|---|---|
| `/weekly-summary` | Full digest for past 7 days → structured weekly report |
| `/standup` | Yesterday + today compact → terse bullets for Slack |
| `/recall <project>` | Search sessions by project/topic → chronological history |
| `/session-metrics` | Tool/project breakdown, daily activity, active hours heatmap |

## What `sessions setup` does

1. Copies `plugin/` to `~/.local/share/sessions/plugin/`
2. Detects installed tools (Claude Code, Cursor, Codex)
3. Adds `sessions --mcp` to each tool's `.mcp.json`
4. Symlinks plugin into each tool's plugin directory
5. Idempotent — `sessions setup` after `brew upgrade` updates skills in place

## Plugin structure

```
plugin/
├── .claude-plugin/plugin.json
├── .cursor-plugin/plugin.json
├── .codex-plugin/plugin.json
├── .mcp.json
└── skills/
    ├── weekly-summary/SKILL.md
    ├── standup/SKILL.md
    ├── recall/SKILL.md
    └── session-metrics/SKILL.md
```

Top-level marketplace manifests (`.claude-plugin/`, `.cursor-plugin/`, `.agents/plugins/`) point to the shared plugin directory.

## Test plan
- [ ] `sessions setup` — verify plugin copied, MCP configured, symlinks created
- [ ] `sessions uninstall` — verify clean removal of plugin, MCP config, symlinks
- [ ] `/weekly-summary` in Claude Code — verify it calls `get_activity_digest` with full detail
- [ ] `/standup` in Claude Code — verify compact format, terse output
- [ ] `/recall` in Claude Code — verify project-scoped search + drill-down
- [ ] `/session-metrics` in Claude Code — verify formatted dashboard output
- [ ] Run `sessions setup` twice — verify idempotent (no errors, updates in place)