### PR TITLE
feat: add `sessions report` (usage report — JSON + HTML dashboard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # superpowers brainstorm/visual-companion artifacts
 .superpowers/
+
+# `sessions report` default output artifacts
+usage-report.json
+report.html

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .DS_Store
 
 *.bun-build
+
+# superpowers brainstorm/visual-companion artifacts
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -116,19 +116,25 @@ sessions report                              # writes usage-report.json + report
 sessions report --format html --out /tmp/r   # just the dashboard
 sessions report --format json --stdout       # print JSON to stdout (for piping)
 sessions report --days 30 --tool claude      # last 30 days, Claude Code only
+sessions report --this-month                 # current month to date
+sessions report --month 2026-05              # a specific calendar month
 ```
+
+The selected period is shown prominently at the top of both outputs (and in the JSON `period`).
 
 ### Report options
 
-| Flag                                    | Description                                                                                                    |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `--format json\|html\|both`             | What to emit. Default `both`.                                                                                  |
-| `--out <path>`                          | For `both`, a directory (default `.`) → `usage-report.json` + `report.html`. For a single format, a file path. |
-| `--from YYYY-MM-DD` / `--to YYYY-MM-DD` | Inclusive local-date range. Default: all time.                                                                 |
-| `--days N`                              | Last `N` days (instead of `--from`/`--to`).                                                                    |
-| `--tool claude\|codex\|pi`              | Restrict to one tool. Default: all three.                                                                      |
-| `--tz <IANA>`                           | Timezone for day/hour bucketing. Default: `$TIMEZONE`, else `America/Chicago`.                                 |
-| `--stdout`                              | Print the JSON to stdout and skip the JSON file (HTML is still written if requested).                          |
+| Flag                                                                        | Description                                                                                                    |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--format json\|html\|both`                                                 | What to emit. Default `both`.                                                                                  |
+| `--out <path>`                                                              | For `both`, a directory (default `.`) → `usage-report.json` + `report.html`. For a single format, a file path. |
+| `--from YYYY-MM-DD` / `--to YYYY-MM-DD`                                     | Inclusive local-date range. Default: all time.                                                                 |
+| `--days N`                                                                  | Last `N` days (instead of `--from`/`--to`).                                                                    |
+| `--today` / `--this-week` / `--this-month` / `--last-month` / `--this-year` | Convenience presets that resolve to a date range.                                                              |
+| `--month YYYY-MM`                                                           | A specific calendar month.                                                                                     |
+| `--tool claude\|codex\|pi`                                                  | Restrict to one tool. Default: all three.                                                                      |
+| `--tz <IANA>`                                                               | Timezone for day/hour bucketing. Default: `$TIMEZONE`, else `America/Chicago`.                                 |
+| `--stdout`                                                                  | Print the JSON to stdout and skip the JSON file (HTML is still written if requested).                          |
 
 ### What's in the report
 

--- a/README.md
+++ b/README.md
@@ -51,21 +51,23 @@ sessions                     # Browse all sessions with fzf
 sessions <query>             # Search session content for a phrase
 sessions --here              # Scope to current git repo only
 sessions --tool claude       # Filter to Claude Code sessions only
+sessions report              # Generate a usage report (JSON + HTML dashboard)
 ```
 
 ### Options
 
-| Flag / Command  | Description                                           |
-| --------------- | ----------------------------------------------------- |
-| `setup`         | Install plugin and configure MCP for detected tools   |
-| `uninstall`     | Remove plugin and MCP config from all tools           |
-| `cleanup`       | Full reset: uninstall plugin + clear search index     |
-| `--here`        | Scope to the current git repo (default: all projects) |
-| `--tool <name>` | Filter by tool: `claude`, `codex`, or `pi`            |
-| `--mcp`         | Start as an MCP server (stdio transport)              |
-| `--clear-cache` | Remove the search index (rebuilds on next use)        |
-| `--no-color`    | Disable colored output                                |
-| `-h`, `--help`  | Show help                                             |
+| Flag / Command  | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `report`        | Generate a usage report — JSON + HTML dashboard (see [Usage reports](#usage-reports)) |
+| `setup`         | Install plugin and configure MCP for detected tools                                   |
+| `uninstall`     | Remove plugin and MCP config from all tools                                           |
+| `cleanup`       | Full reset: uninstall plugin + clear search index                                     |
+| `--here`        | Scope to the current git repo (default: all projects)                                 |
+| `--tool <name>` | Filter by tool: `claude`, `codex`, or `pi`                                            |
+| `--mcp`         | Start as an MCP server (stdio transport)                                              |
+| `--clear-cache` | Remove the search index (rebuilds on next use)                                        |
+| `--no-color`    | Disable colored output                                                                |
+| `-h`, `--help`  | Show help                                                                             |
 
 ### Browsing
 
@@ -104,6 +106,42 @@ When you pick a session, `sessions` displays the resume command and copies it to
 ```
 
 For Claude Code sessions, the command includes `--resume <session-id>`. For Pi and Codex sessions, it navigates to the project directory (these tools don't support direct session resume).
+
+## Usage reports
+
+`sessions report` does a fresh pass over your local Claude Code, Codex, and Pi logs and produces a token/cost usage report — as machine-readable JSON, a self-contained HTML dashboard, or both.
+
+```sh
+sessions report                              # writes usage-report.json + report.html to the cwd
+sessions report --format html --out /tmp/r   # just the dashboard
+sessions report --format json --stdout       # print JSON to stdout (for piping)
+sessions report --days 30 --tool claude      # last 30 days, Claude Code only
+```
+
+### Report options
+
+| Flag                                    | Description                                                                                                    |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--format json\|html\|both`             | What to emit. Default `both`.                                                                                  |
+| `--out <path>`                          | For `both`, a directory (default `.`) → `usage-report.json` + `report.html`. For a single format, a file path. |
+| `--from YYYY-MM-DD` / `--to YYYY-MM-DD` | Inclusive local-date range. Default: all time.                                                                 |
+| `--days N`                              | Last `N` days (instead of `--from`/`--to`).                                                                    |
+| `--tool claude\|codex\|pi`              | Restrict to one tool. Default: all three.                                                                      |
+| `--tz <IANA>`                           | Timezone for day/hour bucketing. Default: `$TIMEZONE`, else `America/Chicago`.                                 |
+| `--stdout`                              | Print the JSON to stdout and skip the JSON file (HTML is still written if requested).                          |
+
+### What's in the report
+
+Both outputs are built from the same data:
+
+- **Summary** — total cost, tokens, sessions, messages, active days, current/longest streak, peak hour, and most-used model.
+- **Breakdowns** — by tool, provider, model, and project.
+- **Daily series** — per-day tokens/cost/sessions/messages with an hourly histogram.
+- **Insights** — a weekly trend plus hour-of-day and weekday activity profiles.
+
+The JSON is a sessions-owned `UsageReport` (`{ "generator": "sessions", "version": 1, ... }`). The HTML is fully self-contained (inline SVG charts, no external assets) and adapts to light/dark.
+
+Cost is estimated from a built-in pricing table for Claude and other known models; Pi sessions use the cost recorded in their own logs. Tokens for unknown models are still counted, with cost shown as `$0`. Token totals exclude cache reads (replayed context, mostly free reuse).
 
 ## Quick Setup
 

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,18 @@ if (Bun.argv.includes('uninstall')) {
   process.exit(0);
 }
 
+if (Bun.argv.includes('report')) {
+  const { parseReportArgs, runReport } = await import('./src/report/index.ts');
+  const idx = Bun.argv.indexOf('report');
+  const opts = parseReportArgs(Bun.argv.slice(idx + 1));
+  const res = await runReport(opts);
+  if (!opts.stdout) {
+    if (res.jsonPath) process.stderr.write(`wrote ${res.jsonPath}\n`);
+    if (res.htmlPath) process.stderr.write(`wrote ${res.htmlPath}\n`);
+  }
+  process.exit(0);
+}
+
 const args = parseArgs(Bun.argv.slice(2));
 const repoRoot = getRepoRoot(args.scopeHere);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ ${C.bold}Options:${C.reset}
   -h, --help       Show this help
 
 ${C.bold}Commands:${C.reset}
+  report           Generate a usage report (JSON for tokenmaxing + HTML dashboard)
   setup            Install plugin and configure MCP for detected tools
   uninstall        Remove plugin and MCP config from all tools
   cleanup          Uninstall plugin + clear search index (full reset)

--- a/src/report/aggregate.report.test.ts
+++ b/src/report/aggregate.report.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'bun:test';
+import { aggregate } from './aggregate.ts';
+import type { UsageEvent } from './parsers/types.ts';
+
+// One Claude event + one Pi event (Pi carries a precomputed cost).
+const events: UsageEvent[] = [
+  {
+    tool: 'claude-code',
+    provider: 'anthropic',
+    model: 'claude-opus-4-6',
+    timestamp: '2026-06-01T14:30:00Z',
+    sessionId: 's1',
+    projectPath: '/Users/x/Developer/sessions',
+    tokens: { input: 1000, output: 500, cacheRead: 10000, cacheWrite: 200 },
+  },
+  {
+    tool: 'pi',
+    provider: 'baseten',
+    model: 'moonshotai/Kimi-K2.5',
+    timestamp: '2026-06-02T09:00:00Z',
+    sessionId: 'p1',
+    projectPath: '/Users/x/Developer/tokenmaxing',
+    tokens: { input: 2000, output: 1000, cacheRead: 0, cacheWrite: 0 },
+    costUSD: 0.12,
+  },
+];
+
+const data = aggregate({
+  events,
+  prs: [],
+  now: '2026-06-06T00:00:00Z',
+  tz: 'UTC',
+  exclude: new Set<string>(),
+  priorDaily: [],
+});
+
+describe('aggregate (report mode)', () => {
+  test('schema + emptiness invariants', () => {
+    expect(data.schemaVersion).toBe(2);
+    expect(data.weeklyHighlights).toEqual([]);
+    expect(data.period).toEqual({ from: '2026-06-01', to: '2026-06-06' });
+  });
+
+  test('summary totals', () => {
+    // Claude totalTokens = 1000+500+200 = 1700 (cacheRead excluded).
+    // Claude cost = (1000*15 + 500*75 + 10000*1.5 + 200*18.75)/1e6 = 0.07125 -> 0.07
+    // Pi totalTokens = 3000, cost passthrough 0.12.
+    expect(data.summary.totalTokens).toBe(4700);
+    expect(data.summary.totalCostUSD).toBe(0.19);
+    expect(data.summary.sessions).toBe(2);
+    expect(data.summary.messages).toBe(2);
+    expect(data.summary.activeDays).toBe(2);
+    expect(data.summary.longestStreakDays).toBe(2);
+    expect(data.summary.currentStreakDays).toBe(0);
+    expect(data.summary.peakHourLocal).toBe(9);
+    expect(data.summary.favoriteModel.id).toBe('claude-opus-4-6');
+  });
+
+  test('daily entries', () => {
+    expect(data.daily.length).toBe(2);
+    expect(data.daily[0]!.date).toBe('2026-06-01');
+    expect(data.daily[0]!.tokens).toBe(1700);
+    expect(data.daily[0]!.costUSD).toBe(0.07);
+    expect(data.daily[0]!.hourCounts[14]).toBe(1);
+    expect(data.daily[1]!.date).toBe('2026-06-02');
+    expect(data.daily[1]!.costUSD).toBe(0.12);
+  });
+
+  test('breakdowns + insights', () => {
+    const tool = data.byTool.find((t) => t.id === 'claude-code')!;
+    expect(tool.costUSD).toBe(0.07);
+    const pi = data.byTool.find((t) => t.id === 'pi')!;
+    expect(pi.costUSD).toBe(0.12);
+    expect(data.insights.hourCounts[9]).toBe(1);
+    expect(data.insights.hourCounts[14]).toBe(1);
+    expect(data.insights.weekdayCounts.reduce((a, b) => a + b, 0)).toBe(2);
+  });
+});

--- a/src/report/aggregate.ts
+++ b/src/report/aggregate.ts
@@ -1,0 +1,592 @@
+// VENDORED VERBATIM from tokenmaxing/src/aggregate.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import type {
+  TokenmaxingData,
+  ToolBreakdown,
+  ProviderBreakdown,
+  ModelBreakdown,
+  ProjectBreakdown,
+  DailyEntry,
+  WeeklyHighlight,
+  PullRequest,
+  ToolId,
+  ModelRef,
+  ToolDailySlot,
+  ProviderDailySlot,
+  ModelDailySlot,
+  ProjectDailySlot,
+  Insights,
+  InsightsWeek,
+} from './types.ts';
+import type { UsageEvent } from './parsers/types.ts';
+import { computeCost } from './pricing.ts';
+import { localDate, localHour, weekEnding } from './parsers/util.ts';
+import { resolveProject } from './project.ts';
+
+const TOOL_LABEL: Record<ToolId, string> = {
+  'claude-code': 'Claude Code',
+  pi: 'Pi',
+  codex: 'Codex',
+};
+const PROVIDER_LABEL: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  baseten: 'Baseten',
+};
+
+export interface AggregateInput {
+  events: UsageEvent[];
+  prs: PullRequest[];
+  now: string;
+  tz: string;
+  exclude: Set<string>; // basenames (existing — keep name for tests)
+  excludePrefixes?: string[]; // optional prefix matches
+  include?: Set<string>; // allowlist basenames; if absent or empty, no allowlist
+  includePrefixes?: string[]; // allowlist prefixes
+  priorDaily: DailyEntry[]; // pass [] when no merge desired (e.g. --reset)
+  priorWeeklyHighlights?: WeeklyHighlight[];
+}
+
+interface EnrichedEvent {
+  e: UsageEvent;
+  cost: number;
+  date: string;
+  hour: number;
+  basename: string;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+// Excludes cache_read (replayed prior context — mostly free reuse, not "new work").
+// cache_creation (cacheWrite) IS counted because those are new tokens written to cache.
+const totalTokens = (t: UsageEvent['tokens']) => t.input + t.output + t.cacheWrite;
+
+function enrich(events: UsageEvent[], tz: string): EnrichedEvent[] {
+  return events.map((e) => ({
+    e,
+    cost: e.costUSD ?? computeCost(e.model, e.tokens),
+    date: localDate(e.timestamp, tz),
+    hour: localHour(e.timestamp, tz),
+    basename: resolveProject(e.projectPath),
+  }));
+}
+
+// Build a fresh-from-events DailyEntry for every active local date.
+function buildFreshDaily(enriched: EnrichedEvent[]): DailyEntry[] {
+  type DaySlot = {
+    date: string;
+    tokens: number;
+    cost: number;
+    sessions: Set<string>;
+    messages: number;
+    hourCounts: number[];
+    byTool: Map<ToolId, { tokens: number; cost: number; sessions: Set<string>; messages: number }>;
+    byProvider: Map<string, { tokens: number; cost: number }>;
+    byModel: Map<
+      string,
+      {
+        ref: { tool: ToolId; provider: string; id: string };
+        tokens: number;
+        cost: number;
+        sessions: Set<string>;
+        messages: number;
+      }
+    >;
+    byProject: Map<string, { tokens: number; cost: number; sessions: Set<string> }>;
+  };
+  const days = new Map<string, DaySlot>();
+  for (const x of enriched) {
+    let d = days.get(x.date);
+    if (!d) {
+      d = {
+        date: x.date,
+        tokens: 0,
+        cost: 0,
+        sessions: new Set(),
+        messages: 0,
+        hourCounts: new Array<number>(24).fill(0),
+        byTool: new Map(),
+        byProvider: new Map(),
+        byModel: new Map(),
+        byProject: new Map(),
+      };
+      days.set(x.date, d);
+    }
+    const tt = totalTokens(x.e.tokens);
+    const sessKey = `${x.e.tool}|${x.e.sessionId}`;
+
+    d.tokens += tt;
+    d.cost += x.cost;
+    d.sessions.add(sessKey);
+    d.messages++;
+    d.hourCounts[x.hour]! += 1;
+
+    // byTool
+    let tSlot = d.byTool.get(x.e.tool);
+    if (!tSlot) {
+      tSlot = { tokens: 0, cost: 0, sessions: new Set(), messages: 0 };
+      d.byTool.set(x.e.tool, tSlot);
+    }
+    tSlot.tokens += tt;
+    tSlot.cost += x.cost;
+    tSlot.sessions.add(sessKey);
+    tSlot.messages++;
+
+    // byProvider
+    let pSlot = d.byProvider.get(x.e.provider);
+    if (!pSlot) {
+      pSlot = { tokens: 0, cost: 0 };
+      d.byProvider.set(x.e.provider, pSlot);
+    }
+    pSlot.tokens += tt;
+    pSlot.cost += x.cost;
+
+    // byModel
+    const mKey = `${x.e.tool}|${x.e.provider}|${x.e.model}`;
+    let mSlot = d.byModel.get(mKey);
+    if (!mSlot) {
+      mSlot = {
+        ref: { tool: x.e.tool, provider: x.e.provider, id: x.e.model },
+        tokens: 0,
+        cost: 0,
+        sessions: new Set(),
+        messages: 0,
+      };
+      d.byModel.set(mKey, mSlot);
+    }
+    mSlot.tokens += tt;
+    mSlot.cost += x.cost;
+    mSlot.sessions.add(sessKey);
+    mSlot.messages++;
+
+    // byProject
+    let prSlot = d.byProject.get(x.basename);
+    if (!prSlot) {
+      prSlot = { tokens: 0, cost: 0, sessions: new Set() };
+      d.byProject.set(x.basename, prSlot);
+    }
+    prSlot.tokens += tt;
+    prSlot.cost += x.cost;
+    prSlot.sessions.add(sessKey);
+  }
+
+  const out: DailyEntry[] = [];
+  for (const d of [...days.values()].sort((a, b) => a.date.localeCompare(b.date))) {
+    const byToolObj: Partial<Record<ToolId, ToolDailySlot>> = {};
+    for (const [k, v] of d.byTool)
+      byToolObj[k] = { tokens: v.tokens, costUSD: round2(v.cost), sessions: v.sessions.size, messages: v.messages };
+
+    const byProviderObj: Record<string, ProviderDailySlot> = {};
+    for (const [k, v] of d.byProvider) byProviderObj[k] = { tokens: v.tokens, costUSD: round2(v.cost) };
+
+    const byModelArr: ModelDailySlot[] = [...d.byModel.values()]
+      .map((v) => ({
+        ...v.ref,
+        tokens: v.tokens,
+        costUSD: round2(v.cost),
+        sessions: v.sessions.size,
+        messages: v.messages,
+      }))
+      .sort((a, b) => b.costUSD - a.costUSD);
+
+    const byProjectObj: Record<string, ProjectDailySlot> = {};
+    for (const [k, v] of d.byProject)
+      byProjectObj[k] = { tokens: v.tokens, costUSD: round2(v.cost), sessions: v.sessions.size };
+
+    out.push({
+      date: d.date,
+      tokens: d.tokens,
+      costUSD: round2(d.cost),
+      sessions: d.sessions.size,
+      messages: d.messages,
+      hourCounts: d.hourCounts,
+      byTool: byToolObj,
+      byProvider: byProviderObj,
+      byModel: byModelArr,
+      byProject: byProjectObj,
+    });
+  }
+  return out;
+}
+
+// Merge by date — fresh wins on collision.
+export function mergeDaily(prior: DailyEntry[], fresh: DailyEntry[]): DailyEntry[] {
+  const m = new Map<string, DailyEntry>();
+  for (const d of prior) m.set(d.date, d);
+  for (const d of fresh) m.set(d.date, d);
+  return [...m.values()].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// Re-derive top-level views by summing daily entries.
+function deriveTopLevel(daily: DailyEntry[]) {
+  const byToolMap = new Map<ToolId, { tokens: number; costUSD: number; sessions: number; messages: number }>();
+  const byProviderMap = new Map<string, { tokens: number; costUSD: number }>();
+  const byModelMap = new Map<
+    string,
+    { tool: ToolId; provider: string; id: string; tokens: number; costUSD: number; sessions: number; messages: number }
+  >();
+  const byProjectMap = new Map<string, { tokens: number; costUSD: number; sessions: number }>();
+  const hourCounts = new Array<number>(24).fill(0);
+  let totalTokens = 0,
+    totalCost = 0,
+    totalMessages = 0,
+    totalSessions = 0;
+
+  for (const d of daily) {
+    totalTokens += d.tokens;
+    totalCost += d.costUSD;
+    totalMessages += d.messages;
+    totalSessions += d.sessions; // sum-across-days approximation; cross-midnight sessions counted twice
+    for (let h = 0; h < 24; h++) hourCounts[h]! += d.hourCounts[h] ?? 0;
+
+    for (const [k, v] of Object.entries(d.byTool) as [ToolId, ToolDailySlot][]) {
+      const slot = byToolMap.get(k) ?? { tokens: 0, costUSD: 0, sessions: 0, messages: 0 };
+      slot.tokens += v.tokens;
+      slot.costUSD += v.costUSD;
+      slot.sessions += v.sessions;
+      slot.messages += v.messages;
+      byToolMap.set(k, slot);
+    }
+    for (const [k, v] of Object.entries(d.byProvider)) {
+      const slot = byProviderMap.get(k) ?? { tokens: 0, costUSD: 0 };
+      slot.tokens += v.tokens;
+      slot.costUSD += v.costUSD;
+      byProviderMap.set(k, slot);
+    }
+    for (const m of d.byModel) {
+      const k = `${m.tool}|${m.provider}|${m.id}`;
+      const slot = byModelMap.get(k) ?? {
+        tool: m.tool,
+        provider: m.provider,
+        id: m.id,
+        tokens: 0,
+        costUSD: 0,
+        sessions: 0,
+        messages: 0,
+      };
+      slot.tokens += m.tokens;
+      slot.costUSD += m.costUSD;
+      slot.sessions += m.sessions;
+      slot.messages += m.messages;
+      byModelMap.set(k, slot);
+    }
+    for (const [k, v] of Object.entries(d.byProject)) {
+      const slot = byProjectMap.get(k) ?? { tokens: 0, costUSD: 0, sessions: 0 };
+      slot.tokens += v.tokens;
+      slot.costUSD += v.costUSD;
+      slot.sessions += v.sessions;
+      byProjectMap.set(k, slot);
+    }
+  }
+
+  const byTool: ToolBreakdown[] = [...byToolMap.entries()]
+    .map(([id, v]) => ({
+      id,
+      label: TOOL_LABEL[id] ?? id,
+      tokens: v.tokens,
+      costUSD: round2(v.costUSD),
+      sessions: v.sessions,
+      messages: v.messages,
+    }))
+    .sort((a, b) => b.costUSD - a.costUSD);
+
+  const byProvider: ProviderBreakdown[] = [...byProviderMap.entries()]
+    .map(([id, v]) => ({ id, label: PROVIDER_LABEL[id] ?? id, tokens: v.tokens, costUSD: round2(v.costUSD) }))
+    .sort((a, b) => b.costUSD - a.costUSD);
+
+  const byModel: ModelBreakdown[] = [...byModelMap.values()]
+    .map((v) => ({
+      tool: v.tool,
+      provider: v.provider,
+      id: v.id,
+      label: v.id,
+      tokens: v.tokens,
+      costUSD: round2(v.costUSD),
+      sessions: v.sessions,
+      messages: v.messages,
+    }))
+    .sort((a, b) => b.costUSD - a.costUSD);
+
+  const byProject: ProjectBreakdown[] = [...byProjectMap.entries()]
+    .map(([label, v]) => ({ label, tokens: v.tokens, costUSD: round2(v.costUSD), sessions: v.sessions }))
+    .sort((a, b) => b.costUSD - a.costUSD);
+
+  return {
+    byTool,
+    byProvider,
+    byModel,
+    byProject,
+    hourCounts,
+    totalTokens,
+    totalCost: round2(totalCost),
+    totalMessages,
+    totalSessions,
+  };
+}
+
+function computeStreaks(activeDates: Set<string>, todayLocal: string): { current: number; longest: number } {
+  if (activeDates.size === 0) return { current: 0, longest: 0 };
+  const sorted = [...activeDates].sort();
+  let longest = 1,
+    run = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = new Date(sorted[i - 1]! + 'T00:00:00Z');
+    const cur = new Date(sorted[i]! + 'T00:00:00Z');
+    const diff = Math.round((cur.getTime() - prev.getTime()) / 86_400_000);
+    run = diff === 1 ? run + 1 : 1;
+    if (run > longest) longest = run;
+  }
+  let current = 0;
+  if (activeDates.has(todayLocal)) {
+    const cursor = new Date(todayLocal + 'T00:00:00Z');
+    while (activeDates.has(cursor.toISOString().slice(0, 10))) {
+      current++;
+      cursor.setUTCDate(cursor.getUTCDate() - 1);
+    }
+  }
+  return { current, longest };
+}
+
+function peakHourFromHistogram(hours: number[]): number {
+  let best = 0,
+    bestCount = -1;
+  for (let h = 0; h < 24; h++) {
+    const c = hours[h] ?? 0;
+    if (c > bestCount) {
+      bestCount = c;
+      best = h;
+    }
+  }
+  return best;
+}
+
+function favoriteModelFromTopLevel(byModel: ModelBreakdown[]): ModelRef {
+  if (byModel.length === 0) {
+    return { tool: 'claude-code', provider: 'anthropic', id: 'unknown', label: 'Unknown' };
+  }
+  // Sort by messages desc, tie-break lex by tool|provider|id (deterministic regardless of input order)
+  const sorted = [...byModel].sort((a, b) => {
+    if (b.messages !== a.messages) return b.messages - a.messages;
+    return `${a.tool}|${a.provider}|${a.id}`.localeCompare(`${b.tool}|${b.provider}|${b.id}`);
+  });
+  const m = sorted[0]!;
+  return { tool: m.tool, provider: m.provider, id: m.id, label: m.label };
+}
+
+// Advance a YYYY-MM-DD week-ending (local Sunday) by `n` weeks, staying on Sunday.
+function addWeeks(weekEndingYmd: string, n: number): string {
+  const [y, m, d] = weekEndingYmd.split('-').map(Number);
+  const dt = new Date(Date.UTC(y!, m! - 1, d!));
+  dt.setUTCDate(dt.getUTCDate() + n * 7);
+  return dt.toISOString().slice(0, 10);
+}
+
+// Build the weekly trend series + activity profiles from merged daily + PRs.
+// Week range is defined by daily activity; PRs only contribute to weeks inside
+// that range (consistent with the page period). Weekly array is dense.
+export function computeInsights(daily: DailyEntry[], prs: PullRequest[], tz: string, hourCounts: number[]): Insights {
+  interface WeekSlot {
+    tokens: number;
+    costUSD: number;
+    sessions: number;
+    messages: number;
+    byTool: Map<ToolId, { tokens: number; costUSD: number }>;
+    prsMerged: number;
+    additions: number;
+    deletions: number;
+  }
+  const newSlot = (): WeekSlot => ({
+    tokens: 0,
+    costUSD: 0,
+    sessions: 0,
+    messages: 0,
+    byTool: new Map(),
+    prsMerged: 0,
+    additions: 0,
+    deletions: 0,
+  });
+
+  const weeks = new Map<string, WeekSlot>();
+  const weekdayCounts = new Array<number>(7).fill(0);
+
+  // 1. Accumulate per-week activity from daily entries.
+  for (const d of daily) {
+    const wk = weekEnding(d.date);
+    let s = weeks.get(wk);
+    if (!s) {
+      s = newSlot();
+      weeks.set(wk, s);
+    }
+    s.tokens += d.tokens;
+    s.costUSD += d.costUSD;
+    s.sessions += d.sessions;
+    s.messages += d.messages;
+    for (const [k, v] of Object.entries(d.byTool) as [ToolId, ToolDailySlot][]) {
+      const t = s.byTool.get(k) ?? { tokens: 0, costUSD: 0 };
+      t.tokens += v.tokens;
+      t.costUSD += v.costUSD;
+      s.byTool.set(k, t);
+    }
+    weekdayCounts[new Date(d.date + 'T00:00:00Z').getUTCDay()]! += d.messages;
+  }
+
+  // 2. Dense-fill missing weeks between first and last active week.
+  const present = [...weeks.keys()].sort();
+  if (present.length > 0) {
+    const first = present[0]!;
+    const last = present[present.length - 1]!;
+    for (let wk = first; wk <= last; wk = addWeeks(wk, 1)) {
+      if (!weeks.has(wk)) weeks.set(wk, newSlot());
+    }
+  }
+
+  // 3. Fold in merged PRs — only weeks already in range get counted.
+  for (const pr of prs) {
+    if (pr.state !== 'merged' || !pr.mergedAt) continue;
+    const wk = weekEnding(localDate(pr.mergedAt, tz));
+    const s = weeks.get(wk);
+    if (!s) continue;
+    s.prsMerged += 1;
+    s.additions += pr.additions;
+    s.deletions += pr.deletions;
+  }
+
+  // 4. Emit sorted dense array.
+  const weekly: InsightsWeek[] = [...weeks.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([weekEnding, s]) => {
+      const byTool: Partial<Record<ToolId, { tokens: number; costUSD: number }>> = {};
+      for (const [k, v] of s.byTool) byTool[k] = { tokens: v.tokens, costUSD: round2(v.costUSD) };
+      return {
+        weekEnding,
+        tokens: s.tokens,
+        costUSD: round2(s.costUSD),
+        sessions: s.sessions,
+        messages: s.messages,
+        byTool,
+        prsMerged: s.prsMerged,
+        additions: s.additions,
+        deletions: s.deletions,
+      };
+    });
+
+  return { weekly, hourCounts: hourCounts.slice(), weekdayCounts };
+}
+
+export function aggregate(input: AggregateInput): TokenmaxingData {
+  const { tz, priorDaily, prs, now } = input;
+  const includeBase = input.include ?? new Set<string>();
+  const includePref = input.includePrefixes ?? [];
+  const hasAllowlist = includeBase.size > 0 || includePref.length > 0;
+  const isAllowed = (label: string) => {
+    if (!hasAllowlist) return true;
+    return includeBase.has(label) || includePref.some((p) => label.startsWith(p));
+  };
+
+  const excludeBase = input.exclude;
+  const excludePref = input.excludePrefixes ?? [];
+  const isExcluded = (label: string) => excludeBase.has(label) || excludePref.some((p) => label.startsWith(p));
+
+  const isKept = (label: string) => isAllowed(label) && !isExcluded(label);
+
+  // 1. Filter events down to kept basenames
+  const filtered = input.events.filter((e) => isKept(resolveProject(e.projectPath)));
+
+  // 2. Build fresh daily entries from current local events
+  const enriched = enrich(filtered, tz);
+  const freshDaily = buildFreshDaily(enriched);
+
+  // 3. Merge with prior gist daily (fresh wins on date collision)
+  //    Apply the same exclusion to prior data so removing from exclude.json
+  //    isn't required to drop a basename from already-published days.
+  const filteredPrior = priorDaily.map((d) => {
+    const byTool = { ...d.byTool };
+    const byProvider = { ...d.byProvider };
+    const byModel = d.byModel.slice();
+    const byProject: Record<string, ProjectDailySlot> = {};
+    let droppedTokens = 0,
+      droppedCost = 0,
+      droppedSessions = 0;
+    for (const [k, v] of Object.entries(d.byProject)) {
+      if (!isKept(k)) {
+        droppedTokens += v.tokens;
+        droppedCost += v.costUSD;
+        droppedSessions += v.sessions;
+      } else {
+        byProject[k] = v;
+      }
+    }
+    return {
+      ...d,
+      tokens: d.tokens - droppedTokens,
+      costUSD: round2(d.costUSD - droppedCost),
+      sessions: d.sessions - droppedSessions,
+      byTool,
+      byProvider,
+      byModel,
+      byProject,
+    };
+  });
+  const merged = mergeDaily(filteredPrior, freshDaily);
+
+  // 4. Re-derive top-level breakdowns + summary stats from merged daily
+  const top = deriveTopLevel(merged);
+
+  const activeDates = new Set(merged.map((d) => d.date));
+  const todayLocal = localDate(now, tz);
+  const { current, longest } = computeStreaks(activeDates, todayLocal);
+  const dates = [...activeDates].sort();
+
+  // 5. Weekly highlights — always fresh from current PR data, no merge
+  const weekMap = new Map<string, PullRequest[]>();
+  for (const pr of prs) {
+    const ts = pr.mergedAt ?? pr.createdAt;
+    const localDay = localDate(ts, tz);
+    const wk = weekEnding(localDay);
+    const arr = weekMap.get(wk) ?? [];
+    arr.push(pr);
+    weekMap.set(wk, arr);
+  }
+  const weeklyHighlights: WeeklyHighlight[] = [...weekMap.entries()]
+    .map(([weekEnding, list]) => ({
+      weekEnding,
+      pullRequests: [...list].sort((a, b) => b.additions + b.deletions - (a.additions + a.deletions)),
+      summary: null,
+    }))
+    .sort((a, b) => b.weekEnding.localeCompare(a.weekEnding));
+
+  // Carry forward existing summaries from prior gist data
+  const priorSummaries = new Map<string, string>();
+  for (const w of input.priorWeeklyHighlights ?? []) {
+    if (w.summary) priorSummaries.set(w.weekEnding, w.summary);
+  }
+  const weeklyHighlightsFinal = weeklyHighlights.map((w) => ({
+    ...w,
+    summary: priorSummaries.get(w.weekEnding) ?? w.summary,
+  }));
+
+  const period = { from: dates[0] ?? todayLocal, to: todayLocal };
+  const weeklyHighlightsFiltered = weeklyHighlightsFinal.filter((w) => w.weekEnding >= period.from);
+
+  return {
+    schemaVersion: 2,
+    generatedAt: now,
+    period,
+    summary: {
+      totalCostUSD: top.totalCost,
+      totalTokens: top.totalTokens,
+      sessions: top.totalSessions,
+      messages: top.totalMessages,
+      activeDays: activeDates.size,
+      currentStreakDays: current,
+      longestStreakDays: longest,
+      peakHourLocal: peakHourFromHistogram(top.hourCounts),
+      favoriteModel: favoriteModelFromTopLevel(top.byModel),
+    },
+    byTool: top.byTool,
+    byProvider: top.byProvider,
+    byModel: top.byModel,
+    byProject: top.byProject,
+    daily: merged,
+    weeklyHighlights: weeklyHighlightsFiltered,
+    insights: computeInsights(merged, prs, tz, top.hourCounts),
+  };
+}

--- a/src/report/extract.test.ts
+++ b/src/report/extract.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gatherEvents } from './extract.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'sessions-report-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const claudeDir = join(tmp, 'claude');
+mkdirSync(join(claudeDir, 'proj'), { recursive: true });
+writeFileSync(
+  join(claudeDir, 'proj', 'a.jsonl'),
+  JSON.stringify({
+    type: 'assistant',
+    sessionId: 's1',
+    cwd: '/Users/x/Developer/sessions',
+    timestamp: '2026-06-01T14:30:00Z',
+    message: {
+      model: 'claude-opus-4-6',
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 10000,
+      },
+    },
+  }) + '\n',
+);
+
+const roots = { claudeCode: claudeDir, pi: join(tmp, 'no-pi'), codex: join(tmp, 'no-codex') };
+
+describe('gatherEvents', () => {
+  test('parses claude events and skips missing tool dirs', async () => {
+    const events = await gatherEvents(roots);
+    expect(events.length).toBe(1);
+    const e = events[0]!;
+    expect(e.tool).toBe('claude-code');
+    expect(e.provider).toBe('anthropic');
+    expect(e.tokens.input).toBe(1000);
+    expect(e.tokens.cacheWrite).toBe(200);
+    expect(e.tokens.cacheRead).toBe(10000);
+    expect(e.projectPath).toContain('sessions');
+  });
+
+  test('honors the tools filter', async () => {
+    const events = await gatherEvents(roots, new Set(['pi']));
+    expect(events.length).toBe(0);
+  });
+});

--- a/src/report/extract.ts
+++ b/src/report/extract.ts
@@ -1,0 +1,32 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { UsageEvent } from './parsers/types.ts';
+import type { ToolId } from './types.ts';
+import { parseClaudeCode } from './parsers/claude-code.ts';
+import { parsePi } from './parsers/pi.ts';
+import { parseCodex } from './parsers/codex.ts';
+
+export interface ReportRoots {
+  claudeCode: string;
+  pi: string;
+  codex: string;
+}
+
+export function defaultRoots(): ReportRoots {
+  const home = homedir();
+  return {
+    claudeCode: join(home, '.claude', 'projects'),
+    pi: join(home, '.pi', 'agent', 'sessions'),
+    codex: join(home, '.codex', 'sessions'),
+  };
+}
+
+export async function gatherEvents(roots: ReportRoots = defaultRoots(), tools?: Set<ToolId>): Promise<UsageEvent[]> {
+  const want = (t: ToolId): boolean => !tools || tools.has(t);
+  const tasks: Promise<UsageEvent[]>[] = [];
+  if (want('claude-code')) tasks.push(parseClaudeCode(roots.claudeCode));
+  if (want('pi')) tasks.push(parsePi(roots.pi));
+  if (want('codex')) tasks.push(parseCodex(roots.codex));
+  const results = await Promise.all(tasks);
+  return results.flat();
+}

--- a/src/report/html.test.ts
+++ b/src/report/html.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'bun:test';
+import { aggregate } from './aggregate.ts';
+import { renderHtml } from './html.ts';
+import { toUsageReport } from './schema.ts';
+import type { UsageEvent } from './parsers/types.ts';
+
+const events: UsageEvent[] = [
+  {
+    tool: 'claude-code',
+    provider: 'anthropic',
+    model: 'claude-opus-4-6',
+    timestamp: '2026-06-01T14:30:00Z',
+    sessionId: 's1',
+    projectPath: '/Users/x/Developer/sessions',
+    tokens: { input: 1000, output: 500, cacheRead: 10000, cacheWrite: 200 },
+  },
+];
+const data = aggregate({
+  events,
+  prs: [],
+  now: '2026-06-06T00:00:00Z',
+  tz: 'UTC',
+  exclude: new Set<string>(),
+  priorDaily: [],
+});
+
+describe('renderHtml', () => {
+  test('produces a self-contained document with expected anchors', () => {
+    const html = renderHtml(toUsageReport(data));
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('AI Usage Report');
+    expect(html).toContain('<svg');
+    expect(html).toContain('Total cost');
+    expect(html).toContain('sessions usage report');
+    // self-contained: no external resource references
+    expect(html).not.toContain('http://');
+    expect(html).not.toContain('https://');
+    // safe DOM: no innerHTML usage in the inline script
+    expect(html).not.toContain('innerHTML');
+  });
+});

--- a/src/report/html.test.ts
+++ b/src/report/html.test.ts
@@ -32,6 +32,10 @@ describe('renderHtml', () => {
     expect(html).toContain('<svg');
     expect(html).toContain('Total cost');
     expect(html).toContain('sessions usage report');
+    // prominent period badge with human-formatted dates
+    expect(html).toContain('class="period"');
+    expect(html).toContain('Jun 1, 2026');
+    expect(html).toContain('Jun 6, 2026');
     // self-contained: no external resource references
     expect(html).not.toContain('http://');
     expect(html).not.toContain('https://');

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -1,0 +1,190 @@
+import type { UsageReport, ToolBreakdown, ModelBreakdown, ProjectBreakdown } from './schema.ts';
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+const fmtUSD = (n: number): string =>
+  '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
+}
+
+const fmtInt = (n: number): string => n.toLocaleString('en-US');
+
+function hourLabel(h: number): string {
+  if (h === 0) return '12 AM';
+  if (h === 12) return '12 PM';
+  return h < 12 ? h + ' AM' : h - 12 + ' PM';
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+interface Bar {
+  value: number;
+  tip: string;
+}
+
+function vBars(bars: Bar[], w: number, h: number): string {
+  const max = Math.max(1, ...bars.map((b) => b.value));
+  const n = Math.max(1, bars.length);
+  const bw = w / n;
+  const rects = bars
+    .map((b, i) => {
+      const bh = Math.round((b.value / max) * (h - 6)) + 2;
+      const x = (i * bw + 0.5).toFixed(1);
+      const y = (h - bh).toFixed(1);
+      const op = (0.45 + (b.value / max) * 0.55).toFixed(2);
+      return `<rect data-tip="${esc(b.tip)}" x="${x}" y="${y}" width="${Math.max(1, bw - 1).toFixed(1)}" height="${bh}" rx="1.5" fill="var(--accent)" opacity="${op}"/>`;
+    })
+    .join('');
+  return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="${h}" preserveAspectRatio="none">${rects}</svg>`;
+}
+
+function areaChart(points: Bar[], w: number, h: number): string {
+  if (points.length === 0) return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="${h}"></svg>`;
+  const max = Math.max(1, ...points.map((p) => p.value));
+  const n = points.length;
+  const xOf = (i: number): number => (n === 1 ? w / 2 : (i / (n - 1)) * (w - 8) + 4);
+  const yOf = (v: number): number => h - 4 - (v / max) * (h - 12);
+  const pts = points.map((p, i) => [xOf(i), yOf(p.value)] as [number, number]);
+  const line = 'M' + pts.map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' L');
+  const area =
+    `M${xOf(0).toFixed(1)},${h} L` +
+    pts.map((p) => `${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(' L') +
+    ` L${xOf(n - 1).toFixed(1)},${h} Z`;
+  const dots = pts
+    .map(
+      (p, i) =>
+        `<circle data-tip="${esc(points[i]!.tip)}" cx="${p[0].toFixed(1)}" cy="${p[1].toFixed(1)}" r="2.5" fill="var(--accent)"/>`,
+    )
+    .join('');
+  return `<svg viewBox="0 0 ${w} ${h}" width="100%" height="${h}"><path d="${area}" fill="var(--accent)" opacity="0.12"/><path d="${line}" fill="none" stroke="var(--accent)" stroke-width="2"/>${dots}</svg>`;
+}
+
+function barList(rows: { name: string; value: number; tip: string }[]): string {
+  const max = Math.max(1, ...rows.map((r) => r.value));
+  return rows
+    .map((r) => {
+      const pct = ((r.value / max) * 100).toFixed(1);
+      return `<div class="item"><span class="name">${esc(r.name)}</span><span class="track"><span class="fill" style="width:${pct}%"></span></span><span class="val" data-tip="${esc(r.tip)}">${fmtUSD(r.value)}</span></div>`;
+    })
+    .join('');
+}
+
+const CSS = `
+:root{--bg:#f6f7f9;--panel:#fff;--ink:#16181d;--muted:#6b7280;--line:#e6e8ec;--accent:#6d5efc;--grid:#eef0f3;--shadow:0 1px 2px rgba(16,24,40,.04),0 4px 16px rgba(16,24,40,.05);--mono:ui-monospace,SFMono-Regular,Menlo,monospace;--sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;}
+@media (prefers-color-scheme:dark){:root{--bg:#0e0f13;--panel:#16181d;--ink:#e8eaed;--muted:#9aa1ad;--line:#262a31;--grid:#20242b;--shadow:0 1px 2px rgba(0,0,0,.3),0 6px 20px rgba(0,0,0,.35);}}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:14px;line-height:1.45;}
+.wrap{max-width:1080px;margin:0 auto;padding:28px 24px 60px;}
+header.rep{border-bottom:1px solid var(--line);padding-bottom:18px;margin-bottom:22px;}
+header.rep h1{font-size:20px;margin:0 0 2px;}header.rep .sub{color:var(--muted);font-size:13px;}
+.hero{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:12px;}
+.stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 16px;box-shadow:var(--shadow);}
+.stat .k,.ministat .k{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);}
+.stat .v{font-family:var(--mono);font-size:24px;font-weight:600;margin-top:4px;}
+.ministats{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-bottom:22px;}
+.ministat{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:10px 12px;box-shadow:var(--shadow);}
+.ministat .v{font-family:var(--mono);font-size:15px;font-weight:600;margin-top:2px;}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px;box-shadow:var(--shadow);margin-bottom:14px;}
+.panel h2{font-size:13px;margin:0 0 14px;display:flex;justify-content:space-between;}
+.panel h2 .hint{font-weight:400;color:var(--muted);font-size:11px;font-family:var(--mono);}
+.row2{display:grid;grid-template-columns:1.6fr 1fr;gap:14px;}.row3{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;}.rowins{display:grid;grid-template-columns:1.4fr 1fr;gap:14px;}
+.barlist{display:flex;flex-direction:column;gap:9px;}
+.barlist .item{display:grid;grid-template-columns:90px 1fr auto;gap:10px;align-items:center;font-size:12px;}
+.barlist .name{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.barlist .track{height:8px;background:var(--grid);border-radius:99px;overflow:hidden;}
+.barlist .fill{height:100%;border-radius:99px;background:var(--accent);}
+.barlist .val{font-family:var(--mono);color:var(--muted);font-size:11px;}
+.tip{position:fixed;pointer-events:none;background:var(--ink);color:var(--bg);font-family:var(--mono);font-size:11px;padding:4px 7px;border-radius:6px;opacity:0;transform:translate(-50%,-130%);white-space:nowrap;z-index:9;}
+footer.rep{margin-top:24px;color:var(--muted);font-size:11px;font-family:var(--mono);text-align:center;}
+`;
+
+// Delegated tooltip — textContent only, never innerHTML.
+const JS = `(function(){var t=document.getElementById('tip');function find(e){return e.target&&e.target.closest?e.target.closest('[data-tip]'):null;}document.addEventListener('mousemove',function(e){var el=find(e);if(!el){t.style.opacity='0';return;}t.textContent=el.getAttribute('data-tip');t.style.opacity='1';t.style.left=e.clientX+'px';t.style.top=e.clientY+'px';});})();`;
+
+export function renderHtml(data: UsageReport): string {
+  const s = data.summary;
+  const dailyBars = vBars(
+    data.daily.map((d) => ({ value: d.costUSD, tip: `${d.date}: ${fmtUSD(d.costUSD)}` })),
+    620,
+    150,
+  );
+  const weeklyArea = areaChart(
+    data.insights.weekly.map((w) => ({ value: w.tokens, tip: `${w.weekEnding}: ${fmtTokens(w.tokens)} tokens` })),
+    320,
+    150,
+  );
+  const hourBars = vBars(
+    data.insights.hourCounts.map((c, h) => ({ value: c, tip: `${hourLabel(h)}: ${c} msgs` })),
+    620,
+    110,
+  );
+  const weekdayBars = vBars(
+    data.insights.weekdayCounts.map((c, i) => ({ value: c, tip: `${WEEKDAYS[i]!}: ${c} msgs` })),
+    320,
+    110,
+  );
+  const byTool = barList(
+    data.byTool.map((t: ToolBreakdown) => ({
+      name: t.label,
+      value: t.costUSD,
+      tip: `${fmtTokens(t.tokens)} tokens · ${t.sessions} sessions`,
+    })),
+  );
+  const byModel = barList(
+    data.byModel.slice(0, 6).map((m: ModelBreakdown) => ({
+      name: m.label,
+      value: m.costUSD,
+      tip: `${fmtTokens(m.tokens)} tokens · ${m.messages} msgs`,
+    })),
+  );
+  const byProject = barList(
+    data.byProject.slice(0, 8).map((p: ProjectBreakdown) => ({
+      name: p.label,
+      value: p.costUSD,
+      tip: `${fmtTokens(p.tokens)} tokens · ${p.sessions} sessions`,
+    })),
+  );
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>AI Usage Report — ${esc(data.period.from)} to ${esc(data.period.to)}</title>
+<style>${CSS}</style></head>
+<body><div class="wrap">
+<header class="rep"><h1>AI Usage Report</h1>
+<div class="sub">${esc(data.period.from)} – ${esc(data.period.to)} · generated ${esc(data.generatedAt)}</div></header>
+<div class="hero">
+<div class="stat"><div class="k">Total cost</div><div class="v">${fmtUSD(s.totalCostUSD)}</div></div>
+<div class="stat"><div class="k">Total tokens</div><div class="v">${fmtTokens(s.totalTokens)}</div></div>
+<div class="stat"><div class="k">Sessions</div><div class="v">${fmtInt(s.sessions)}</div></div>
+<div class="stat"><div class="k">Messages</div><div class="v">${fmtInt(s.messages)}</div></div>
+</div>
+<div class="ministats">
+<div class="ministat"><div class="k">Active days</div><div class="v">${s.activeDays}</div></div>
+<div class="ministat"><div class="k">Current streak</div><div class="v">${s.currentStreakDays}d</div></div>
+<div class="ministat"><div class="k">Longest streak</div><div class="v">${s.longestStreakDays}d</div></div>
+<div class="ministat"><div class="k">Peak hour</div><div class="v">${esc(hourLabel(s.peakHourLocal))}</div></div>
+<div class="ministat"><div class="k">Top model</div><div class="v" style="font-size:12px">${esc(s.favoriteModel.label)}</div></div>
+</div>
+<div class="row2">
+<div class="panel"><h2>Daily cost <span class="hint">per day</span></h2>${dailyBars}</div>
+<div class="panel"><h2>Weekly tokens <span class="hint">trend</span></h2>${weeklyArea}</div>
+</div>
+<div class="row3">
+<div class="panel"><h2>By tool</h2><div class="barlist">${byTool}</div></div>
+<div class="panel"><h2>By model</h2><div class="barlist">${byModel}</div></div>
+<div class="panel"><h2>By project</h2><div class="barlist">${byProject}</div></div>
+</div>
+<div class="rowins">
+<div class="panel"><h2>Activity by hour <span class="hint">messages</span></h2>${hourBars}</div>
+<div class="panel"><h2>By weekday</h2>${weekdayBars}</div>
+</div>
+<footer class="rep">sessions usage report · ${s.activeDays} active days</footer>
+</div>
+<div class="tip" id="tip"></div>
+<script>${JS}</script>
+</body></html>`;
+}

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -21,6 +21,16 @@ function hourLabel(h: number): string {
 }
 
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatDate(ymd: string): string {
+  const [y, m, d] = ymd.split('-').map(Number);
+  return `${MONTHS[m! - 1]} ${d}, ${y}`;
+}
+
+function periodLabel(from: string, to: string): string {
+  return from === to ? formatDate(from) : `${formatDate(from)} → ${formatDate(to)}`;
+}
 
 interface Bar {
   value: number;
@@ -79,8 +89,10 @@ const CSS = `
 @media (prefers-color-scheme:dark){:root{--bg:#0e0f13;--panel:#16181d;--ink:#e8eaed;--muted:#9aa1ad;--line:#262a31;--grid:#20242b;--shadow:0 1px 2px rgba(0,0,0,.3),0 6px 20px rgba(0,0,0,.35);}}
 *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:14px;line-height:1.45;}
 .wrap{max-width:1080px;margin:0 auto;padding:28px 24px 60px;}
-header.rep{border-bottom:1px solid var(--line);padding-bottom:18px;margin-bottom:22px;}
-header.rep h1{font-size:20px;margin:0 0 2px;}header.rep .sub{color:var(--muted);font-size:13px;}
+header.rep{display:flex;justify-content:space-between;align-items:flex-end;flex-wrap:wrap;gap:8px;border-bottom:1px solid var(--line);padding-bottom:18px;margin-bottom:22px;}
+header.rep h1{font-size:20px;margin:0;}
+.period{font-family:var(--mono);font-size:16px;font-weight:600;color:var(--accent);margin-top:6px;}
+.genstamp{color:var(--muted);font-size:11px;font-family:var(--mono);}
 .hero{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:12px;}
 .stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px 16px;box-shadow:var(--shadow);}
 .stat .k,.ministat .k{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);}
@@ -154,8 +166,9 @@ export function renderHtml(data: UsageReport): string {
 <title>AI Usage Report — ${esc(data.period.from)} to ${esc(data.period.to)}</title>
 <style>${CSS}</style></head>
 <body><div class="wrap">
-<header class="rep"><h1>AI Usage Report</h1>
-<div class="sub">${esc(data.period.from)} – ${esc(data.period.to)} · generated ${esc(data.generatedAt)}</div></header>
+<header class="rep"><div><h1>AI Usage Report</h1>
+<div class="period">${esc(periodLabel(data.period.from, data.period.to))}</div></div>
+<div class="genstamp">generated ${esc(data.generatedAt)}</div></header>
 <div class="hero">
 <div class="stat"><div class="k">Total cost</div><div class="v">${fmtUSD(s.totalCostUSD)}</div></div>
 <div class="stat"><div class="k">Total tokens</div><div class="v">${fmtTokens(s.totalTokens)}</div></div>

--- a/src/report/index.test.ts
+++ b/src/report/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runReport, parseReportArgs } from './index.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'sessions-report-run-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const claudeDir = join(tmp, 'claude');
+mkdirSync(join(claudeDir, 'proj'), { recursive: true });
+writeFileSync(
+  join(claudeDir, 'proj', 'a.jsonl'),
+  JSON.stringify({
+    type: 'assistant',
+    sessionId: 's1',
+    cwd: '/Users/x/Developer/sessions',
+    timestamp: '2026-06-01T14:30:00Z',
+    message: {
+      model: 'claude-opus-4-6',
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 10000,
+      },
+    },
+  }) + '\n',
+);
+const roots = { claudeCode: claudeDir, pi: join(tmp, 'no-pi'), codex: join(tmp, 'no-codex') };
+
+describe('parseReportArgs', () => {
+  test('defaults', () => {
+    const o = parseReportArgs([]);
+    expect(o.format).toBe('both');
+    expect(o.stdout).toBe(false);
+  });
+  test('parses flags', () => {
+    const o = parseReportArgs(['--format', 'json', '--days', '7', '--tool', 'claude', '--tz', 'UTC', '--stdout']);
+    expect(o.format).toBe('json');
+    expect(o.days).toBe(7);
+    expect(o.tool).toBe('claude-code');
+    expect(o.tz).toBe('UTC');
+    expect(o.stdout).toBe(true);
+  });
+});
+
+describe('runReport', () => {
+  test('writes both json and html to the out dir', async () => {
+    const outDir = join(tmp, 'out');
+    mkdirSync(outDir, { recursive: true });
+    const res = await runReport({
+      format: 'both',
+      out: outDir,
+      tz: 'UTC',
+      stdout: false,
+      roots,
+      now: '2026-06-06T00:00:00Z',
+    });
+    expect(res.jsonPath).toBe(join(outDir, 'usage-report.json'));
+    expect(res.htmlPath).toBe(join(outDir, 'report.html'));
+    expect(existsSync(res.jsonPath!)).toBe(true);
+    expect(existsSync(res.htmlPath!)).toBe(true);
+    const report = JSON.parse(readFileSync(res.jsonPath!, 'utf8'));
+    expect(report.generator).toBe('sessions');
+    expect(report.version).toBe(1);
+    expect(report.weeklyHighlights).toBeUndefined();
+    expect(report.summary.totalTokens).toBe(1700);
+    expect(readFileSync(res.htmlPath!, 'utf8').startsWith('<!DOCTYPE html>')).toBe(true);
+  });
+});

--- a/src/report/index.test.ts
+++ b/src/report/index.test.ts
@@ -43,6 +43,14 @@ describe('parseReportArgs', () => {
     expect(o.tz).toBe('UTC');
     expect(o.stdout).toBe(true);
   });
+
+  test('parses period presets', () => {
+    expect(parseReportArgs(['--this-month']).preset).toBe('this-month');
+    expect(parseReportArgs(['--today']).preset).toBe('today');
+    const m = parseReportArgs(['--month', '2026-05']);
+    expect(m.preset).toBe('month');
+    expect(m.month).toBe('2026-05');
+  });
 });
 
 describe('runReport', () => {
@@ -67,5 +75,24 @@ describe('runReport', () => {
     expect(report.weeklyHighlights).toBeUndefined();
     expect(report.summary.totalTokens).toBe(1700);
     expect(readFileSync(res.htmlPath!, 'utf8').startsWith('<!DOCTYPE html>')).toBe(true);
+  });
+
+  test('period reflects the requested range, and out-of-range events are excluded', async () => {
+    const out = join(tmp, 'may.json');
+    // The only fixture event is 2026-06-01, so a May window yields an empty report.
+    const res = await runReport({
+      format: 'json',
+      out,
+      tz: 'UTC',
+      stdout: false,
+      roots,
+      now: '2026-06-06T00:00:00Z',
+      from: '2026-05-01',
+      to: '2026-05-31',
+    });
+    const report = JSON.parse(readFileSync(res.jsonPath!, 'utf8'));
+    expect(report.period).toEqual({ from: '2026-05-01', to: '2026-05-31' });
+    expect(report.summary.sessions).toBe(0);
+    expect(report.summary.totalTokens).toBe(0);
   });
 });

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -5,6 +5,7 @@ import { gatherEvents, defaultRoots, type ReportRoots } from './extract.ts';
 import { aggregate } from './aggregate.ts';
 import { renderHtml } from './html.ts';
 import { toUsageReport } from './schema.ts';
+import { resolvePeriod, type PeriodPreset } from './period.ts';
 import { localDate } from './parsers/util.ts';
 
 export type ReportFormat = 'json' | 'html' | 'both';
@@ -15,6 +16,8 @@ export interface ReportOptions {
   from?: string;
   to?: string;
   days?: number;
+  preset?: PeriodPreset;
+  month?: string;
   tool?: ToolId;
   tz: string;
   stdout: boolean;
@@ -79,6 +82,17 @@ export function parseReportArgs(argv: string[]): ReportOptions {
         opts.tool = mapped;
         break;
       }
+      case '--today':
+      case '--this-week':
+      case '--this-month':
+      case '--last-month':
+      case '--this-year':
+        opts.preset = a.slice(2) as PeriodPreset;
+        break;
+      case '--month':
+        opts.preset = 'month';
+        opts.month = argv[++i];
+        break;
       default:
         die(`unknown option: ${a}`);
     }
@@ -101,8 +115,14 @@ export async function runReport(opts: ReportOptions): Promise<ReportResult> {
   const events = await gatherEvents(opts.roots ?? defaultRoots(), tools);
 
   const todayLocal = localDate(now, tz);
-  const from = opts.days ? daysAgo(todayLocal, opts.days) : opts.from;
-  const to = opts.to;
+  // Precedence: a named preset wins, then --days, then explicit --from/--to.
+  let from = opts.from;
+  let to = opts.to;
+  if (opts.preset) {
+    ({ from, to } = resolvePeriod(opts.preset, opts.month, todayLocal));
+  } else if (opts.days) {
+    from = daysAgo(todayLocal, opts.days);
+  }
   const inRange = events.filter((e) => {
     const d = localDate(e.timestamp, tz);
     if (from && d < from) return false;
@@ -114,6 +134,9 @@ export async function runReport(opts: ReportOptions): Promise<ReportResult> {
 
   const data = aggregate({ events: inRange, prs: [], now, tz, exclude: new Set<string>(), priorDaily: [] });
   const report = toUsageReport(data);
+  // The internal aggregate always reports "to today"; reflect the requested
+  // window instead so an explicit range (e.g. --month 2026-05) reads correctly.
+  report.period = { from: from ?? data.period.from, to: to ?? data.period.to };
   const json = JSON.stringify(report, null, 2);
   const result: ReportResult = { json };
 

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -1,0 +1,139 @@
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ToolId } from './types.ts';
+import { gatherEvents, defaultRoots, type ReportRoots } from './extract.ts';
+import { aggregate } from './aggregate.ts';
+import { renderHtml } from './html.ts';
+import { toUsageReport } from './schema.ts';
+import { localDate } from './parsers/util.ts';
+
+export type ReportFormat = 'json' | 'html' | 'both';
+
+export interface ReportOptions {
+  format: ReportFormat;
+  out?: string;
+  from?: string;
+  to?: string;
+  days?: number;
+  tool?: ToolId;
+  tz: string;
+  stdout: boolean;
+  roots?: ReportRoots;
+  now?: string;
+}
+
+export interface ReportResult {
+  jsonPath?: string;
+  htmlPath?: string;
+  json: string;
+}
+
+const TOOL_MAP: Record<string, ToolId> = { claude: 'claude-code', codex: 'codex', pi: 'pi' };
+
+function die(msg: string): never {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(1);
+}
+
+export function parseReportArgs(argv: string[]): ReportOptions {
+  const opts: ReportOptions = {
+    format: 'both',
+    tz: process.env['TIMEZONE'] ?? 'America/Chicago',
+    stdout: false,
+  };
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i]!;
+    switch (a) {
+      case '--format': {
+        const v = argv[++i];
+        if (v !== 'json' && v !== 'html' && v !== 'both') die('--format must be json|html|both');
+        opts.format = v;
+        break;
+      }
+      case '--out':
+        opts.out = argv[++i];
+        break;
+      case '--from':
+        opts.from = argv[++i];
+        break;
+      case '--to':
+        opts.to = argv[++i];
+        break;
+      case '--days': {
+        const v = Number(argv[++i]);
+        if (!Number.isInteger(v) || v <= 0) die('--days must be a positive integer');
+        opts.days = v;
+        break;
+      }
+      case '--tz':
+        opts.tz = argv[++i] ?? opts.tz;
+        break;
+      case '--stdout':
+        opts.stdout = true;
+        break;
+      case '--tool': {
+        const v = argv[++i] ?? '';
+        const mapped = TOOL_MAP[v];
+        if (!mapped) die('--tool must be claude|codex|pi');
+        opts.tool = mapped;
+        break;
+      }
+      default:
+        die(`unknown option: ${a}`);
+    }
+    i++;
+  }
+  return opts;
+}
+
+function daysAgo(todayLocal: string, n: number): string {
+  const [y, m, d] = todayLocal.split('-').map(Number);
+  const dt = new Date(Date.UTC(y!, m! - 1, d!));
+  dt.setUTCDate(dt.getUTCDate() - (n - 1));
+  return dt.toISOString().slice(0, 10);
+}
+
+export async function runReport(opts: ReportOptions): Promise<ReportResult> {
+  const now = opts.now ?? new Date().toISOString();
+  const tz = opts.tz;
+  const tools = opts.tool ? new Set<ToolId>([opts.tool]) : undefined;
+  const events = await gatherEvents(opts.roots ?? defaultRoots(), tools);
+
+  const todayLocal = localDate(now, tz);
+  const from = opts.days ? daysAgo(todayLocal, opts.days) : opts.from;
+  const to = opts.to;
+  const inRange = events.filter((e) => {
+    const d = localDate(e.timestamp, tz);
+    if (from && d < from) return false;
+    if (to && d > to) return false;
+    return true;
+  });
+
+  if (inRange.length === 0) process.stderr.write('warning: no usage events in range; report is empty\n');
+
+  const data = aggregate({ events: inRange, prs: [], now, tz, exclude: new Set<string>(), priorDaily: [] });
+  const report = toUsageReport(data);
+  const json = JSON.stringify(report, null, 2);
+  const result: ReportResult = { json };
+
+  const wantJson = opts.format === 'json' || opts.format === 'both';
+  const wantHtml = opts.format === 'html' || opts.format === 'both';
+
+  if (opts.stdout) {
+    process.stdout.write(json + '\n');
+  } else if (wantJson) {
+    const p = opts.format === 'both' ? join(opts.out ?? '.', 'usage-report.json') : (opts.out ?? './usage-report.json');
+    await writeFile(p, json, 'utf8');
+    result.jsonPath = p;
+  }
+
+  if (wantHtml) {
+    const html = renderHtml(report);
+    const p = opts.format === 'both' ? join(opts.out ?? '.', 'report.html') : (opts.out ?? './report.html');
+    await writeFile(p, html, 'utf8');
+    result.htmlPath = p;
+  }
+
+  return result;
+}

--- a/src/report/parsers/claude-code.ts
+++ b/src/report/parsers/claude-code.ts
@@ -1,0 +1,52 @@
+// VENDORED VERBATIM from tokenmaxing/src/parsers/claude-code.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import type { UsageEvent } from './types.ts';
+import { walkJsonl, readJsonlLines } from './util.ts';
+
+interface ClaudeAssistantLine {
+  type: 'assistant';
+  sessionId?: string;
+  cwd?: string;
+  timestamp?: string;
+  message?: {
+    model?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+}
+
+function isAssistantLine(v: unknown): v is ClaudeAssistantLine {
+  return !!v && typeof v === 'object' && (v as { type?: unknown }).type === 'assistant';
+}
+
+export async function parseClaudeCode(root: string): Promise<UsageEvent[]> {
+  const events: UsageEvent[] = [];
+  for await (const path of walkJsonl(root)) {
+    for await (const line of readJsonlLines(path)) {
+      if (!isAssistantLine(line)) continue;
+      const u = line.message?.usage;
+      const model = line.message?.model;
+      const ts = line.timestamp;
+      const sid = line.sessionId;
+      if (!u || !model || !ts || !sid) continue;
+      events.push({
+        tool: 'claude-code',
+        provider: 'anthropic',
+        model,
+        timestamp: ts,
+        sessionId: sid,
+        projectPath: line.cwd,
+        tokens: {
+          input: u.input_tokens ?? 0,
+          output: u.output_tokens ?? 0,
+          cacheRead: u.cache_read_input_tokens ?? 0,
+          cacheWrite: u.cache_creation_input_tokens ?? 0,
+        },
+      });
+    }
+  }
+  return events;
+}

--- a/src/report/parsers/codex.ts
+++ b/src/report/parsers/codex.ts
@@ -1,0 +1,84 @@
+// VENDORED VERBATIM from tokenmaxing/src/parsers/codex.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import type { UsageEvent } from './types.ts';
+import { walkJsonl, readJsonlLines } from './util.ts';
+
+interface CodexEnvelope {
+  timestamp: string;
+  type: string;
+  payload?: unknown;
+}
+
+interface SessionMetaPayload {
+  id: string;
+  cwd?: string;
+}
+interface TokenCountInfo {
+  last_token_usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_output_tokens?: number;
+    cached_input_tokens?: number;
+  };
+}
+interface TokenCountPayload {
+  type: 'token_count';
+  info: TokenCountInfo | null;
+}
+
+function isEnvelope(v: unknown): v is CodexEnvelope {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    typeof (v as { type?: unknown }).type === 'string' &&
+    typeof (v as { timestamp?: unknown }).timestamp === 'string'
+  );
+}
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+export async function parseCodex(root: string): Promise<UsageEvent[]> {
+  const events: UsageEvent[] = [];
+  for await (const path of walkJsonl(root)) {
+    let meta: SessionMetaPayload | null = null;
+    let model: string | null = null;
+    for await (const line of readJsonlLines(path)) {
+      if (!isEnvelope(line)) continue;
+      const payload = line.payload;
+      if (line.type === 'session_meta') {
+        if (isObject(payload) && typeof payload['id'] === 'string') {
+          meta = { id: payload['id'], cwd: typeof payload['cwd'] === 'string' ? payload['cwd'] : undefined };
+        }
+        continue;
+      }
+      if (line.type === 'turn_context') {
+        if (isObject(payload) && typeof payload['model'] === 'string') {
+          model = payload['model'];
+        }
+        continue;
+      }
+      if (line.type !== 'event_msg') continue;
+      if (!isObject(payload) || payload['type'] !== 'token_count') continue;
+      const tcp = payload as unknown as TokenCountPayload;
+      const info = tcp.info;
+      if (!info || !info.last_token_usage) continue;
+      if (!meta || !model) continue;
+      const u = info.last_token_usage;
+      events.push({
+        tool: 'codex',
+        provider: 'openai',
+        model,
+        timestamp: line.timestamp,
+        sessionId: meta.id,
+        projectPath: meta.cwd,
+        tokens: {
+          input: u.input_tokens ?? 0,
+          output: (u.output_tokens ?? 0) + (u.reasoning_output_tokens ?? 0),
+          cacheRead: u.cached_input_tokens ?? 0,
+          cacheWrite: 0,
+        },
+      });
+    }
+  }
+  return events;
+}

--- a/src/report/parsers/pi.ts
+++ b/src/report/parsers/pi.ts
@@ -1,0 +1,69 @@
+// VENDORED VERBATIM from tokenmaxing/src/parsers/pi.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import type { UsageEvent } from './types.ts';
+import { walkJsonl, readJsonlLines } from './util.ts';
+
+interface PiSessionLine {
+  type: 'session';
+  id: string;
+  cwd?: string;
+}
+interface PiUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  cost?: { total?: number };
+}
+interface PiMessageLine {
+  type: 'message';
+  timestamp: string;
+  // Current Pi nests provider/model/usage inside `message`; older logs put them at the top level.
+  message?: { role?: string; provider?: string; model?: string; usage?: PiUsage };
+  provider?: string;
+  model?: string;
+  usage?: PiUsage;
+}
+
+function isSession(v: unknown): v is PiSessionLine {
+  return !!v && typeof v === 'object' && (v as { type?: unknown }).type === 'session';
+}
+function isMessage(v: unknown): v is PiMessageLine {
+  return !!v && typeof v === 'object' && (v as { type?: unknown }).type === 'message';
+}
+
+export async function parsePi(root: string): Promise<UsageEvent[]> {
+  const events: UsageEvent[] = [];
+  for await (const path of walkJsonl(root)) {
+    let session: PiSessionLine | null = null;
+    for await (const line of readJsonlLines(path)) {
+      if (isSession(line)) {
+        session = line;
+        continue;
+      }
+      if (!isMessage(line)) continue;
+      if (line.message?.role !== 'assistant') continue;
+      // Pi moved provider/model/usage from the top level into `message`.
+      // Prefer the nested location; fall back to legacy top-level fields.
+      const provider = line.message?.provider ?? line.provider;
+      const model = line.message?.model ?? line.model;
+      const usage = line.message?.usage ?? line.usage;
+      if (!usage || !provider || !model || !session) continue;
+      events.push({
+        tool: 'pi',
+        provider,
+        model,
+        timestamp: line.timestamp,
+        sessionId: session.id,
+        projectPath: session.cwd,
+        tokens: {
+          input: usage.input ?? 0,
+          output: usage.output ?? 0,
+          cacheRead: usage.cacheRead ?? 0,
+          cacheWrite: usage.cacheWrite ?? 0,
+        },
+        costUSD: usage.cost?.total,
+      });
+    }
+  }
+  return events;
+}

--- a/src/report/parsers/types.ts
+++ b/src/report/parsers/types.ts
@@ -1,0 +1,20 @@
+// VENDORED VERBATIM from tokenmaxing/src/parsers/types.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import type { ToolId, ProviderId } from '../types.ts';
+
+// Unified intermediate emitted by every parser; aggregate.ts consumes these.
+export interface UsageEvent {
+  tool: ToolId;
+  provider: ProviderId;
+  model: string; // raw model id from log
+  modelLabel?: string; // optional friendly label
+  timestamp: string; // ISO UTC
+  sessionId: string; // unique within the tool
+  projectPath?: string; // raw cwd if known
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  costUSD?: number; // only set when source pre-computes (Pi); otherwise computed downstream
+}

--- a/src/report/parsers/util.ts
+++ b/src/report/parsers/util.ts
@@ -1,0 +1,85 @@
+// VENDORED VERBATIM from tokenmaxing/src/parsers/util.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function* walkJsonl(root: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkJsonl(full);
+    } else if (entry.isFile() && full.endsWith('.jsonl')) {
+      yield full;
+    }
+  }
+}
+
+export async function* readJsonlLines(path: string): AsyncGenerator<unknown> {
+  const file = Bun.file(path);
+  const text = await file.text();
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      yield JSON.parse(line);
+    } catch {
+      // skip malformed line
+    }
+  }
+}
+
+const dateFmtCache = new Map<string, Intl.DateTimeFormat>();
+const hourFmtCache = new Map<string, Intl.DateTimeFormat>();
+
+function dateFmt(tz: string) {
+  let f = dateFmtCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    dateFmtCache.set(tz, f);
+  }
+  return f;
+}
+
+function hourFmt(tz: string) {
+  let f = hourFmtCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hour: '2-digit',
+      hour12: false,
+    });
+    hourFmtCache.set(tz, f);
+  }
+  return f;
+}
+
+export function localDate(isoUtc: string, tz: string): string {
+  return dateFmt(tz).format(new Date(isoUtc));
+}
+
+export function localHour(isoUtc: string, tz: string): number {
+  const parts = hourFmt(tz).formatToParts(new Date(isoUtc));
+  const h = parts.find((p) => p.type === 'hour')?.value ?? '0';
+  return Number(h) % 24;
+}
+
+// ISO-style week ending on Sunday in the given tz
+export function weekEnding(localYmd: string): string {
+  const [y, m, d] = localYmd.split('-').map(Number);
+  const date = new Date(Date.UTC(y!, m! - 1, d!));
+  const dow = date.getUTCDay();
+  const daysToSunday = (7 - dow) % 7;
+  date.setUTCDate(date.getUTCDate() + daysToSunday);
+  return date.toISOString().slice(0, 10);
+}

--- a/src/report/period.test.ts
+++ b/src/report/period.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'bun:test';
+import { resolvePeriod } from './period.ts';
+
+const TODAY = '2026-06-15';
+
+describe('resolvePeriod', () => {
+  test('today', () => {
+    expect(resolvePeriod('today', undefined, TODAY)).toEqual({ from: '2026-06-15', to: '2026-06-15' });
+  });
+
+  test('this-month → first of month through today', () => {
+    expect(resolvePeriod('this-month', undefined, TODAY)).toEqual({ from: '2026-06-01', to: '2026-06-15' });
+  });
+
+  test('last-month → full previous calendar month', () => {
+    expect(resolvePeriod('last-month', undefined, TODAY)).toEqual({ from: '2026-05-01', to: '2026-05-31' });
+  });
+
+  test('last-month handles January → previous December', () => {
+    expect(resolvePeriod('last-month', undefined, '2026-01-10')).toEqual({ from: '2025-12-01', to: '2025-12-31' });
+  });
+
+  test('this-year → Jan 1 through today', () => {
+    expect(resolvePeriod('this-year', undefined, TODAY)).toEqual({ from: '2026-01-01', to: '2026-06-15' });
+  });
+
+  test('month YYYY-MM → that whole month (non-leap Feb)', () => {
+    expect(resolvePeriod('month', '2026-02', TODAY)).toEqual({ from: '2026-02-01', to: '2026-02-28' });
+  });
+
+  test('this-week → ends today, starts on a Monday within the last 7 days', () => {
+    const wk = resolvePeriod('this-week', undefined, TODAY);
+    expect(wk.to).toBe(TODAY);
+    expect(new Date(wk.from + 'T00:00:00Z').getUTCDay()).toBe(1); // Monday
+    expect(wk.from <= wk.to).toBe(true);
+  });
+
+  test('month requires YYYY-MM', () => {
+    expect(() => resolvePeriod('month', 'nope', TODAY)).toThrow();
+    expect(() => resolvePeriod('month', undefined, TODAY)).toThrow();
+  });
+});

--- a/src/report/period.ts
+++ b/src/report/period.ts
@@ -1,0 +1,62 @@
+// Resolve named period presets to an inclusive { from, to } local-date range.
+// All math is done on YYYY-MM-DD strings via UTC date arithmetic (no local-TZ
+// drift), consistent with the rest of the report's day bucketing.
+
+export type PeriodPreset = 'today' | 'this-week' | 'this-month' | 'last-month' | 'this-year' | 'month';
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function fmt(y: number, m: number, d: number): string {
+  return `${y}-${pad(m)}-${pad(d)}`;
+}
+
+// Last calendar day of 1-based month `m` in year `y`.
+function lastDayOfMonth(y: number, m: number): number {
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+export function resolvePeriod(
+  preset: PeriodPreset,
+  month: string | undefined,
+  today: string,
+): { from: string; to: string } {
+  const [ty, tm, td] = today.split('-').map(Number);
+  const y = ty!;
+  const m = tm!;
+  const d = td!;
+
+  switch (preset) {
+    case 'today':
+      return { from: today, to: today };
+
+    case 'this-week': {
+      // Weeks run Monday→Sunday (the report's weeks end on Sunday).
+      const dt = new Date(Date.UTC(y, m - 1, d));
+      const back = (dt.getUTCDay() + 6) % 7; // days since Monday
+      dt.setUTCDate(dt.getUTCDate() - back);
+      return { from: dt.toISOString().slice(0, 10), to: today };
+    }
+
+    case 'this-month':
+      return { from: fmt(y, m, 1), to: today };
+
+    case 'last-month': {
+      const ly = m === 1 ? y - 1 : y;
+      const lm = m === 1 ? 12 : m - 1;
+      return { from: fmt(ly, lm, 1), to: fmt(ly, lm, lastDayOfMonth(ly, lm)) };
+    }
+
+    case 'this-year':
+      return { from: fmt(y, 1, 1), to: today };
+
+    case 'month': {
+      if (!month || !/^\d{4}-\d{2}$/.test(month)) {
+        throw new Error('--month requires a YYYY-MM value');
+      }
+      const [my, mm] = month.split('-').map(Number);
+      return { from: fmt(my!, mm!, 1), to: fmt(my!, mm!, lastDayOfMonth(my!, mm!)) };
+    }
+  }
+}

--- a/src/report/pricing.ts
+++ b/src/report/pricing.ts
@@ -1,0 +1,46 @@
+// VENDORED VERBATIM from tokenmaxing/src/pricing.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+export interface ModelPricing {
+  inputUSDPer1M: number;
+  outputUSDPer1M: number;
+  cacheReadUSDPer1M?: number;
+  cacheWriteUSDPer1M?: number;
+}
+
+export interface UsageCounts {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+// Verify these against published prices on first publish.
+// Update when new models ship; old entries can stay for historical accuracy.
+export const PRICING: Record<string, ModelPricing> = {
+  // Anthropic — Claude
+  'claude-opus-4-7': { inputUSDPer1M: 15, outputUSDPer1M: 75, cacheReadUSDPer1M: 1.5, cacheWriteUSDPer1M: 18.75 },
+  'claude-opus-4-6': { inputUSDPer1M: 15, outputUSDPer1M: 75, cacheReadUSDPer1M: 1.5, cacheWriteUSDPer1M: 18.75 },
+  'claude-sonnet-4-6': { inputUSDPer1M: 3, outputUSDPer1M: 15, cacheReadUSDPer1M: 0.3, cacheWriteUSDPer1M: 3.75 },
+  'claude-haiku-4-5': { inputUSDPer1M: 1, outputUSDPer1M: 5, cacheReadUSDPer1M: 0.1, cacheWriteUSDPer1M: 1.25 },
+
+  // OpenAI — Codex (GPT-5 family; verify before first publish)
+  'gpt-5-5-codex': { inputUSDPer1M: 5, outputUSDPer1M: 15 },
+  'gpt-5-codex': { inputUSDPer1M: 5, outputUSDPer1M: 15 },
+
+  // Baseten — open-weight models routed via Pi
+  'moonshotai/Kimi-K2.5': { inputUSDPer1M: 0.5, outputUSDPer1M: 2.0 },
+};
+
+export function getPricing(modelId: string): ModelPricing | undefined {
+  return PRICING[modelId];
+}
+
+export function computeCost(modelId: string, usage: UsageCounts): number {
+  const p = PRICING[modelId];
+  if (!p) return 0;
+  return (
+    (usage.input * p.inputUSDPer1M) / 1_000_000 +
+    (usage.output * p.outputUSDPer1M) / 1_000_000 +
+    (usage.cacheRead * (p.cacheReadUSDPer1M ?? 0)) / 1_000_000 +
+    (usage.cacheWrite * (p.cacheWriteUSDPer1M ?? 0)) / 1_000_000
+  );
+}

--- a/src/report/project.ts
+++ b/src/report/project.ts
@@ -1,0 +1,14 @@
+// VENDORED VERBATIM from tokenmaxing/src/project.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+import { basename } from 'node:path';
+
+// Match /<anything>/Developer/<repo>(/...) -> <repo>.
+// Falls back to basename(path) for paths outside ~/Developer or for empty input.
+const DEV_RE = /^\/[^/]+\/[^/]+\/Developer\/([^/]+)/;
+
+export function resolveProject(cwd: string | undefined): string {
+  if (!cwd) return 'unknown';
+  const m = DEV_RE.exec(cwd);
+  if (m && m[1]) return m[1];
+  const b = basename(cwd);
+  return b || 'unknown';
+}

--- a/src/report/schema.test.ts
+++ b/src/report/schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'bun:test';
+import { aggregate } from './aggregate.ts';
+import { toUsageReport } from './schema.ts';
+import type { UsageEvent } from './parsers/types.ts';
+
+const events: UsageEvent[] = [
+  {
+    tool: 'claude-code',
+    provider: 'anthropic',
+    model: 'claude-opus-4-6',
+    timestamp: '2026-06-01T14:30:00Z',
+    sessionId: 's1',
+    projectPath: '/Users/x/Developer/sessions',
+    tokens: { input: 1000, output: 500, cacheRead: 10000, cacheWrite: 200 },
+  },
+];
+const report = toUsageReport(
+  aggregate({ events, prs: [], now: '2026-06-06T00:00:00Z', tz: 'UTC', exclude: new Set<string>(), priorDaily: [] }),
+);
+
+describe('UsageReport contract', () => {
+  test('owns its schema (generator + version, no tokenmaxing fields)', () => {
+    expect(report.generator).toBe('sessions');
+    expect(report.version).toBe(1);
+    expect(report).not.toHaveProperty('weeklyHighlights');
+    expect(report).not.toHaveProperty('schemaVersion');
+  });
+
+  test('has every top-level key', () => {
+    for (const key of [
+      'generator',
+      'version',
+      'generatedAt',
+      'period',
+      'summary',
+      'byTool',
+      'byProvider',
+      'byModel',
+      'byProject',
+      'daily',
+      'insights',
+    ]) {
+      expect(report).toHaveProperty(key);
+    }
+  });
+
+  test('insights shape; weekly entries carry no PR fields', () => {
+    expect(report.insights.hourCounts.length).toBe(24);
+    expect(report.insights.weekdayCounts.length).toBe(7);
+    expect(report.insights.weekly.length).toBeGreaterThan(0);
+    const wk = report.insights.weekly[0]!;
+    expect(wk).not.toHaveProperty('prsMerged');
+    expect(wk).not.toHaveProperty('additions');
+    expect(wk).not.toHaveProperty('deletions');
+    expect(wk).toHaveProperty('tokens');
+  });
+});

--- a/src/report/schema.ts
+++ b/src/report/schema.ts
@@ -1,0 +1,87 @@
+// Sessions-owned usage report schema — the public contract for `sessions report`.
+// Independent of tokenmaxing's gist shape: no weeklyHighlights, no PR fields.
+// The internal aggregation (vendored from tokenmaxing) is mapped down to this
+// via `toUsageReport`. Generic breakdown/daily shapes are reused from the
+// aggregation types since they carry no tokenmaxing-specific concerns.
+import type {
+  TokenmaxingData,
+  ToolBreakdown,
+  ProviderBreakdown,
+  ModelBreakdown,
+  ProjectBreakdown,
+  DailyEntry,
+  ModelRef,
+  ToolId,
+} from './types.ts';
+
+export type { ToolBreakdown, ProviderBreakdown, ModelBreakdown, ProjectBreakdown, DailyEntry, ModelRef, ToolId };
+
+export interface UsageSummary {
+  totalCostUSD: number;
+  totalTokens: number;
+  sessions: number;
+  messages: number;
+  activeDays: number;
+  currentStreakDays: number;
+  longestStreakDays: number;
+  peakHourLocal: number;
+  favoriteModel: ModelRef;
+}
+
+export interface UsageWeek {
+  weekEnding: string; // YYYY-MM-DD local Sunday
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  messages: number;
+  byTool: Partial<Record<ToolId, { tokens: number; costUSD: number }>>;
+}
+
+export interface UsageInsights {
+  weekly: UsageWeek[]; // dense: every week from first→last active week
+  hourCounts: number[]; // length 24, by local hour
+  weekdayCounts: number[]; // length 7, 0 = Sunday
+}
+
+export interface UsageReport {
+  generator: 'sessions';
+  version: 1;
+  generatedAt: string; // ISO UTC
+  period: { from: string; to: string };
+  summary: UsageSummary;
+  byTool: ToolBreakdown[];
+  byProvider: ProviderBreakdown[];
+  byModel: ModelBreakdown[];
+  byProject: ProjectBreakdown[];
+  daily: DailyEntry[];
+  insights: UsageInsights;
+}
+
+// Map the internal aggregation result to the sessions-owned public schema,
+// dropping tokenmaxing/website-specific fields (weeklyHighlights + per-week PR counts).
+export function toUsageReport(data: TokenmaxingData): UsageReport {
+  return {
+    generator: 'sessions',
+    version: 1,
+    generatedAt: data.generatedAt,
+    period: data.period,
+    summary: data.summary,
+    byTool: data.byTool,
+    byProvider: data.byProvider,
+    byModel: data.byModel,
+    byProject: data.byProject,
+    daily: data.daily,
+    insights: {
+      weekly: data.insights.weekly.map((w) => ({
+        weekEnding: w.weekEnding,
+        tokens: w.tokens,
+        costUSD: w.costUSD,
+        sessions: w.sessions,
+        messages: w.messages,
+        byTool: w.byTool,
+      })),
+      hourCounts: data.insights.hourCounts,
+      weekdayCounts: data.insights.weekdayCounts,
+    },
+  };
+}

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -1,0 +1,145 @@
+// VENDORED VERBATIM from tokenmaxing/src/types.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+// Types match the public data contract in
+// nicknisi.com/docs/superpowers/specs/2026-04-28-tokenmaxing-design.md §4
+
+export type ToolId = 'claude-code' | 'pi' | 'codex';
+export type KnownProviderId = 'anthropic' | 'openai' | 'baseten';
+export type ProviderId = KnownProviderId | (string & {});
+
+export interface ModelRef {
+  tool: ToolId;
+  provider: ProviderId;
+  id: string;
+  label: string;
+}
+
+export interface ToolBreakdown {
+  id: ToolId;
+  label: string;
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  messages: number;
+}
+
+export interface ProviderBreakdown {
+  id: ProviderId;
+  label: string;
+  tokens: number;
+  costUSD: number;
+}
+
+export interface ModelBreakdown extends ModelRef {
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  messages: number;
+}
+
+export interface ProjectBreakdown {
+  label: string;
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+}
+
+export interface ToolDailySlot {
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  messages: number;
+}
+
+export interface ProviderDailySlot {
+  tokens: number;
+  costUSD: number;
+}
+
+export interface ModelDailySlot {
+  tool: ToolId;
+  provider: ProviderId;
+  id: string;
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  messages: number;
+}
+
+export interface ProjectDailySlot {
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+}
+
+export interface DailyEntry {
+  date: string; // YYYY-MM-DD local
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  messages: number;
+  hourCounts: number[]; // length 24, message counts by local hour
+  byTool: Partial<Record<ToolId, ToolDailySlot>>;
+  byProvider: Record<string, ProviderDailySlot>;
+  byModel: ModelDailySlot[];
+  byProject: Record<string, ProjectDailySlot>;
+}
+
+export interface PullRequest {
+  url: string;
+  repo: string;
+  number: number;
+  title: string;
+  state: 'open' | 'merged' | 'closed';
+  additions: number;
+  deletions: number;
+  createdAt: string; // ISO UTC
+  mergedAt: string | null;
+}
+
+export interface WeeklyHighlight {
+  weekEnding: string; // YYYY-MM-DD local Sunday
+  pullRequests: PullRequest[];
+  summary: string | null;
+}
+
+export interface InsightsWeek {
+  weekEnding: string; // YYYY-MM-DD local Sunday — same keys as WeeklyHighlight
+  tokens: number;
+  costUSD: number;
+  sessions: number; // sum-of-daily approximation (cross-midnight counted twice)
+  messages: number;
+  byTool: Partial<Record<ToolId, { tokens: number; costUSD: number }>>;
+  prsMerged: number; // PRs whose mergedAt falls in this week
+  additions: number; // summed over those merged PRs
+  deletions: number;
+}
+
+export interface Insights {
+  weekly: InsightsWeek[]; // dense: every week from first→last active week, zero-filled
+  hourCounts: number[]; // length 24, message counts by local hour
+  weekdayCounts: number[]; // length 7, message counts by local weekday, 0 = Sunday
+}
+
+export interface TokenmaxingData {
+  schemaVersion: 2;
+  generatedAt: string; // ISO UTC
+  period: { from: string; to: string };
+  summary: {
+    totalCostUSD: number;
+    totalTokens: number;
+    sessions: number;
+    messages: number;
+    activeDays: number;
+    currentStreakDays: number;
+    longestStreakDays: number;
+    peakHourLocal: number;
+    favoriteModel: ModelRef;
+  };
+  byTool: ToolBreakdown[];
+  byProvider: ProviderBreakdown[];
+  byModel: ModelBreakdown[];
+  byProject: ProjectBreakdown[];
+  daily: DailyEntry[];
+  weeklyHighlights: WeeklyHighlight[];
+  insights: Insights;
+}


### PR DESCRIPTION
## Summary

Adds a `sessions report` command that does a fresh per-message pass over local `~/.claude`, `~/.pi`, `~/.codex` logs and emits:

- a **sessions-owned `UsageReport` JSON** (`{ "generator": "sessions", "version": 1, … }`) — summary, per-tool/provider/model/project breakdowns, daily series, and activity insights (weekly trend, hour & weekday histograms), and
- a **self-contained HTML dashboard** (inline SVG charts, delegated-tooltip JS, light/dark, zero external assets — works offline and survives the compiled single-binary).

Aggregation logic is **vendored verbatim** from tokenmaxing (`src/report/` mirrors its `src/` layout) and mapped down to the public `UsageReport` via `toUsageReport()`, so the proven token/cost math is reused while the public schema stays sessions-owned (no `weeklyHighlights`/PR fields). Feeding tokenmaxing from this JSON is intentionally left as a separate adapter job.

### Time period
- Range flags `--from`/`--to`/`--days`, plus convenience presets `--today`, `--this-week`, `--this-month`, `--last-month`, `--this-year`, and `--month YYYY-MM`.
- The report's `period` reflects the **requested window** (not "always to today"), shown as a prominent header badge in the HTML.

### Notable
- **Pi parser fix:** current Pi logs nest `provider`/`model`/`usage` under `message`; the vendored parser now reads the nested location with a top-level fallback. On real data this recovers ~3,380 Pi events / ~$279 that were previously dropped silently. (The same fix is committed in the tokenmaxing repo.)
- All three tools verified against real logs (Claude, Codex, Pi).
- Zero new runtime dependencies.

### CLI
```
sessions report [--format json|html|both] [--out <path>]
                [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--days N]
                [--today | --this-week | --this-month | --last-month | --this-year | --month YYYY-MM]
                [--tool claude|codex|pi] [--tz <IANA>] [--stdout]
```

### Commits
1. `chore(report)`: vendor tokenmaxing parse/price/aggregate (incl. Pi nested-format fix)
2. `feat(report)`: the `sessions report` command — `UsageReport` schema, HTML renderer, orchestrator, CLI wiring, tests
3. `docs(report)`: document the command in the README
4. `chore`: gitignore the default report output artifacts
5. `feat(report)`: period presets + prominent period badge
6. `docs(report)`: document period presets and the period badge

### Docs
README has a **Usage reports** section (command, full flags table incl. presets, output description, period note), an options-table row, and usage examples.

## Test Plan
- [x] `bun test` — 53 pass (extractor, aggregation anchor, HTML smoke, orchestrator, `UsageReport` contract, period presets, period-reflects-range)
- [x] `bun run typecheck` clean for new code; `oxlint` 0 errors; `oxfmt --check` clean
- [x] `sessions report --format both --out /tmp/r --tz UTC` → writes `usage-report.json` + `report.html`; dashboard opened in a browser
- [x] Presets verified on real logs: `--this-month` → `2026-06-01 → today`; `--month 2026-05` badge reads `May 1, 2026 → May 31, 2026`
- [x] Claude / Codex / Pi all produce data on real logs
- [ ] Reviewer: eyeball the HTML dashboard and confirm the JSON shape fits your downstream use