### PR TITLE
feat(report): open HTML dashboard from a temp dir by default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -47,6 +47,10 @@ if (Bun.argv.includes('report')) {
     if (res.jsonPath) process.stderr.write(`wrote ${res.jsonPath}\n`);
     if (res.htmlPath) process.stderr.write(`wrote ${res.htmlPath}\n`);
   }
+  if (res.htmlPath && !opts.out && !opts.stdout) {
+    const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    Bun.spawnSync([opener, res.htmlPath]);
+  }
   process.exit(0);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,8 +22,10 @@ ${C.bold}Options:${C.reset}
   -h, --help       Show this help
 
 ${C.bold}Commands:${C.reset}
-  report           Generate a usage report (JSON for tokenmaxing + HTML dashboard)
-                   Accepts --here to scope the report to the current project
+  report           Generate a usage report (HTML dashboard, opens in browser)
+                   --out <path> saves instead of opening; --format json|html|both
+                   (default html); --stdout prints JSON; --here scopes to the
+                   current project; --from/--to/--days/--month limit the period
   setup            Install plugin and configure MCP for detected tools
   uninstall        Remove plugin and MCP config from all tools
   cleanup          Uninstall plugin + clear search index (full reset)

--- a/src/report/index.test.ts
+++ b/src/report/index.test.ts
@@ -51,8 +51,9 @@ const hereRoots = { claudeCode: hereClaudeDir, pi: join(tmp, 'no-pi'), codex: jo
 describe('parseReportArgs', () => {
   test('defaults', () => {
     const o = parseReportArgs([]);
-    expect(o.format).toBe('both');
+    expect(o.format).toBe('html');
     expect(o.stdout).toBe(false);
+    expect(o.out).toBeUndefined();
   });
   test('parses flags', () => {
     const o = parseReportArgs(['--format', 'json', '--days', '7', '--tool', 'claude', '--tz', 'UTC', '--stdout']);
@@ -78,6 +79,35 @@ describe('parseReportArgs', () => {
 });
 
 describe('runReport', () => {
+  test('without --out, writes html to a fresh temp dir', async () => {
+    const res = await runReport({
+      format: 'html',
+      tz: 'UTC',
+      stdout: false,
+      roots,
+      now: '2026-06-06T00:00:00Z',
+    });
+    expect(res.jsonPath).toBeUndefined();
+    expect(res.htmlPath).toContain('sessions-report-');
+    expect(res.htmlPath!.endsWith('report.html')).toBe(true);
+    expect(readFileSync(res.htmlPath!, 'utf8').startsWith('<!DOCTYPE html>')).toBe(true);
+    rmSync(join(res.htmlPath!, '..'), { recursive: true, force: true });
+  });
+
+  test('without --out, format both puts both files in the same temp dir', async () => {
+    const res = await runReport({
+      format: 'both',
+      tz: 'UTC',
+      stdout: false,
+      roots,
+      now: '2026-06-06T00:00:00Z',
+    });
+    expect(res.jsonPath).toContain('sessions-report-');
+    expect(join(res.jsonPath!, '..')).toBe(join(res.htmlPath!, '..'));
+    expect(existsSync(res.jsonPath!)).toBe(true);
+    rmSync(join(res.jsonPath!, '..'), { recursive: true, force: true });
+  });
+
   test('writes both json and html to the out dir', async () => {
     const outDir = join(tmp, 'out');
     mkdirSync(outDir, { recursive: true });

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -1,4 +1,5 @@
-import { writeFile } from 'node:fs/promises';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ToolId } from './types.ts';
 import { gatherEvents, defaultRoots, type ReportRoots } from './extract.ts';
@@ -43,7 +44,7 @@ function die(msg: string): never {
 
 export function parseReportArgs(argv: string[]): ReportOptions {
   const opts: ReportOptions = {
-    format: 'both',
+    format: 'html',
     tz: process.env['TIMEZONE'] ?? 'America/Chicago',
     stdout: false,
   };
@@ -156,17 +157,21 @@ export async function runReport(opts: ReportOptions): Promise<ReportResult> {
   const wantJson = opts.format === 'json' || opts.format === 'both';
   const wantHtml = opts.format === 'html' || opts.format === 'both';
 
+  // With no --out, files land in a fresh temp dir (the CLI opens the HTML from there).
+  const needsFile = wantHtml || (wantJson && !opts.stdout);
+  const outBase = opts.out ?? (needsFile ? await mkdtemp(join(tmpdir(), 'sessions-report-')) : undefined);
+
   if (opts.stdout) {
     process.stdout.write(json + '\n');
   } else if (wantJson) {
-    const p = opts.format === 'both' ? join(opts.out ?? '.', 'usage-report.json') : (opts.out ?? './usage-report.json');
+    const p = opts.format === 'both' || !opts.out ? join(outBase!, 'usage-report.json') : opts.out;
     await writeFile(p, json, 'utf8');
     result.jsonPath = p;
   }
 
   if (wantHtml) {
     const html = renderHtml(report);
-    const p = opts.format === 'both' ? join(opts.out ?? '.', 'report.html') : (opts.out ?? './report.html');
+    const p = opts.format === 'both' || !opts.out ? join(outBase!, 'report.html') : opts.out;
     await writeFile(p, html, 'utf8');
     result.htmlPath = p;
   }


### PR DESCRIPTION
## Summary
- `sessions report` now defaults to `--format html`, writes to a fresh temp dir (`$TMPDIR/sessions-report-*`), and opens the dashboard in the browser immediately
- `--out <path>` saves to the given location instead and does **not** auto-open
- JSON is no longer written by default — opt in with `--format json|both` or `--stdout`
- Help text now documents the report flags (`--out`, `--format`, `--stdout`, `--from/--to/--days/--month`, `--here`)

## Breaking change
Anything relying on `sessions report` dropping `usage-report.json` / `report.html` in the cwd needs `--format json --out <path>` or `--stdout` now.

## Test plan
- [x] `bun test` — 59 pass, including 2 new tests covering temp-dir output
- [x] Manual: default run opens browser from temp dir; `--out` saves without opening; `--stdout` emits valid JSON