### PR TITLE
feat(search): rank by relevance, add stemming, OR recall, and index assistant text

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ The `get_activity_digest` tool supports a `detail` parameter: `"compact"` (defau
 
 The MCP server maintains a SQLite + FTS5 index at `~/.cache/sessions/index.db` for fast full-text search across all sessions. The index is built automatically on first use (~5s for thousands of sessions) and updated incrementally on subsequent calls by checking file modification times — only new or changed sessions are re-indexed.
 
+Search covers both your messages and the assistant's replies, uses porter stemming (so `refactor` matches `refactoring`), and ranks results by relevance (BM25) rather than recency. A multi-word query matches sessions containing _any_ of the terms, with the closest matches ranked first — so natural-language queries degrade gracefully instead of requiring every word to be present.
+
 To clear the index and force a full rebuild:
 
 ```sh

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -48,10 +48,12 @@ const CLAUDE_DIR = process.env.SESSIONS_CLAUDE_DIR || join(home, '.claude/projec
 const PI_DIR = process.env.SESSIONS_PI_DIR || join(home, '.pi/agent/sessions');
 const CODEX_DIR = process.env.SESSIONS_CODEX_DIR || join(home, '.codex/sessions');
 
-// Bump 3 -> 4: adds the `branch` column and recomputes intent / closing_user /
-// closing_assistant from genuine turns. The getDb path drops + rebuilds tables on
-// a user_version mismatch, so this triggers a one-time destructive reindex.
-const SCHEMA_VERSION = 4;
+// Bump 4 -> 5: the FTS index gains an `assistant_content` column and a porter
+// stemming tokenizer, and search now ranks by bm25 relevance instead of recency.
+// The new column + tokenizer change the virtual table shape, so the getDb path
+// drops + rebuilds tables on a user_version mismatch — a one-time destructive
+// reindex that re-extracts assistant text from every session.
+const SCHEMA_VERSION = 5;
 let _db: Database | null = null;
 
 export function clearCache(): void {
@@ -99,10 +101,16 @@ function getDb(): Database {
       branch TEXT NOT NULL DEFAULT ''
     )
   `);
+  // `user_content` and `assistant_content` are separate columns so search can rank
+  // and snippet each independently (a match in the model's own diagnosis is just as
+  // findable as one in the prompt). `porter unicode61` adds stemming on top of the
+  // default unicode tokenizer so e.g. "refactoring" matches an indexed "refactor".
   db.run(`
     CREATE VIRTUAL TABLE IF NOT EXISTS session_fts USING fts5(
       file_path UNINDEXED,
-      user_content
+      user_content,
+      assistant_content,
+      tokenize = 'porter unicode61'
     )
   `);
   _db = db;
@@ -222,6 +230,10 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
     .filter((m) => m.role === 'user')
     .map((m) => m.text)
     .join('\n');
+  const assistantContent = messages
+    .filter((m) => m.role === 'assistant')
+    .map((m) => m.text)
+    .join('\n');
 
   const subagentContent = tool === 'claude' ? collectSubagentContent(filePath) : '';
   const fullContent = subagentContent ? userContent + '\n' + subagentContent : userContent;
@@ -254,7 +266,11 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
       branch,
     ],
   );
-  db.run('INSERT INTO session_fts (file_path, user_content) VALUES (?, ?)', [filePath, fullContent]);
+  db.run('INSERT INTO session_fts (file_path, user_content, assistant_content) VALUES (?, ?, ?)', [
+    filePath,
+    fullContent,
+    assistantContent,
+  ]);
   return true;
 }
 
@@ -313,12 +329,20 @@ export async function searchSessions(
 
   let rows: SessionRow[];
 
-  if (query) {
-    const ftsQuery = query
-      .replace(/['"]/g, '')
-      .split(/\s+/)
-      .map((w) => `"${w}"`)
-      .join(' ');
+  // Split the free-text query into individual quoted terms joined with OR. OR recall
+  // (any term may match) paired with bm25() ranking surfaces the sessions matching the
+  // most — and rarest — terms first, instead of the old strict-AND that returned
+  // nothing unless every word was present. This matters most for the LLM/MCP caller,
+  // which issues long natural-language queries. Quoting each term keeps FTS5 operators
+  // in user input literal. An all-whitespace/quotes query yields no terms → recent list.
+  const ftsTerms = query
+    .replace(/['"]/g, '')
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+    .map((w) => `"${w}"`);
+  const ftsQuery = ftsTerms.join(' OR ');
+
+  if (ftsQuery) {
     const conditions: string[] = [];
     const params: (string | number)[] = [ftsQuery];
 
@@ -339,12 +363,12 @@ export async function searchSessions(
       .query<SessionRow, any[]>(`
       SELECT s.file_path, s.cwd, s.tool, s.session_id, s.date, s.created_at, s.first_prompt,
              s.custom_title, s.message_count,
-             snippet(session_fts, 1, '', '', '…', 32) as snippet
+             snippet(session_fts, -1, '', '', '…', 32) as snippet
       FROM session_fts f
       JOIN sessions s ON s.file_path = f.file_path
       WHERE f.session_fts MATCH ?
       ${extra}
-      ORDER BY s.date DESC
+      ORDER BY bm25(session_fts)
       LIMIT ?
     `)
       .all(...params);

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -220,6 +220,62 @@ describe('empty-state', () => {
   });
 });
 
+describe('searchSessions', () => {
+  test('ranks by bm25 relevance, not recency — the stronger match wins even when older', async () => {
+    const cwd = join(fixtureRoot, 'search-rank');
+    // Older, but matches BOTH query terms (including the rare "plonkish").
+    const strong = writeClaudeSession({
+      cwd,
+      firstPrompt: 'quokkavar plonkish',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    // Newer, but matches only the common term — under the old `ORDER BY date DESC`
+    // this would have come first purely by recency.
+    const weak = writeClaudeSession({ cwd, firstPrompt: 'quokkavar zzfiller', createdAt: '2026-06-20T10:00:00.000Z' });
+
+    const results = await cache.searchSessions('quokkavar plonkish', '', cwd, 20);
+    const ids = results.map((r) => r.sessionId);
+    expect(ids).toContain(strong);
+    expect(ids).toContain(weak);
+    expect(ids[0]).toBe(strong); // relevance beats recency
+  });
+
+  test('OR recall: a multi-word query still matches when only some terms are present', async () => {
+    const cwd = join(fixtureRoot, 'search-or');
+    const id = writeClaudeSession({ cwd, firstPrompt: 'fix the rate limiter on the api' });
+    // Neither "yesterday" nor "afternoon" appears — the old strict-AND returned nothing.
+    const results = await cache.searchSessions('rate limiter yesterday afternoon', '', cwd, 20);
+    expect(results.map((r) => r.sessionId)).toContain(id);
+  });
+
+  test('porter stemming connects inflected forms ("refactor" matches "refactoring")', async () => {
+    const cwd = join(fixtureRoot, 'search-stem');
+    const id = writeClaudeSession({ cwd, firstPrompt: 'refactoring the authentication layer' });
+    const results = await cache.searchSessions('refactor', '', cwd, 20);
+    expect(results.map((r) => r.sessionId)).toContain(id);
+  });
+
+  test('assistant message text is searchable (a term only in the reply is found)', async () => {
+    const cwd = join(fixtureRoot, 'search-asst');
+    const id = writeClaudeSession({
+      cwd,
+      firstPrompt: 'why does the build keep failing',
+      closingAssistant: 'the root cause was a quibblefrotz race in the scheduler',
+    });
+    const results = await cache.searchSessions('quibblefrotz', '', cwd, 20);
+    expect(results.map((r) => r.sessionId)).toContain(id);
+    // and the snippet is drawn from the matching (assistant) column
+    expect(results.find((r) => r.sessionId === id)!.displayText).toContain('quibblefrotz');
+  });
+
+  test('a term that appears nowhere returns no matches', async () => {
+    const cwd = join(fixtureRoot, 'search-empty');
+    writeClaudeSession({ cwd, firstPrompt: 'ordinary session about ordinary things' });
+    const results = await cache.searchSessions('zzztotallyabsentzzz', '', cwd, 20);
+    expect(results).toHaveLength(0);
+  });
+});
+
 const ctx = await import('./context');
 
 describe('cli', () => {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -15,7 +15,12 @@ server.tool(
   'search_sessions',
   'Search across AI coding sessions from Claude Code, Codex, and Pi. Returns matching sessions with snippets.',
   {
-    query: z.string().optional().describe('Text to search for in user messages. Omit to list recent sessions.'),
+    query: z
+      .string()
+      .optional()
+      .describe(
+        'Text to search across session messages (both yours and the assistant replies). Natural-language queries work — results are ranked by relevance and any term may match. Omit to list recent sessions.',
+      ),
     tool: z.enum(['claude', 'codex', 'pi']).optional().describe('Filter to a specific tool'),
     project: z.string().optional().describe('Filter to sessions from this project directory path'),
     limit: z.number().optional().default(20).describe('Max results to return (default 20)'),


### PR DESCRIPTION
The FTS5-backed search_sessions MCP tool was lexical-only and underpowered:
results were ordered by recency rather than relevance, queries required every
term to match (strict AND), there was no stemming, and only user messages were
indexed.

- Rank by bm25() instead of ORDER BY date DESC, so the strongest match surfaces
  first regardless of age.
- Join query terms with OR so natural-language and partial queries still match
  (the LLM/MCP caller issues long NL queries that strict-AND returned nothing
  for); bm25 keeps the closest matches on top.
- Add porter stemming to the FTS tokenizer (refactor <-> refactoring).
- Index assistant message text in a new assistant_content column so the model's
  own diagnoses and summaries are searchable; snippets pick the best-matching
  column via snippet(..., -1, ...).

Bumps the index schema version (4 -> 5) to force a one-time rebuild that
re-extracts assistant text. Adds searchSessions tests covering relevance
ranking, OR recall, stemming, and assistant-text search. The interactive CLI
`sessions <query>` grep path is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HQAbfTi87HPDoKKYBy2ejf