### PR TITLE
feat: add `sessions wrapped` (Spotify-style year in review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,21 @@ The JSON is a sessions-owned `UsageReport` (`{ "generator": "sessions", "version
 
 Cost is estimated from [LiteLLM](https://github.com/BerriAI/litellm) pricing data, fetched at most once per day and cached locally, with an embedded snapshot as the offline fallback — a failed fetch never blocks the report. Pi sessions use the cost recorded in their own logs. Tokens for unknown models are still counted, with cost shown as `$0`. Token totals exclude cache reads (replayed context, mostly free reuse).
 
+## Wrapped
+
+`sessions wrapped` turns your year of AI pairing into a Spotify-Wrapped-style scroll-through story and opens it in your browser: tokens with a human-scale equivalence, the API-rate receipt, streaks, a rhythm heatmap, top projects and models, your most significant session — and a set of fun stats mined from what you and your agents actually said to each other (the interrupt census, the two-sided apology scoreboard, how many times Claude told you "you're absolutely right", your word of the year). It ends with a coding-personality reveal built from three behavioral axes, with the evidence printed on the card.
+
+```sh
+sessions wrapped                     # this year, opens in your browser
+sessions wrapped --year 2025         # a past calendar year
+sessions wrapped --stdout            # the underlying JSON, for piping
+sessions wrapped --extras roast.json # inject extra agent-authored slides
+```
+
+The fun slides are **dynamically selected**: every candidate stat is scored for how notable it is in _your_ data, and only the top ones render — a daylight coder never sees a 3 AM slide. Everything is computed locally (event logs + the search index); nothing leaves your machine. Because AI tools prune old transcripts, the page discloses when its data starts if that's later than January 1. Token and cost math match `sessions report` exactly.
+
+`--extras <path>` accepts a JSON array of up to six slides (`[{"headline": "...", "title"?, "subline"?, "footnote"?}]`) — the hook for having an agent mine your history for bespoke slides and inject them into the story.
+
 ## How it works
 
 ### Session discovery

--- a/README.md
+++ b/README.md
@@ -280,13 +280,18 @@ Cost is estimated from [LiteLLM](https://github.com/BerriAI/litellm) pricing dat
 ```sh
 sessions wrapped                     # this year, opens in your browser
 sessions wrapped --year 2025         # a past calendar year
+sessions wrapped --roast             # let an agent CLI improvise roast slides
 sessions wrapped --stdout            # the underlying JSON, for piping
-sessions wrapped --extras roast.json # inject extra agent-authored slides
+sessions wrapped --extras roast.json # inject your own extra slides
 ```
 
 The fun slides are **dynamically selected**: every candidate stat is scored for how notable it is in _your_ data, and only the top ones render — a daylight coder never sees a 3 AM slide. Everything is computed locally (event logs + the search index); nothing leaves your machine. Because AI tools prune old transcripts, the page discloses when its data starts if that's later than January 1. Token and cost math match `sessions report` exactly.
 
-`--extras <path>` accepts a JSON array of up to six slides (`[{"headline": "...", "title"?, "subline"?, "footnote"?}]`) — the hook for having an agent mine your history for bespoke slides and inject them into the story.
+### Roast mode
+
+`--roast` hands your computed stats to an agent CLI you already have installed (`claude`, then `codex`, then `pi` — override with `--roast-with <tool>`) and asks it to improvise a few edgy, bespoke roast slides, which are appended to the story. It rides your existing subscription — no API key, no setup. Only the **stats** are sent (counts, project names, the numbers already on the page), never raw transcript text, and every roast slide is stamped "improvised by \<tool\>" so a generated line can never pass for a counted one. It's opt-in and fails open: no CLI, a timeout, or unparseable output just drops the roast and the deterministic page renders as normal. Expect it to add 15–90s.
+
+`--extras <path>` is the manual version: a JSON array of up to six slides (`[{"headline": "...", "title"?, "subline"?, "footnote"?}]`) injected into the story. `--roast` is the same seam, filled by a model instead of by hand.
 
 ## How it works
 

--- a/docs/ideation/wrapped/research.md
+++ b/docs/ideation/wrapped/research.md
@@ -1,0 +1,54 @@
+# `sessions wrapped` — research & design notes
+
+_2026-07-13 · deep-research synthesis (5 agents: report-pipeline map, content-layer map, CLI conventions, Spotify Wrapped design research, dev-tool year-in-review precedents) + implementation decisions._
+
+## Why these metrics
+
+Two data sources with different truths, deliberately split:
+
+| Source                                                            | Truth it holds                 | Metrics built on it                                                                                                                               |
+| ----------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Report pipeline `UsageEvent[]` (re-parsed JSONL, full timestamps) | tokens, cost, per-message time | totals, receipt, streaks, rhythm heatmap, nights past midnight, longest **sitting**, biggest day, model adoption dates, cache hit rate            |
+| Search index (`message_fts` + `sessions`)                         | what was actually said         | phrase censuses, monologue asymmetry, drive-bys, abandoned project, session of the year (significanceScore), word of the year, top files/commands |
+
+Key mechanics locked during research (verified live against the real index):
+
+- **Phrase counting uses `LIKE`, never FTS `MATCH`** — porter stemming makes phrase queries fuzzy ("wait" matches "waiting") and `MATCH` counts rows regardless. Counts are messages-containing, which is dispute-proof.
+- **Token math matches `sessions report`** (input + output + cacheWrite; cacheRead excluded) so the two commands never disagree. Cache reads get their own line on the receipt card.
+- **Sessions counted as distinct `tool|sessionId` over raw events** — `aggregate()`'s summary double-counts cross-midnight sessions (sum-of-daily).
+- **Longest sitting, not longest session**: resumed sessions span weeks; events are split into continuous runs (≤ 30 min gaps).
+- **Session of the year uses `significanceScore` alone** (not `blendedScore` — recency decay would bury January).
+- **Depth median excludes drive-bys** (≤ 2 messages): the distribution is bimodal and the raw median lands in the trivia lobe.
+- **Vendored files (`aggregate.ts`, `types.ts`, parsers/util, pi, project) are never edited** — wrapped layers on top of `aggregate()` output plus its own event pass.
+
+## Dynamic fun-slide selection (the personalization mechanism)
+
+Every fun stat is a scored candidate (`select.ts`); saturating notability scores (`1 − e^(−count/mid)`) with per-stat thresholds. Only the top candidates render, grouped into three themed cards (friction reel / relationship / bloopers) — a card drops entirely if its lead stat doesn't clear the bar. Consequences:
+
+- No "0 times" filler slides (the one deliberate exception: the "you're absolutely right" zero-joke).
+- Graceful degradation and personalization are the same mechanism — no index → no fun cards, page still works.
+- Corpus-mined **word of the year**: TF over genuine user prompts, ~700-word stop list (common English + dev-generic), required spread ≥ 8 sessions so one rant can't win.
+- `--extras <json>` injects agent-authored slides (cap 6, shape-validated) — the LLM tier lives outside the binary, which stays offline/deterministic.
+
+## Design rules applied (from the Wrapped research)
+
+Story not dashboard (one stat per full-viewport scroll-snap card, payoffs late, persona as climax) · numerals as artwork (echo layer) · flat text panels over decoration (the 2021→2024 legibility lesson) · limited palette = the report's six OKLCH accents, one per card · self-relative comparisons only, never invented percentiles (the Spotify-2024 trust failure) · hedged copy on disputable stats ("pastes count", "failing greps count") · evidence printed on the persona card (the "Pink Pilates Princess" lesson: never a label the user can't verify) · data-horizon disclosure ("data begins Feb 11 — transcripts pruned") · self-contained HTML, no external requests, textContent-only JS, `prefers-reduced-motion` honored.
+
+Persona recipe (Spotify Listening Personality, adapted): 3 median-split behavioral axes → 8 flattering archetypes. Clock (night share ≥ 25%), Focus (top-project token share ≥ 40%), Depth (median engaged-session turns ≥ 40). Interrupt rate is display-only flavor, not a fourth split.
+
+## Known limitations (reviewed and accepted for v1)
+
+Both surfaced by the adversarial review (fable-5 4-lens workflow + independent gpt-5.5/codex pass) and accepted as indexer-level constraints, not wrapped bugs:
+
+- **Index dates are UTC-sliced** (`created_at`/`date` come from `ts.slice(0,10)`) while event stats bucket in local tz — content stats can disagree with event stats by one day near midnight UTC. Time-of-day is not stored in the index, so wrapped cannot convert. The cursed-weekday footnote discloses UTC attribution. Fix would be a schema bump storing local dates or timestamps.
+- **Forked/resumed Claude transcripts duplicate history in the index** — the report pipeline dedupes usage by `message.id|requestId`, but `message_fts` has no message ids, so a phrase copied into a fork counts once per copy. Phrase-census copy says "messages containing each phrase," which is literally what is counted. Fix would be indexer-level dedup (affects search semantics too — forks are deliberately findable).
+
+Content-stat period semantics: **sessions started within the calendar year** (`created_at` in range) — overlap semantics would import entire prior-December sessions into the new year and were rejected in review.
+
+## Deferred / follow-ups
+
+- **Retention**: transcripts prune (~6 months survive); a December run won't cover January. Option: persist monthly aggregate snapshots. For now the page discloses its horizon.
+- **Share export**: no canvas/9:16 export in v1 — the persona card invites a screenshot instead.
+- **`/wrapped` plugin skill**: could have an agent mine the index via MCP and drive `--extras` automatically. The CLI hook exists.
+- **Tool-call league table** (Bash vs Edit vs Read counts): needs a full JSONL re-parse; the `commands` column proxy was judged enough for v1.
+- Per-tool data asymmetry (Pi: no files/commands; Codex: no files_read, cacheWrite always 0) is footnoted, not normalized.

--- a/docs/ideation/wrapped/research.md
+++ b/docs/ideation/wrapped/research.md
@@ -49,6 +49,6 @@ Content-stat period semantics: **sessions started within the calendar year** (`c
 
 - **Retention**: transcripts prune (~6 months survive); a December run won't cover January. Option: persist monthly aggregate snapshots. For now the page discloses its horizon.
 - **Share export**: no canvas/9:16 export in v1 — the persona card invites a screenshot instead.
-- **`/wrapped` plugin skill**: could have an agent mine the index via MCP and drive `--extras` automatically. The CLI hook exists.
+- **Roast mode (shipped)**: `--roast` sends the stats-only digest to an installed agent CLI (`claude`→`codex`→`pi`, or `--roast-with`), validates the returned slides through the shared `coerceExtras`, and stamps provenance. Opt-in, fails open, rides the user's own auth. Chosen over a `/wrapped` plugin skill (tool-specific, needs install/update) because wrapped's users definitionally have an agent CLI installed. Deeper snippet-level roasting (feeding the model actual message excerpts) deferred — stats-only avoids the latency/cost/hallucination jump and the privacy surface.
 - **Tool-call league table** (Bash vs Edit vs Read counts): needs a full JSONL re-parse; the `commands` column proxy was judged enough for v1.
 - Per-tool data asymmetry (Pi: no files/commands; Codex: no files_read, cacheWrite always 0) is footnoted, not normalized.

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,12 @@ if (Bun.argv.includes('--clear-cache')) {
   process.exit(0);
 }
 
-if (Bun.argv.includes('cleanup')) {
+// Commands dispatch on the positional word only. Matching anywhere in argv
+// (the old behavior) let a flag VALUE fire a command — `sessions wrapped
+// --out cleanup` would have uninstalled the plugin and wiped the index.
+const command = Bun.argv[2];
+
+if (command === 'cleanup') {
   const { clearCache } = await import('./src/cache');
   const { runUninstall } = await import('./src/setup');
   runUninstall();
@@ -28,22 +33,21 @@ if (Bun.argv.includes('--mcp')) {
   await new Promise(() => {});
 }
 
-if (Bun.argv.includes('setup')) {
+if (command === 'setup') {
   const { runSetup } = await import('./src/setup');
   runSetup({ hooks: Bun.argv.includes('--hooks') });
   process.exit(0);
 }
 
-if (Bun.argv.includes('uninstall')) {
+if (command === 'uninstall') {
   const { runUninstall } = await import('./src/setup');
   runUninstall();
   process.exit(0);
 }
 
-if (Bun.argv.includes('report')) {
+if (command === 'report') {
   const { parseReportArgs, runReport } = await import('./src/report/index.ts');
-  const idx = Bun.argv.indexOf('report');
-  const opts = parseReportArgs(Bun.argv.slice(idx + 1));
+  const opts = parseReportArgs(Bun.argv.slice(3));
   const res = await runReport(opts);
   if (!opts.stdout) {
     if (res.jsonPath) process.stderr.write(`wrote ${res.jsonPath}\n`);
@@ -56,17 +60,27 @@ if (Bun.argv.includes('report')) {
   process.exit(0);
 }
 
-if (Bun.argv.includes('context')) {
-  const i = Bun.argv.indexOf('context');
-  const { parseContextArgs, runContext } = await import('./src/context.ts');
-  await runContext(parseContextArgs(Bun.argv.slice(i + 1)));
+if (command === 'wrapped') {
+  const { parseWrappedArgs, runWrapped } = await import('./src/wrapped/index.ts');
+  const opts = parseWrappedArgs(Bun.argv.slice(3));
+  const res = await runWrapped(opts);
+  if (res.htmlPath) process.stderr.write(`wrote ${res.htmlPath}\n`);
+  if (res.htmlPath && !opts.out && !opts.stdout) {
+    const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    Bun.spawnSync([opener, res.htmlPath]);
+  }
   process.exit(0);
 }
 
-if (Bun.argv.includes('digest')) {
-  const i = Bun.argv.indexOf('digest');
+if (command === 'context') {
+  const { parseContextArgs, runContext } = await import('./src/context.ts');
+  await runContext(parseContextArgs(Bun.argv.slice(3)));
+  process.exit(0);
+}
+
+if (command === 'digest') {
   const { parseDigestArgs, runDigest } = await import('./src/digest.ts');
-  await runDigest(parseDigestArgs(Bun.argv.slice(i + 1)));
+  await runDigest(parseDigestArgs(Bun.argv.slice(3)));
   process.exit(0);
 }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -416,6 +416,14 @@ export async function refreshIndex(): Promise<{ total: number; updated: number }
   return { total: files.length, updated };
 }
 
+// Read-only index access for stats consumers (`sessions wrapped`). Refreshes
+// first so queries see current transcripts, then hands back the shared handle.
+// Callers must treat the connection as read-only — all writes stay in this file.
+export async function getIndexDb(): Promise<Database> {
+  await refreshIndex();
+  return getDb();
+}
+
 export interface SearchOptions {
   tool?: Tool | '';
   project?: string;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,9 @@ ${C.bold}Commands:${C.reset}
                    --out <path> saves instead of opening; --format json|html|both
                    (default html); --stdout prints JSON; --here scopes to the
                    current project; --from/--to/--days/--month limit the period
+  wrapped          Your year with AI agents, Spotify-Wrapped style (opens in
+                   browser). --year <YYYY> wraps a past year; --out/--stdout,
+                   --tool, --extras <json> add agent-authored slides
   setup            Install plugin and configure MCP for detected tools
                    --hooks opts in to SessionStart auto-injection (off by
                    default); without it, an interactive prompt asks when on a TTY

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -194,7 +194,9 @@ export async function runReport(opts: ReportOptions): Promise<ReportResult> {
   const outBase = opts.out ?? (needsFile ? await mkdtemp(join(tmpdir(), 'sessions-report-')) : undefined);
 
   if (opts.stdout) {
-    process.stdout.write(json + '\n');
+    // Bun.write awaits the flush; process.stdout.write + the caller's
+    // process.exit(0) truncates piped output at the 64KB pipe buffer.
+    await Bun.write(Bun.stdout, json + '\n');
   } else if (wantJson) {
     const p = opts.format === 'both' || !opts.out ? join(outBase!, 'usage-report.json') : opts.out;
     await writeFile(p, json, 'utf8');

--- a/src/report/pricing.ts
+++ b/src/report/pricing.ts
@@ -287,10 +287,19 @@ function tiered(tokens: number, base: number, above?: number): number {
 // ---------------------------------------------------------------------------
 let warnings: PricingWarning[] = [];
 
+// computeCost pushes one entry per unpriced EVENT; consumers want one line per
+// model. Merge here (summing tokens, first-seen order) so stderr never reads
+// "67 model(s) had no pricing" followed by the same two ids 67 times.
 export function drainPricingWarnings(): PricingWarning[] {
-  const out = warnings;
+  const raw = warnings;
   warnings = [];
-  return out;
+  const byModel = new Map<string, PricingWarning>();
+  for (const w of raw) {
+    const cur = byModel.get(w.model);
+    if (cur) cur.tokens += w.tokens;
+    else byModel.set(w.model, { ...w });
+  }
+  return [...byModel.values()];
 }
 
 export function resetPricingWarnings(): void {

--- a/src/wrapped/compute.ts
+++ b/src/wrapped/compute.ts
@@ -1,0 +1,230 @@
+// Event-pass aggregations for wrapped — everything aggregate() doesn't compute
+// but raw UsageEvent timestamps make possible: session durations, small-hours
+// census, the weekday×hour heatmap, model adoption dates, and cache efficiency.
+// Pure and deterministic; tz-sensitive bucketing goes through the same
+// localDate/localHour helpers as the report so the two always reconcile.
+
+import type { UsageEvent } from '../report/parsers/types.ts';
+import { localDate, localHour } from '../report/parsers/util.ts';
+import { resolveProject } from '../report/project.ts';
+import type { WrappedLongestSession, WrappedRhythm } from './types.ts';
+
+export interface ModelFirsts {
+  firstSeen: string;
+  firstTopDay: string | null;
+}
+
+export interface WrappedEventStats {
+  distinctSessions: number;
+  rhythm: WrappedRhythm;
+  cacheReadTokens: number;
+  /** cacheRead / (input + cacheRead), or null when nothing was cacheable. */
+  cacheHitRate: number | null;
+  longestSession: WrappedLongestSession | null;
+  /** Median assistant replies per session — persona depth fallback when no index. */
+  medianReplies: number;
+  /** Distinct sessions per tool / resolved project — aggregate's per-day sums
+   *  double-count cross-midnight sessions, so wrapped never uses them. */
+  sessionsByTool: Map<string, number>;
+  sessionsByProject: Map<string, number>;
+  modelFirsts: Map<string, ModelFirsts>;
+  /** Share of messages in local hours 22-23 and 0-5, 0-1. */
+  nightShare: number;
+}
+
+/** Weekday (0=Sun) of a local YYYY-MM-DD without tz drift. */
+export function weekdayOf(ymd: string): number {
+  const [y, m, d] = ymd.split('-').map(Number);
+  return new Date(Date.UTC(y!, m! - 1, d!)).getUTCDay();
+}
+
+const clockFmtCache = new Map<string, Intl.DateTimeFormat>();
+function clockFmt(tz: string): Intl.DateTimeFormat {
+  let f = clockFmtCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit', hour12: true });
+    clockFmtCache.set(tz, f);
+  }
+  return f;
+}
+
+function localClock(isoUtc: string, tz: string): string {
+  return clockFmt(tz).format(new Date(isoUtc)).replace(/\s/g, ' ');
+}
+
+function localMinute(isoUtc: string, tz: string): number {
+  const m = clockFmt(tz)
+    .formatToParts(new Date(isoUtc))
+    .find((p) => p.type === 'minute')?.value;
+  return Number(m ?? '0');
+}
+
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+export function computeEventStats(events: UsageEvent[], tz: string): WrappedEventStats {
+  const heat: number[][] = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0));
+  const nightDates = new Set<string>();
+  // Latest small-hours moment = max clock time within hours 0-4 (closest to 5 AM).
+  let latestNight: { date: string; clock: string; weekday: number; key: number } | null = null;
+  let cacheRead = 0;
+  let cacheableInput = 0;
+  const sessions = new Map<string, { tool: string; timestamps: string[]; replies: number; project?: string }>();
+  const dayModel = new Map<string, Map<string, number>>();
+  const modelFirsts = new Map<string, ModelFirsts>();
+  let nightMsgs = 0;
+
+  for (const e of events) {
+    const date = localDate(e.timestamp, tz);
+    const hour = localHour(e.timestamp, tz);
+    const wd = weekdayOf(date);
+    heat[wd]![hour] = heat[wd]![hour]! + 1;
+    if (hour >= 22 || hour <= 5) nightMsgs++;
+
+    if (hour <= 4) {
+      nightDates.add(date);
+      const key = hour * 60 + localMinute(e.timestamp, tz);
+      if (!latestNight || key > latestNight.key) {
+        latestNight = { date, clock: localClock(e.timestamp, tz), weekday: wd, key };
+      }
+    }
+
+    cacheRead += e.tokens.cacheRead;
+    cacheableInput += e.tokens.input + e.tokens.cacheRead;
+
+    const sk = `${e.tool}|${e.sessionId}`;
+    const s = sessions.get(sk);
+    if (!s) {
+      sessions.set(sk, { tool: e.tool, timestamps: [e.timestamp], replies: 1, project: e.projectPath });
+    } else {
+      s.timestamps.push(e.timestamp);
+      s.replies++;
+      if (!s.project) s.project = e.projectPath;
+    }
+
+    let models = dayModel.get(date);
+    if (!models) {
+      models = new Map();
+      dayModel.set(date, models);
+    }
+    models.set(e.model, (models.get(e.model) ?? 0) + 1);
+
+    const first = modelFirsts.get(e.model);
+    if (!first) {
+      modelFirsts.set(e.model, { firstSeen: date, firstTopDay: null });
+    } else if (date < first.firstSeen) {
+      first.firstSeen = date;
+    }
+  }
+
+  // Adoption dates: walk days in order, record the first day each model topped.
+  for (const date of [...dayModel.keys()].sort()) {
+    let top: string | null = null;
+    let topCount = -1;
+    for (const [model, count] of dayModel.get(date)!) {
+      if (count > topCount || (count === topCount && top !== null && model < top)) {
+        top = model;
+        topCount = count;
+      }
+    }
+    if (top !== null) {
+      const first = modelFirsts.get(top)!;
+      if (first.firstTopDay === null) first.firstTopDay = date;
+    }
+  }
+
+  // Longest *sitting*, not longest session id: resumed sessions span days or
+  // weeks, so a session's events are split into continuous runs (gap ≤ 30 min)
+  // and the longest run wins. 92 replies spread over 27 days is not a sitting.
+  const SITTING_GAP_MS = 30 * 60_000;
+  let longest: WrappedLongestSession | null = null;
+  for (const s of sessions.values()) {
+    const ts = s.timestamps.map((t) => Date.parse(t)).sort((a, b) => a - b);
+    let runStart = 0;
+    for (let i = 1; i <= ts.length; i++) {
+      if (i === ts.length || ts[i]! - ts[i - 1]! > SITTING_GAP_MS) {
+        const durationMs = ts[i - 1]! - ts[runStart]!;
+        if (!longest || durationMs > longest.durationMs) {
+          longest = {
+            durationMs,
+            replies: i - runStart,
+            date: localDate(new Date(ts[runStart]!).toISOString(), tz),
+            project: resolveProject(s.project),
+          };
+        }
+        runStart = i;
+      }
+    }
+  }
+
+  // Each peak is its own marginal — busiest hour summed over days, busiest day
+  // summed over hours — so "10 AM on Thursdays" makes two independently true
+  // claims. The heatmap outlines its own argmax cell, which may differ.
+  const hourTotals = Array.from({ length: 24 }, () => 0);
+  const weekdayTotals = Array.from({ length: 7 }, () => 0);
+  for (let wd = 0; wd < 7; wd++) {
+    for (let h = 0; h < 24; h++) {
+      const v = heat[wd]![h]!;
+      hourTotals[h] = hourTotals[h]! + v;
+      weekdayTotals[wd] = weekdayTotals[wd]! + v;
+    }
+  }
+  const peakHour = hourTotals.indexOf(Math.max(...hourTotals));
+  const peakWeekday = weekdayTotals.indexOf(Math.max(...weekdayTotals));
+
+  const replyCounts = [...sessions.values()].map((s) => s.replies).sort((a, b) => a - b);
+
+  const sessionsByTool = new Map<string, number>();
+  const sessionsByProject = new Map<string, number>();
+  for (const s of sessions.values()) {
+    sessionsByTool.set(s.tool, (sessionsByTool.get(s.tool) ?? 0) + 1);
+    const proj = resolveProject(s.project);
+    sessionsByProject.set(proj, (sessionsByProject.get(proj) ?? 0) + 1);
+  }
+
+  return {
+    distinctSessions: sessions.size,
+    rhythm: {
+      heat,
+      peakHour,
+      peakWeekday,
+      nightsPastMidnight: nightDates.size,
+      latestNight: latestNight
+        ? { date: latestNight.date, clock: latestNight.clock, weekday: latestNight.weekday }
+        : null,
+    },
+    cacheReadTokens: cacheRead,
+    cacheHitRate: cacheableInput > 0 ? cacheRead / cacheableInput : null,
+    longestSession: longest,
+    medianReplies: median(replyCounts),
+    sessionsByTool,
+    sessionsByProject,
+    modelFirsts,
+    nightShare: events.length > 0 ? nightMsgs / events.length : 0,
+  };
+}
+
+/** Longest run of consecutive active dates, with its range. */
+export function longestStreakRange(activeDates: string[]): { days: number; from: string; to: string } | null {
+  const dates = [...new Set(activeDates)].sort();
+  if (dates.length === 0) return null;
+  let best: { days: number; from: string; to: string } = { days: 1, from: dates[0]!, to: dates[0]! };
+  let runFrom = dates[0]!;
+  let runDays = 1;
+  for (let i = 1; i < dates.length; i++) {
+    const prev = dates[i - 1]!;
+    const cur = dates[i]!;
+    const gap = (Date.parse(cur) - Date.parse(prev)) / 86_400_000;
+    if (gap === 1) {
+      runDays++;
+    } else {
+      runFrom = cur;
+      runDays = 1;
+    }
+    if (runDays > best.days) best = { days: runDays, from: runFrom, to: cur };
+  }
+  return best;
+}

--- a/src/wrapped/content.ts
+++ b/src/wrapped/content.ts
@@ -1,0 +1,411 @@
+// Index-backed content stats for wrapped — the fun-metric raw material that
+// only message text can provide. All queries go through getIndexDb() (which
+// refreshes first) and scope to the wrapped period by joining message_fts to
+// sessions on file_path. Phrase counts use LIKE, never MATCH: porter stemming
+// makes phrase queries fuzzy ("wait" matches "waiting") and MATCH counts rows
+// anyway — LIKE over stored text is exact and case-insensitive for ASCII.
+
+import type { Database } from 'bun:sqlite';
+import { getIndexDb } from '../cache.ts';
+import { significanceScore, isTrivia, hasArtifact } from '../significance.ts';
+import { resolveProject } from '../report/project.ts';
+import type { PhraseStat, WrappedContentStats, WrappedSessionOfYear } from './types.ts';
+
+/** Index tool names ('claude') differ from report ToolIds ('claude-code'). */
+const INDEX_TOOL: Record<string, string> = { 'claude-code': 'claude', codex: 'codex', pi: 'pi' };
+
+interface PhraseSpec {
+  id: string;
+  role: 'user' | 'assistant';
+  /** OR-composed LIKE patterns. */
+  patterns: string[];
+}
+
+// Messages-containing counts (not occurrences) — dispute-proof and cheap.
+// user rows in message_fts are genuine turns only; msg_index >= 0 excludes
+// subagent sentinel rows.
+const PHRASES: PhraseSpec[] = [
+  { id: 'absolutelyRight', role: 'assistant', patterns: ['%absolutely right%'] },
+  { id: 'interrupts', role: 'user', patterns: ['%request interrupted%'] },
+  { id: 'please', role: 'user', patterns: ['%please%'] },
+  { id: 'thanks', role: 'user', patterns: ['%thanks%', '%thank you%'] },
+  { id: 'actually', role: 'user', patterns: ['%actually%'] },
+  { id: 'tryAgain', role: 'user', patterns: ['%try again%'] },
+  { id: 'noWait', role: 'user', patterns: ['%no, wait%', '%no wait%', '%actually wait%'] },
+  { id: 'swears', role: 'user', patterns: ['%fuck%', '%shit%', '%wtf%', '%damn%'] },
+  { id: 'userSorry', role: 'user', patterns: ['%sorry%', '%apolog%'] },
+  { id: 'assistantApology', role: 'assistant', patterns: ['%apolog%'] },
+  { id: 'ultrathink', role: 'user', patterns: ['%ultrathink%'] },
+];
+
+// Vocabulary mining: words we never crown. Common English + generic dev terms —
+// the survivors are the user's own vocabulary, which is the whole joke.
+const STOPWORDS = new Set(
+  (
+    'the and for that this with have from what when where which will would could should there their they them then than ' +
+    'been being because before after about above below into over under again further once here both each more most other ' +
+    'some such only same very just also them these those your yours ours mine hers his its our you are was were has had ' +
+    'does did doing done can cannot cant dont wont isnt arent wasnt didnt doesnt shouldnt couldnt wouldnt not but who whom ' +
+    'why how all any few nor too own so as of in on at by to up if or an is it be do we me my no us am let lets like want ' +
+    'need make makes made making sure look looks looking looked see seen saw says said say going goes went get gets got ' +
+    'getting give gives gave take takes took keep keeps kept still right left good great okay yes yeah nope now new old ' +
+    'one two three first second next last thing things something anything everything nothing way ways use uses used using ' +
+    'work works worked working well better best actually please thanks thank sorry wait maybe probably think thought ' +
+    'know known knows knew come comes came back down out off between through during without within instead really always ' +
+    'never sometimes often already currently point start starts started end ends ended run runs ran running ' +
+    // dev-generic — true for every developer, so never distinctive
+    'file files code test tests testing function functions error errors bug bugs fix fixes fixed line lines change ' +
+    'changes changed update updates updated add adds added remove removes removed delete deleted create creates created ' +
+    'build builds built command commands branch commit commits push pull merge main master repo repository project ' +
+    'projects folder directory path paths name names type types value values string number list array object data ' +
+    'component components page pages user users server client api call calls called check checks checked version case ' +
+    'issue issues problem problems result results output input example examples question questions answer time times ' +
+    'true false null undefined const import export return async await class method methods module script json html css ' +
+    'text item items set sets setting settings config options option flag flags default logic implement implementation ' +
+    'implemented feature features support supported supports current existing based instead different single multiple ' +
+    'able available actual specific proper properly correct correctly wrong empty missing invalid valid every each'
+  )
+    .split(/\s+/)
+    .filter(Boolean),
+);
+
+interface CountRow {
+  n: number;
+}
+
+// "Sessions started within the period." Overlap semantics would import an
+// entire December-spanning session into the new year (message_fts rows carry
+// no timestamps to filter individually), and would let a prior-year session
+// win session-of-the-year. The explicit '?' guard documents intent even though
+// lexical comparison already excludes the sentinel. Known skew, disclosed in
+// docs: these are UTC-sliced dates while event stats bucket in local tz.
+const PERIOD_WHERE = `s.created_at >= $from AND s.created_at <= $to AND s.created_at != '?'`;
+
+function phraseCounts(db: Database, from: string, to: string, tool: string | null): PhraseStat[] {
+  const out: PhraseStat[] = [];
+  for (const spec of PHRASES) {
+    const likes = spec.patterns.map((_, i) => `m.text LIKE $p${i}`).join(' OR ');
+    const params: Record<string, string> = { $from: from, $to: to, $role: spec.role };
+    spec.patterns.forEach((p, i) => {
+      params[`$p${i}`] = p;
+    });
+    let sql =
+      `SELECT COUNT(*) AS n FROM message_fts m JOIN sessions s ON s.file_path = m.file_path ` +
+      `WHERE ${PERIOD_WHERE} AND m.role = $role AND m.msg_index >= 0 AND (${likes})`;
+    if (tool) {
+      sql += ` AND s.tool = $tool`;
+      params['$tool'] = tool;
+    }
+    const row = db.query<CountRow, Record<string, string>>(sql).get(params);
+    out.push({ id: spec.id, role: spec.role, count: row?.n ?? 0 });
+  }
+  return out;
+}
+
+/** Strip the noise that isn't the user's own voice before mining vocabulary. */
+export function cleanForMining(text: string): string {
+  return (
+    text
+      .replace(/```[\s\S]*?```/g, ' ') // fenced code
+      .replace(/`[^`]*`/g, ' ') // inline code
+      .replace(/<[^>\n]{1,80}>/g, ' ') // tags/markers
+      .replace(/\[request interrupted[^\]]*\]/gi, ' ')
+      .replace(/https?:\/\/\S+/g, ' ') // urls
+      // Paths. Segments are bounded: an unbounded [\w.-]+ prefix backtracks
+      // quadratically on long slash-free runs (unfenced base64url/hex pastes).
+      .replace(/[\w.-]{1,256}\/[\w./-]{1,512}/g, ' ')
+  );
+}
+
+export function mineWords(
+  texts: { text: string; file: string }[],
+  limit: number,
+): { word: string; count: number; sessions: number }[] {
+  const counts = new Map<string, { count: number; files: Set<string> }>();
+  for (const { text, file } of texts) {
+    const words = cleanForMining(text.toLowerCase()).match(/[a-z][a-z'-]{3,}/g);
+    if (!words) continue;
+    for (const raw of words) {
+      const w = raw.replace(/['-]/g, '');
+      if (w.length < 4 || STOPWORDS.has(w)) continue;
+      let e = counts.get(w);
+      if (!e) {
+        e = { count: 0, files: new Set() };
+        counts.set(w, e);
+      }
+      e.count++;
+      e.files.add(file);
+    }
+  }
+  return [...counts.entries()]
+    .map(([word, e]) => ({ word, count: e.count, sessions: e.files.size }))
+    .filter((w) => w.count >= 10 && w.sessions >= 5) // spread across sessions, not one rant
+    .sort((a, b) => b.count - a.count || b.sessions - a.sessions)
+    .slice(0, limit);
+}
+
+// Agent plumbing — commands every transcript is full of regardless of the
+// human's habits. Filtering them makes "featuring: git status" possible;
+// "featuring: ls" says nothing about anyone.
+const PLUMBING = new Set([
+  'ls',
+  'cd',
+  'cat',
+  'find',
+  'grep',
+  'rg',
+  'echo',
+  'pwd',
+  'head',
+  'tail',
+  'wc',
+  'which',
+  'mkdir',
+  'rm',
+  'cp',
+  'mv',
+  'touch',
+  'sed',
+  'awk',
+  'sort',
+  'uniq',
+  'tr',
+  'cut',
+  'xargs',
+  'chmod',
+  'true',
+  'test',
+  'sleep',
+  'date',
+  'env',
+  'export',
+]);
+
+/** Normalize a shell command to its "family": first two tokens (`git status`),
+ *  or one for bare commands. Keeps `git status -sb` and `git status` together. */
+export function commandFamily(cmd: string): string {
+  const tokens = cmd.trim().split(/\s+/);
+  const first = tokens[0] ?? '';
+  const second = tokens[1] ?? '';
+  if (!first) return '';
+  if (!second || second.startsWith('-') || second.includes('/') || second.includes('=')) return first;
+  return `${first} ${second}`;
+}
+
+interface SessionRow {
+  file_path: string;
+  cwd: string;
+  session_id: string;
+  created_at: string;
+  date: string;
+  first_prompt: string;
+  custom_title: string;
+  message_count: number;
+  files_touched: string;
+  commands: string;
+  errored: number;
+  error_count: number;
+  closing_user: string;
+  closing_assistant: string;
+}
+
+function parseArr(json: string): string[] {
+  try {
+    const v = JSON.parse(json);
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export interface ContentOptions {
+  from: string;
+  to: string;
+  /** Report ToolId; mapped to the index's tool naming. */
+  tool?: string;
+  /** Days of silence before a project counts as abandoned. */
+  abandonedAfterDays?: number;
+}
+
+export async function computeContentStats(opts: ContentOptions): Promise<
+  WrappedContentStats & {
+    sessionOfYear: WrappedSessionOfYear | null;
+  }
+> {
+  const db = await getIndexDb();
+  const tool = opts.tool ? (INDEX_TOOL[opts.tool] ?? opts.tool) : null;
+  const params: Record<string, string> = { $from: opts.from, $to: opts.to };
+  let toolWhere = '';
+  if (tool) {
+    toolWhere = ' AND s.tool = $tool';
+    params['$tool'] = tool;
+  }
+
+  const rows = db
+    .query<SessionRow, Record<string, string>>(
+      `SELECT file_path, cwd, session_id, created_at, date, first_prompt, custom_title, message_count,
+              files_touched, commands, errored, error_count, closing_user, closing_assistant
+       FROM sessions s WHERE ${PERIOD_WHERE}${toolWhere}`,
+    )
+    .all(params);
+
+  const phrases = phraseCounts(db, opts.from, opts.to, tool);
+
+  // Monologue asymmetry — the data picks the punchline, copy must not assume a direction.
+  const mono = db
+    .query<{ role: string; avg: number; max: number }, Record<string, string>>(
+      `SELECT m.role AS role, AVG(LENGTH(m.text)) AS avg, MAX(LENGTH(m.text)) AS max
+       FROM message_fts m JOIN sessions s ON s.file_path = m.file_path
+       WHERE ${PERIOD_WHERE}${toolWhere} AND m.msg_index >= 0 GROUP BY m.role`,
+    )
+    .all(params);
+  const user = mono.find((r) => r.role === 'user');
+  const assistant = mono.find((r) => r.role === 'assistant');
+
+  // Vocabulary mining over genuine user prompts.
+  const userTexts = db
+    .query<{ text: string; file_path: string }, Record<string, string>>(
+      `SELECT m.text AS text, m.file_path AS file_path
+       FROM message_fts m JOIN sessions s ON s.file_path = m.file_path
+       WHERE ${PERIOD_WHERE}${toolWhere} AND m.role = 'user' AND m.msg_index >= 0`,
+    )
+    .all(params);
+  const words = mineWords(
+    userTexts.map((r) => ({ text: r.text, file: r.file_path })),
+    5,
+  );
+
+  // Per-session JSON columns → league tables.
+  const fileCounts = new Map<string, number>();
+  const commandCounts = new Map<string, number>();
+  const projectAgg = new Map<string, { sessions: number; lastSeen: string }>();
+  const errByWeekday = Array.from({ length: 7 }, () => 0);
+  let sessionsErrored = 0;
+  let totalErrors = 0;
+  let driveBys = 0;
+  let best: { score: number; row: SessionRow; files: number } | null = null;
+  const messageCounts: number[] = [];
+
+  for (const r of rows) {
+    // Depth measures engaged sessions; drive-bys would drag a bimodal median
+    // into the trivia lobe and describe neither mode.
+    if (r.message_count > 2) messageCounts.push(r.message_count);
+    if (r.message_count <= 2) driveBys++;
+    if (r.errored) sessionsErrored++;
+    totalErrors += r.error_count;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(r.created_at)) {
+      const wd = new Date(`${r.created_at}T00:00:00Z`).getUTCDay();
+      errByWeekday[wd] = errByWeekday[wd]! + r.error_count;
+    }
+
+    for (const f of new Set(parseArr(r.files_touched))) {
+      fileCounts.set(f, (fileCounts.get(f) ?? 0) + 1);
+    }
+    for (const c of new Set(parseArr(r.commands).map(commandFamily))) {
+      if (c && !PLUMBING.has(c.split(' ')[0]!)) commandCounts.set(c, (commandCounts.get(c) ?? 0) + 1);
+    }
+
+    const proj = projectAgg.get(r.cwd);
+    if (!proj) {
+      projectAgg.set(r.cwd, { sessions: 1, lastSeen: r.date });
+    } else {
+      proj.sessions++;
+      if (r.date > proj.lastSeen) proj.lastSeen = r.date;
+    }
+
+    const scorable = {
+      messageCount: r.message_count,
+      filesTouchedCount: parseArr(r.files_touched).length,
+      closingText: `${r.closing_user} ${r.closing_assistant}`,
+      createdAt: r.created_at,
+    };
+    if (!isTrivia(scorable)) {
+      const score = significanceScore(scorable);
+      if (!best || score > best.score) best = { score, row: r, files: scorable.filesTouchedCount };
+    }
+  }
+
+  // Most-abandoned: meaningfully used, then silent for 90+ days before period end.
+  const cutoff = new Date(Date.parse(`${opts.to}T00:00:00Z`) - (opts.abandonedAfterDays ?? 90) * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+  let abandoned: { name: string; sessions: number; lastSeen: string } | null = null;
+  for (const [cwd, agg] of projectAgg) {
+    if (agg.sessions >= 10 && agg.lastSeen < cutoff) {
+      if (!abandoned || agg.sessions > abandoned.sessions) {
+        abandoned = { name: resolveProject(cwd), sessions: agg.sessions, lastSeen: agg.lastSeen };
+      }
+    }
+  }
+
+  const top = <K>(m: Map<K, number>, n: number): { name: K; sessions: number }[] =>
+    [...m.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, n)
+      .map(([name, sessions]) => ({ name, sessions }));
+
+  const maxErr = Math.max(...errByWeekday);
+  messageCounts.sort((a, b) => a - b);
+  const mid = Math.floor(messageCounts.length / 2);
+  const depthMedian =
+    messageCounts.length === 0
+      ? null
+      : messageCounts.length % 2 === 1
+        ? messageCounts[mid]!
+        : (messageCounts[mid - 1]! + messageCounts[mid]!) / 2;
+
+  const sessionOfYear: WrappedSessionOfYear | null = best
+    ? {
+        title: cleanTitle(best.row.custom_title || best.row.first_prompt || 'untitled'),
+        project: resolveProject(best.row.cwd),
+        date: best.row.created_at,
+        messageCount: best.row.message_count,
+        filesTouched: best.files,
+        shipped: hasArtifact(`${best.row.closing_user} ${best.row.closing_assistant}`),
+      }
+    : null;
+
+  return {
+    indexedSessions: rows.length,
+    phrases,
+    monologue: user
+      ? {
+          userAvg: Math.round(user.avg),
+          assistantAvg: Math.round(assistant?.avg ?? 0),
+          longestUser: user.max,
+        }
+      : null,
+    driveBys: rows.length > 0 ? { count: driveBys, total: rows.length } : null,
+    abandoned,
+    errors:
+      rows.length > 0
+        ? {
+            sessionsErrored,
+            totalErrors,
+            cursedWeekday: maxErr > 0 ? errByWeekday.indexOf(maxErr) : null,
+            cursedCount: maxErr > 0 ? maxErr : 0,
+          }
+        : null,
+    topFiles: top(fileCounts, 5).map((f) => ({ name: shortPath(f.name), sessions: f.sessions })),
+    topCommands: top(commandCounts, 5),
+    words,
+    depthMedian,
+    sessionOfYear,
+  };
+}
+
+/** First prompts arrive as raw markdown; a display title shouldn't. */
+export function cleanTitle(raw: string): string {
+  const cleaned = raw
+    .replace(/[#*`>_|]+/g, ' ')
+    .replace(/[\u2600-\u27bf]|\ufe0f/gu, ' ') // status emoji (checkmarks, warnings) + variation selector
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned.length > 72 ? `${cleaned.slice(0, 72).trimEnd()}…` : cleaned || 'untitled';
+}
+
+/** Last two path segments — enough to recognize a file without the noise. */
+export function shortPath(p: string): string {
+  const parts = p.split('/').filter(Boolean);
+  return parts.slice(-2).join('/');
+}

--- a/src/wrapped/extras.ts
+++ b/src/wrapped/extras.ts
@@ -1,0 +1,30 @@
+// Shared slide validator for the two extra-slide sources — --extras (a file)
+// and --roast (model output). Whatever the origin, the page owns shape, field
+// length, and count. Kept in its own module so index.ts and roast.ts can both
+// import it without a cycle.
+
+import type { WrappedExtra } from './types.ts';
+
+export function coerceExtras(parsed: unknown): WrappedExtra[] {
+  if (!Array.isArray(parsed)) return [];
+  // Cap by code points, not UTF-16 units — String.slice can split a surrogate
+  // pair and leave a lone half that renders as U+FFFD on the slide.
+  const cap = (s: unknown, n: number): string | undefined => {
+    if (typeof s !== 'string' || s.trim().length === 0) return undefined;
+    return [...s.trim()].slice(0, n).join('');
+  };
+  const out: WrappedExtra[] = [];
+  for (const item of parsed.slice(0, 6)) {
+    if (typeof item !== 'object' || item === null) continue;
+    const o = item as Record<string, unknown>;
+    const headline = cap(o['headline'], 120);
+    if (!headline) continue;
+    out.push({
+      headline,
+      title: cap(o['title'], 60),
+      subline: cap(o['subline'], 200),
+      footnote: cap(o['footnote'], 160),
+    });
+  }
+  return out;
+}

--- a/src/wrapped/html.ts
+++ b/src/wrapped/html.ts
@@ -1,0 +1,533 @@
+// The wrapped page — a scroll-snap story, not a dashboard. Design rules from
+// the Spotify Wrapped research: one stat per full-viewport card, payoffs late
+// (persona is the climax), numerals as artwork, decoration behind flat text
+// panels, a limited high-contrast palette (the report's OKLCH accents, one per
+// card), self-relative comparisons only, hedged copy on disputable stats, and
+// zero external requests. JS is textContent-only — never innerHTML.
+
+import type { WrappedData, FunCard, WrappedExtra } from './types.ts';
+
+const esc = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+const fmtInt = (n: number): string => n.toLocaleString('en-US');
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(2) + 'B';
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
+}
+
+const fmtUSD = (n: number): string => '$' + Math.round(n).toLocaleString('en-US');
+
+function fmtDuration(ms: number): string {
+  const mins = Math.round(ms / 60_000);
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function hourLabel(h: number): string {
+  if (h === 0) return '12 AM';
+  if (h === 12) return '12 PM';
+  return h < 12 ? h + ' AM' : h - 12 + ' PM';
+}
+
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const DAY_LETTERS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatDate(ymd: string): string {
+  const [y, m, d] = ymd.split('-').map(Number);
+  return `${MONTHS[m! - 1]} ${d}, ${y}`;
+}
+
+function shortDate(ymd: string): string {
+  const [, m, d] = ymd.split('-').map(Number);
+  return `${MONTHS[m! - 1]} ${d}`;
+}
+
+// Same accents as the report — wrapped and report read as one product. The
+// page commits to dark (it's a mood); each card adopts one accent in rotation.
+const ACCENTS = [
+  { name: 'magenta', c: 'oklch(70% 0.24 350)' },
+  { name: 'lime', c: 'oklch(86% 0.23 132)' },
+  { name: 'cyan', c: 'oklch(80% 0.14 200)' },
+  { name: 'cobalt', c: 'oklch(70% 0.17 262)' },
+  { name: 'tangerine', c: 'oklch(76% 0.18 50)' },
+  { name: 'red', c: 'oklch(68% 0.21 25)' },
+] as const;
+
+/** "claude-opus-4-8" / "claude-haiku-4-5-20251001" → "Opus 4.8" / "Haiku 4.5";
+ *  anything unrecognized keeps its raw id (never invent a name). */
+export function prettyModel(id: string): string {
+  // The minor version is 1-2 digits at a segment boundary — an 8-digit date
+  // suffix (claude-opus-4-20250514) is NOT a minor version.
+  const claude = id.match(/^claude-(opus|sonnet|haiku|fable|mythos)-(\d+)(?:-(\d{1,2})(?=-|$))?/);
+  if (claude) {
+    const family = claude[1]!.charAt(0).toUpperCase() + claude[1]!.slice(1);
+    return claude[3] ? `${family} ${claude[2]}.${claude[3]}` : `${family} ${claude[2]}`;
+  }
+  const gpt = id.match(/^gpt-([\d.]+)(-\w+)?/);
+  if (gpt) return `GPT-${gpt[1]}${gpt[2] ?? ''}`;
+  return id;
+}
+
+/** Reframe the raw token count as something human — the "minutes listened" move. */
+export function tokenEquivalence(tokens: number): string | null {
+  // Recognizable units beat precise ones, and big multipliers are the point —
+  // "469 Harry Potter series" lands harder than "11 Britannicas".
+  const scales: { unit: number; many: string }[] = [
+    { unit: 6_000_000_000, many: 'copies of the English Wikipedia' },
+    { unit: 1_400_000, many: 'read-throughs of the Harry Potter series' },
+    { unit: 780_000, many: 'copies of War and Peace' },
+  ];
+  for (const s of scales) {
+    const x = tokens / s.unit;
+    if (x >= 1.5) {
+      const n = x >= 10 ? fmtInt(Math.round(x)) : x.toFixed(1);
+      return `that’s ${n} ${s.many}`;
+    }
+  }
+  return tokens >= 400_000 ? 'that’s most of War and Peace' : null;
+}
+
+interface Card {
+  id: string;
+  cls?: string;
+  body: string;
+}
+
+function kicker(text: string): string {
+  return `<p class="kicker">${esc(text)}</p>`;
+}
+
+function foot(text: string): string {
+  return `<p class="foot">${esc(text)}</p>`;
+}
+
+/** Oversized echo of the card's hero — the decoration layer, never the data. */
+function echo(text: string): string {
+  return `<div class="echo" aria-hidden="true">${esc(text)}</div>`;
+}
+
+function bigNum(n: number, fmt: 'int' | 'tok' | 'usd'): string {
+  const rendered = fmt === 'usd' ? fmtUSD(n) : fmt === 'tok' ? fmtTokens(n) : fmtInt(n);
+  return `<div class="big"><span class="n" data-n="${n}" data-fmt="${fmt}">${esc(rendered)}</span></div>`;
+}
+
+function heatmap(heat: number[][]): string {
+  let max = 0;
+  let maxWd = -1;
+  let maxHour = -1;
+  for (let wd = 0; wd < 7; wd++) {
+    for (let h = 0; h < 24; h++) {
+      if (heat[wd]![h]! > max) {
+        max = heat[wd]![h]!;
+        maxWd = wd;
+        maxHour = h;
+      }
+    }
+  }
+  if (max === 0) return '';
+  let cells = '';
+  for (let wd = 0; wd < 7; wd++) {
+    cells += `<div class="hm-lbl">${DAY_LETTERS[wd]}</div>`;
+    for (let h = 0; h < 24; h++) {
+      const v = heat[wd]![h]!;
+      const pct = v === 0 ? 0 : Math.round(12 + 78 * Math.sqrt(v / max));
+      const peak = wd === maxWd && h === maxHour ? ' peak' : '';
+      cells += `<div class="hm-cell${peak}" style="--p:${pct}%" data-tip="${esc(`${WEEKDAYS[wd]} ${hourLabel(h)} — ${fmtInt(v)} msgs`)}"></div>`;
+    }
+  }
+  let hours = '<div></div>';
+  for (let h = 0; h < 24; h++) {
+    hours += `<div class="hm-hr">${h % 6 === 0 ? hourLabel(h).replace(' ', '') : ''}</div>`;
+  }
+  return `<div class="scrollx"><div class="hm">${cells}${hours}</div></div>`;
+}
+
+function streakStrip(daily: { date: string; tokens: number }[], streak: { from: string; to: string } | null): string {
+  if (daily.length === 0) return '';
+  const byDate = new Map(daily.map((d) => [d.date, d.tokens]));
+  const max = Math.max(...daily.map((d) => d.tokens), 1);
+  const first = daily[0]!.date;
+  const last = daily[daily.length - 1]!.date;
+  // Start the strip on the Sunday on/before the first active day.
+  const start = new Date(`${first}T00:00:00Z`);
+  start.setUTCDate(start.getUTCDate() - start.getUTCDay());
+  let cells = '';
+  const cur = new Date(start);
+  while (cur.toISOString().slice(0, 10) <= last) {
+    const ymd = cur.toISOString().slice(0, 10);
+    const v = byDate.get(ymd) ?? 0;
+    const pct = v === 0 ? 0 : Math.round(15 + 75 * Math.sqrt(v / max));
+    const inStreak = streak && ymd >= streak.from && ymd <= streak.to ? ' streak' : '';
+    cells += `<div class="cal-cell${inStreak}" style="--p:${pct}%" data-tip="${esc(`${formatDate(ymd)} — ${fmtTokens(v)} tokens`)}"></div>`;
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return `<div class="scrollx"><div class="cal">${cells}</div></div>`;
+}
+
+function rankedList(rows: { name: string; value: number; detail: string }[], unit: 'tok' | 'usd'): string {
+  const max = Math.max(1, ...rows.map((r) => r.value));
+  return `<ol class="rank">${rows
+    .map((r, i) => {
+      const pct = ((r.value / max) * 100).toFixed(1);
+      const val = unit === 'usd' ? fmtUSD(r.value) : fmtTokens(r.value);
+      return `<li style="--i:${rows.length - 1 - i}"><span class="pos">${i + 1}</span><span class="rname">${esc(r.name)}</span><span class="rtrack"><span class="rfill" style="width:${pct}%"></span></span><span class="rval" data-tip="${esc(r.detail)}">${val}</span></li>`;
+    })
+    .join('')}</ol>`;
+}
+
+function funCard(card: FunCard): Card {
+  const [lead, ...rest] = card.stats;
+  const restRows = rest
+    .map(
+      (s, i) =>
+        `<div class="substat" style="--i:${i + 1}"><span class="sn">${esc(s.big)}</span><span class="sl">${esc(s.label)}${s.sub ? ` <em>· ${esc(s.sub)}</em>` : ''}</span></div>`,
+    )
+    .join('');
+  return {
+    id: `fun-${card.id}`,
+    body: `${echo(lead!.big.length <= 8 ? lead!.big : '!?')}<div class="panel">${kicker(card.kicker)}<h2>${esc(card.title)}</h2><div class="big"><span class="n">${esc(lead!.big)}</span></div><p class="lede">${esc(lead!.label)}${lead!.sub ? ` <em>· ${esc(lead!.sub)}</em>` : ''}</p>${restRows}${card.footnote ? foot(card.footnote) : ''}</div>`,
+  };
+}
+
+function extraCard(x: WrappedExtra, i: number): Card {
+  return {
+    id: `extra-${i}`,
+    body: `<div class="panel">${kicker(x.title ?? 'guest appearance')}<div class="big bigword"><span class="n">${esc(x.headline)}</span></div>${x.subline ? `<p class="lede">${esc(x.subline)}</p>` : ''}${x.footnote ? foot(x.footnote) : ''}</div>`,
+  };
+}
+
+export function renderWrappedHtml(d: WrappedData): string {
+  const cards: Card[] = [];
+  const empty = d.totals.sessions === 0;
+
+  const horizon =
+    d.dataBegins && d.dataBegins > d.period.from
+      ? `data begins ${formatDate(d.dataBegins)} — older transcripts have been pruned by your tools`
+      : null;
+
+  cards.push({
+    id: 'cover',
+    cls: 'cover',
+    body: `${echo(String(d.year))}<div class="panel center">
+<p class="brand">sessions</p>
+<h1><span>your</span> <span class="yr">${d.year}</span> <span>wrapped</span></h1>
+<p class="lede">${esc(formatDate(d.period.from))} → ${esc(formatDate(d.period.to))}${d.period.to.slice(5) !== '12-31' ? ' · so far' : ''}</p>
+${empty ? `<p class="lede">A quiet year — no sessions found. The mystery of you deepens.</p>` : `<p class="hint">scroll<span class="chev">▾</span></p>`}
+<p class="foot">generated locally from your own transcripts · nothing leaves your machine${horizon ? ` · ${esc(horizon)}` : ''}</p>
+</div>`,
+  });
+
+  if (!empty) {
+    const equiv = tokenEquivalence(d.totals.tokens);
+    cards.push({
+      id: 'tokens',
+      body: `${echo(fmtTokens(d.totals.tokens))}<div class="panel center">${kicker('the year in tokens')}<h2>You and your agents had a lot to say.</h2>${bigNum(d.totals.tokens, 'tok')}<p class="lede">tokens exchanged${equiv ? ` — ${esc(equiv)}` : ''}</p>${foot('input + output + cache writes · same math as sessions report')}</div>`,
+    });
+
+    const cachePct = d.cacheHitRate !== null ? Math.round(d.cacheHitRate * 100) : null;
+    cards.push({
+      id: 'cost',
+      body: `${echo(fmtUSD(d.totals.costUSD))}<div class="panel center">${kicker('the receipt')}<h2>All of that, à la carte?</h2>${bigNum(d.totals.costUSD, 'usd')}<p class="lede">what this year would have cost at API list prices</p>${
+        cachePct !== null
+          ? `<div class="substat" style="--i:1"><span class="sn">${cachePct}%</span><span class="sl">cache hit rate — ${fmtTokens(d.totals.cacheReadTokens)} tokens re-read from cache instead of full price</span></div>`
+          : ''
+      }${
+        d.warnings.length > 0
+          ? foot(
+              `${d.warnings.length} model(s) had no pricing — the real number is higher: ${d.warnings.map((w) => w.model).join(', ')}`,
+            )
+          : foot('estimated from LiteLLM list prices · cache reads billed at cache rates')
+      }</div>`,
+    });
+
+    const streak = d.totals.longestStreak;
+    cards.push({
+      id: 'showedup',
+      body: `${echo(fmtInt(d.totals.sessions))}<div class="panel">${kicker('attendance')}<h2>You showed up.</h2>
+<div class="statrow">
+<div class="stat" style="--i:0"><span class="n" data-n="${d.totals.sessions}" data-fmt="int">${fmtInt(d.totals.sessions)}</span><span class="l">conversations</span></div>
+<div class="stat" style="--i:1"><span class="n" data-n="${d.totals.messages}" data-fmt="int">${fmtInt(d.totals.messages)}</span><span class="l">replies</span></div>
+<div class="stat" style="--i:2"><span class="n" data-n="${d.totals.activeDays}" data-fmt="int">${fmtInt(d.totals.activeDays)}</span><span class="l">active days</span></div>
+</div>
+${streakStrip(d.daily, streak ? { from: streak.from, to: streak.to } : null)}
+${streak ? `<p class="lede">longest streak: <b>${streak.days} days</b> <em>(${esc(shortDate(streak.from))} – ${esc(shortDate(streak.to))})</em></p>` : ''}
+</div>`,
+    });
+
+    cards.push({
+      id: 'rhythm',
+      body: `<div class="panel">${kicker('your rhythm')}<h2>You have a witching hour.</h2>
+${heatmap(d.rhythm.heat)}
+<p class="lede">peak: <b>${esc(hourLabel(d.rhythm.peakHour))}</b> on <b>${esc(WEEKDAYS[d.rhythm.peakWeekday]!)}s</b>${
+        d.rhythm.nightsPastMidnight > 0
+          ? ` <em>· past midnight on ${fmtInt(d.rhythm.nightsPastMidnight)} nights</em>`
+          : ''
+      }</p>${foot(`local time (${d.tz})`)}</div>`,
+    });
+
+    if (d.projects.length > 0) {
+      const topShare = Math.round((d.projects[0]?.share ?? 0) * 100);
+      cards.push({
+        id: 'projects',
+        body: `<div class="panel">${kicker('the obsessions')}<h2>Where the year actually went.</h2>${rankedList(
+          d.projects.map((p) => ({
+            name: p.name,
+            value: p.tokens,
+            detail: `${fmtInt(p.sessions)} sessions · ${fmtUSD(p.costUSD)}`,
+          })),
+          'tok',
+        )}${topShare >= 25 ? `<p class="lede"><b>${esc(d.projects[0]!.name)}</b> alone ate <b>${topShare}%</b> of everything.</p>` : ''}</div>`,
+      });
+    }
+
+    if (d.models.length > 0) {
+      // The adoption story features the newest model that actually took over —
+      // "the week X arrived" beats restating the year-long #1.
+      const adopters = d.models.filter((m) => m.firstTopDay && m.share >= 0.1);
+      const newest = adopters.sort((a, b) => (a.firstSeen < b.firstSeen ? 1 : -1))[0];
+      const takeover =
+        newest && newest.firstTopDay === newest.firstSeen
+          ? 'your daily #1 the day it landed'
+          : newest
+            ? `your daily #1 by <b>${esc(shortDate(newest.firstTopDay!))}</b>`
+            : '';
+      const story = newest
+        ? `<p class="lede"><b>${esc(prettyModel(newest.label))}</b> arrived <b>${esc(shortDate(newest.firstSeen))}</b> — ${takeover}. ${newest.id === d.models[0]!.id ? 'It never looked back.' : 'The old guard held on.'}</p>`
+        : '';
+      const toolStrip =
+        d.tools.length > 1
+          ? `<div class="pills">${d.tools.map((t) => `<span class="pill">${esc(t.label)} ${Math.round(t.share * 100)}%</span>`).join('')}</div>`
+          : '';
+      cards.push({
+        id: 'models',
+        body: `<div class="panel">${kicker('the cast')}<h2>Every voice in the room.</h2>${rankedList(
+          d.models.slice(0, 5).map((m) => ({
+            name: prettyModel(m.label),
+            value: m.messages,
+            detail: `${fmtTokens(m.tokens)} tokens · first seen ${shortDate(m.firstSeen)}`,
+          })),
+          'tok',
+        )}${story}${toolStrip}${foot('ranked by replies · bars show reply volume')}</div>`,
+      });
+    }
+
+    if (d.biggestDay) {
+      const ratio = d.biggestDay.medianTokens > 0 ? d.biggestDay.tokens / d.biggestDay.medianTokens : 0;
+      cards.push({
+        id: 'bigday',
+        body: `${echo(shortDate(d.biggestDay.date))}<div class="panel center">${kicker('the bender')}<h2>Then there was ${esc(formatDate(d.biggestDay.date))}.</h2>${bigNum(d.biggestDay.tokens, 'tok')}<p class="lede">tokens in a single day${
+          ratio >= 2 ? ` — <b>${ratio >= 10 ? Math.round(ratio) : ratio.toFixed(1)}×</b> your median day` : ''
+        }</p></div>`,
+      });
+    }
+
+    // A sitting under an hour isn't a superlative — drop the line, keep the card.
+    const soy = d.sessionOfYear;
+    const ls = d.longestSession && d.longestSession.durationMs >= 3_600_000 ? d.longestSession : null;
+    if (soy || ls) {
+      cards.push({
+        id: 'magnum',
+        body: `<div class="panel">${kicker('your magnum opus')}${
+          soy
+            ? `<h2>“${esc(soy.title)}”</h2><p class="lede">${esc(formatDate(soy.date))} · <b>${esc(soy.project)}</b> · ${fmtInt(soy.messageCount)} messages · ${fmtInt(soy.filesTouched)} files${soy.shipped ? ' · <span class="badge">shipped</span>' : ''}</p>`
+            : ''
+        }${
+          ls
+            ? `<div class="substat" style="--i:1"><span class="sn">${esc(fmtDuration(ls.durationMs))}</span><span class="sl">your longest sitting — ${fmtInt(ls.replies)} replies, ${esc(formatDate(ls.date))}, ${esc(ls.project)}</span></div>`
+            : ''
+        }${soy ? foot('ranked by substance: message volume, files edited, and whether something shipped') : ''}</div>`,
+      });
+    }
+
+    for (const card of d.fun) cards.push(funCard(card));
+
+    if (d.wordOfYear) {
+      const w = d.wordOfYear;
+      cards.push({
+        id: 'word',
+        body: `${echo(w.word)}<div class="panel center">${kicker('your word of the year')}<div class="big bigword"><span class="n">${esc(w.word)}</span></div><p class="lede">typed <b>${fmtInt(w.count)}</b> times across <b>${fmtInt(w.sessions)}</b> sessions</p>${
+          w.runnersUp.length > 0 ? `<p class="lede"><em>also in rotation: ${esc(w.runnersUp.join(', '))}</em></p>` : ''
+        }${foot('mined from your own prompts · common words excluded')}</div>`,
+      });
+    }
+
+    for (const [i, x] of d.extras.entries()) cards.push(extraCard(x, i));
+
+    if (d.persona) {
+      const pa = d.persona;
+      cards.push({
+        id: 'persona',
+        cls: 'persona',
+        body: `<div class="panel center">${kicker(`the reveal — this year you were`)}
+<div class="big bigword"><span class="n">${esc(pa.name)}</span></div>
+<p class="lede tagline">${esc(pa.tagline)}</p>
+<div class="axes">${pa.axes
+          .map(
+            (a, i) =>
+              `<div class="axis" style="--i:${i}"><span class="al">${esc(a.label)}</span><span class="av">${esc(a.value)}</span><span class="ax">${esc(a.lean)}</span></div>`,
+          )
+          .join('')}</div>
+${pa.flavor ? `<p class="lede"><em>${esc(pa.flavor)}</em></p>` : ''}
+${foot('a description of how you worked this year, not who you are · this card wants to be a screenshot')}</div>`,
+      });
+    }
+  }
+
+  // Extras render even on an empty year — an agent-authored roast of a quiet
+  // year is still a slide, and --stdout already includes them unconditionally.
+  if (empty) for (const [i, x] of d.extras.entries()) cards.push(extraCard(x, i));
+
+  const creditRows: [string, string][] = [];
+  if (d.models[0]) creditRows.push(['starring', prettyModel(d.models[0].label)]);
+  if (d.content?.topCommands[0]) {
+    creditRows.push([
+      'featuring',
+      `${d.content.topCommands[0].name} (${fmtInt(d.content.topCommands[0].sessions)} sessions)`,
+    ]);
+  }
+  if (d.projects[0]) creditRows.push(['on location', d.projects[0].name]);
+  if (d.content?.topFiles[0]) creditRows.push(['set dressing', d.content.topFiles[0].name]);
+  if (d.content?.errors && d.content.errors.totalErrors > 0) {
+    creditRows.push(['stunts', `${fmtInt(d.content.errors.totalErrors)} errors, all survived`]);
+  }
+  creditRows.push(['directed by', 'you']);
+  cards.push({
+    id: 'credits',
+    cls: 'credits',
+    body: `<div class="panel center">${kicker('roll credits')}<dl class="creditlist">${creditRows
+      .map(([k, v], i) => `<div style="--i:${i}"><dt>${esc(k)}</dt><dd>${esc(v)}</dd></div>`)
+      .join(
+        '',
+      )}</dl><p class="foot">sessions wrapped ${d.year} · generated ${esc(d.generatedAt.slice(0, 10))} · locally, with no telemetry</p></div>`,
+  });
+
+  const sections = cards
+    .map((c, i) => {
+      const accent = ACCENTS[i % ACCENTS.length]!;
+      return `<section class="card ${c.cls ?? ''}" id="${c.id}" style="--a:${accent.c}">${c.body}</section>`;
+    })
+    .join('\n');
+
+  const dots = cards
+    .map((c) => `<button type="button" data-for="${c.id}" aria-label="${esc(c.id)}"></button>`)
+    .join('');
+
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>sessions wrapped ${d.year}</title>
+<style>${CSS}</style></head>
+<body>
+<main>
+${sections}
+</main>
+<nav class="dots" aria-label="slides">${dots}</nav>
+<div class="tip" id="tip"></div>
+<script>${JS}</script>
+</body></html>`;
+}
+
+const CSS = `
+:root{--bg:oklch(13% 0.01 280);--panel:oklch(17% 0.012 280);--ink:oklch(97% 0 0);--muted:oklch(72% 0 0);--faint:oklch(45% 0 0);--track:oklch(24% 0.01 280);--mono:ui-monospace,SFMono-Regular,Menlo,monospace;--sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,sans-serif;}
+*{box-sizing:border-box}
+html{background:var(--bg);scroll-snap-type:y mandatory;}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.5;}
+main{width:100%;}
+.card{position:relative;min-height:100svh;display:flex;align-items:center;justify-content:center;scroll-snap-align:start;overflow:hidden;padding:48px 24px;background:radial-gradient(120% 90% at 50% 110%,color-mix(in oklch,var(--a) 14%,transparent),transparent 60%),var(--bg);}
+.panel{position:relative;z-index:1;max-width:680px;width:100%;}
+.panel.center{text-align:center;}
+.echo{position:absolute;inset:auto -4% -6% auto;z-index:0;font-weight:900;font-size:clamp(8rem,34vw,26rem);line-height:.8;letter-spacing:-.04em;color:transparent;-webkit-text-stroke:1.5px color-mix(in oklch,var(--a) 38%,transparent);transform:rotate(-6deg);user-select:none;pointer-events:none;white-space:nowrap;}
+.kicker{font-family:var(--mono);font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.14em;color:var(--a);margin:0 0 14px;}
+h1{font-size:clamp(3rem,9vw,5.6rem);font-weight:900;line-height:.95;letter-spacing:-.03em;text-transform:uppercase;margin:12px 0;}
+h1 .yr{color:var(--a);text-shadow:0 0 70px color-mix(in oklch,var(--a) 45%,transparent);}
+h1 span{display:block;}
+h2{font-size:clamp(1.5rem,4vw,2.2rem);font-weight:800;letter-spacing:-.01em;line-height:1.15;margin:0 0 18px;text-wrap:balance;}
+.big{margin:10px 0 14px;}
+.big .n{font-size:clamp(4rem,14vw,9.5rem);font-weight:900;letter-spacing:-.04em;line-height:1;color:var(--a);text-shadow:0 0 70px color-mix(in oklch,var(--a) 40%,transparent);}
+.big.bigword .n{font-size:clamp(2.4rem,9vw,5.5rem);letter-spacing:-.02em;text-wrap:balance;}
+.lede{font-size:clamp(1.05rem,2.2vw,1.3rem);color:var(--ink);margin:10px 0 0;text-wrap:balance;}
+.lede em,.sl em{color:var(--muted);font-style:normal;}
+.lede b{color:var(--a);font-weight:800;}
+.foot{font-family:var(--mono);font-size:11px;color:var(--faint);margin:26px 0 0;line-height:1.6;}
+.brand{font-family:var(--mono);font-weight:700;font-size:14px;color:var(--a);margin:0;}
+.hint{font-family:var(--mono);font-size:12px;color:var(--muted);margin-top:34px;}
+.chev{display:inline-block;margin-left:6px;animation:bob 1.6s ease-in-out infinite;}
+@keyframes bob{0%,100%{transform:translateY(0)}50%{transform:translateY(5px)}}
+.statrow{display:flex;gap:36px;flex-wrap:wrap;margin:18px 0 22px;}
+.stat{display:flex;flex-direction:column;}
+.stat .n{font-size:clamp(2.2rem,6vw,3.6rem);font-weight:900;letter-spacing:-.03em;line-height:1.05;color:var(--a);}
+.stat .l{font-family:var(--mono);font-size:11.5px;color:var(--muted);margin-top:4px;}
+.substat{display:flex;align-items:baseline;gap:14px;margin:20px 0 0;text-align:left;}
+.panel.center .substat{justify-content:center;}
+.substat .sn{font-size:clamp(1.5rem,4vw,2.3rem);font-weight:900;letter-spacing:-.02em;color:var(--a);white-space:nowrap;}
+.substat .sl{font-size:.98rem;color:var(--ink);max-width:44ch;}
+.badge{display:inline-block;font-family:var(--mono);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--bg);background:var(--a);border-radius:3px;padding:2px 7px;vertical-align:2px;}
+.pills{display:flex;gap:8px;flex-wrap:wrap;margin-top:18px;}
+.pill{font-family:var(--mono);font-size:11.5px;font-weight:600;color:var(--ink);border:1px solid var(--track);border-radius:999px;padding:4px 11px;}
+.rank{list-style:none;margin:6px 0 14px;padding:0;display:flex;flex-direction:column;gap:12px;}
+.rank li{display:grid;grid-template-columns:1.6em minmax(7em,14em) 1fr auto;gap:12px;align-items:center;}
+.rank .pos{font-weight:900;font-size:1.15rem;color:var(--a);text-align:right;}
+.rank .rname{font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.rank .rtrack{height:12px;background:var(--track);border-radius:0 3px 3px 0;overflow:hidden;}
+.rank .rfill{display:block;height:100%;background:var(--a);border-radius:0 3px 3px 0;transform-origin:left;}
+.rank .rval{font-family:var(--mono);font-size:12px;color:var(--muted);}
+.scrollx{overflow-x:auto;margin:8px 0 14px;padding-bottom:4px;}
+.hm{display:grid;grid-template-columns:1.2em repeat(24,minmax(14px,1fr));gap:3px;min-width:520px;}
+.hm-lbl,.hm-hr{font-family:var(--mono);font-size:9.5px;color:var(--faint);display:flex;align-items:center;}
+.hm-hr{justify-content:flex-start;}
+.hm-cell{aspect-ratio:1;border-radius:2px;background:color-mix(in oklch,var(--a) var(--p),oklch(20% 0.01 280));}
+.hm-cell.peak{outline:2px solid var(--ink);outline-offset:-1px;}
+.cal{display:grid;grid-auto-flow:column;grid-template-rows:repeat(7,10px);gap:3px;width:max-content;}
+.cal-cell{width:10px;height:10px;border-radius:2px;background:color-mix(in oklch,var(--a) var(--p),oklch(20% 0.01 280));}
+.cal-cell.streak{outline:1.5px solid var(--ink);outline-offset:-1px;}
+.axes{display:flex;flex-direction:column;gap:10px;margin:26px auto 0;max-width:430px;}
+.axis{display:grid;grid-template-columns:5.5em 1fr auto;gap:12px;align-items:baseline;border-top:1px solid var(--track);padding-top:10px;text-align:left;}
+.axis .al{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);}
+.axis .av{font-weight:700;}
+.axis .ax{font-family:var(--mono);font-size:11.5px;font-weight:700;color:var(--a);}
+.tagline{margin-top:2px;}
+.card.persona{background:radial-gradient(130% 100% at 20% 0%,color-mix(in oklch,var(--a) 22%,transparent),transparent 55%),radial-gradient(130% 100% at 90% 100%,color-mix(in oklch,oklch(70% 0.24 350) 18%,transparent),transparent 55%),var(--bg);}
+.creditlist{margin:10px 0 0;padding:0;display:flex;flex-direction:column;gap:14px;}
+.creditlist div{display:flex;flex-direction:column;gap:2px;}
+.creditlist dt{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:var(--muted);}
+.creditlist dd{margin:0;font-size:clamp(1.2rem,3vw,1.7rem);font-weight:800;letter-spacing:-.01em;}
+.dots{position:fixed;right:14px;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;gap:8px;z-index:5;}
+.dots button{width:8px;height:8px;border-radius:50%;border:0;padding:0;background:var(--track);cursor:pointer;transition:background .2s,transform .2s;}
+.dots button.on{background:var(--ink);transform:scale(1.3);}
+.tip{position:fixed;pointer-events:none;background:var(--ink);color:var(--bg);font-family:var(--mono);font-size:11px;padding:4px 7px;border-radius:4px;opacity:0;transform:translate(-50%,-130%);white-space:nowrap;z-index:10;}
+.card .panel>*,.card .echo{opacity:0;transform:translateY(18px);transition:opacity .7s ease-out,transform .7s ease-out;}
+.card .echo{transform:rotate(-6deg) translateY(24px);transition-duration:1.1s;}
+.card.live .panel>*,.card.live .echo{opacity:1;transform:translateY(0);}
+.card.live .echo{transform:rotate(-6deg);}
+.card.live .panel>*:nth-child(2){transition-delay:.08s}
+.card.live .panel>*:nth-child(3){transition-delay:.16s}
+.card.live .panel>*:nth-child(4){transition-delay:.26s}
+.card.live .panel>*:nth-child(5){transition-delay:.36s}
+.card.live .panel>*:nth-child(6){transition-delay:.46s}
+.card.live .panel>*:nth-child(n+7){transition-delay:.56s}
+.card.live .rank li,.card.live .substat,.card.live .axis,.card.live .creditlist div{opacity:0;transform:translateY(14px);animation:rise .6s ease-out forwards;animation-delay:calc(.3s + var(--i,0)*.18s);}
+@keyframes rise{to{opacity:1;transform:translateY(0)}}
+@media (max-width:640px){.dots{display:none;}.rank li{grid-template-columns:1.4em 1fr auto;}.rank .rtrack{display:none;}}
+@media (prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important;}.card .panel>*,.card .echo,.card.live .rank li,.card.live .substat,.card.live .axis,.card.live .creditlist div{opacity:1!important;transform:none!important;}}
+`;
+
+// Count-up + card reveal + tooltip + dots. textContent only — never innerHTML.
+const JS = `(function(){
+var reduce=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+function fmt(n,kind){if(kind==='usd')return '$'+Math.round(n).toLocaleString('en-US');if(kind==='tok'){if(n>=1e9)return (n/1e9).toFixed(2)+'B';if(n>=1e6)return (n/1e6).toFixed(1)+'M';if(n>=1e3)return (n/1e3).toFixed(1)+'K';return String(Math.round(n));}return Math.round(n).toLocaleString('en-US');}
+function countUp(el){var n=Number(el.getAttribute('data-n'));var kind=el.getAttribute('data-fmt');if(!isFinite(n)||!kind)return;if(reduce){el.textContent=fmt(n,kind);return;}var t0=null;function step(t){if(t0===null)t0=t;var p=Math.min(1,(t-t0)/1200);var e=1-Math.pow(1-p,3);el.textContent=fmt(n*e,kind);if(p<1)requestAnimationFrame(step);}requestAnimationFrame(step);}
+var seen=new WeakSet();
+var obs=new IntersectionObserver(function(entries){entries.forEach(function(en){if(!en.isIntersecting)return;var card=en.target;card.classList.add('live');dotFor(card.id);if(!seen.has(card)){seen.add(card);card.querySelectorAll('[data-n]').forEach(countUp);}});},{threshold:0.45});
+document.querySelectorAll('.card').forEach(function(c){obs.observe(c);});
+var dots=document.querySelectorAll('.dots button');
+function dotFor(id){dots.forEach(function(b){b.classList.toggle('on',b.getAttribute('data-for')===id);});}
+dots.forEach(function(b){b.addEventListener('click',function(){var el=document.getElementById(b.getAttribute('data-for'));if(el)el.scrollIntoView({behavior:reduce?'auto':'smooth'});});});
+var tip=document.getElementById('tip');
+document.addEventListener('mousemove',function(e){var el=e.target&&e.target.closest?e.target.closest('[data-tip]'):null;if(!el){tip.style.opacity='0';return;}tip.textContent=el.getAttribute('data-tip');tip.style.opacity='1';tip.style.left=e.clientX+'px';tip.style.top=e.clientY+'px';});
+console.log('sessions wrapped \\u2014 generated locally from your own session logs. No telemetry.');
+})();`;

--- a/src/wrapped/index.test.ts
+++ b/src/wrapped/index.test.ts
@@ -1,0 +1,235 @@
+import { describe, test, expect, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runWrapped, parseWrappedArgs, parseExtras } from './index.ts';
+
+const tmp = mkdtempSync(join(tmpdir(), 'sessions-wrapped-run-'));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+const claudeDir = join(tmp, 'claude');
+mkdirSync(join(claudeDir, 'proj'), { recursive: true });
+
+const event = (sessionId: string, timestamp: string, model = 'claude-opus-4-6', input = 1000, output = 500) =>
+  JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    cwd: '/Users/x/Developer/sessions',
+    timestamp,
+    message: {
+      model,
+      usage: {
+        input_tokens: input,
+        output_tokens: output,
+        cache_creation_input_tokens: 200,
+        cache_read_input_tokens: 10_000,
+      },
+    },
+  }) + '\n';
+
+writeFileSync(
+  join(claudeDir, 'proj', 'a.jsonl'),
+  // One long sitting (three replies 10 min apart) …
+  event('s1', '2026-06-01T14:00:00Z') +
+    event('s1', '2026-06-01T14:10:00Z') +
+    event('s1', '2026-06-01T14:20:00Z') +
+    // … then the same session resumed three weeks later — must not count as a 3-week sitting.
+    event('s1', '2026-06-22T09:00:00Z') +
+    // A small-hours event (03:30 UTC = 22:30 America/Chicago the previous day; use UTC tz in tests).
+    event('s2', '2026-06-03T03:30:00Z', 'claude-fable-5') +
+    // Out-of-year noise that must be filtered.
+    event('s3', '2025-11-11T11:00:00Z'),
+);
+const roots = { claudeCode: claudeDir, pi: join(tmp, 'no-pi'), codex: join(tmp, 'no-codex') };
+const NOW = '2026-07-13T12:00:00Z';
+
+describe('parseWrappedArgs', () => {
+  test('defaults', () => {
+    const o = parseWrappedArgs([]);
+    expect(o.stdout).toBe(false);
+    expect(o.year).toBeUndefined();
+    expect(o.out).toBeUndefined();
+  });
+
+  test('parses flags', () => {
+    const o = parseWrappedArgs(['--year', '2025', '--tool', 'claude', '--tz', 'UTC', '--stdout', '--offline']);
+    expect(o.year).toBe(2025);
+    expect(o.tool).toBe('claude-code');
+    expect(o.tz).toBe('UTC');
+    expect(o.stdout).toBe(true);
+    expect(o.offline).toBe(true);
+  });
+
+  test('rejects a bad year in a child process', () => {
+    const r = Bun.spawnSync(['bun', '-e', "require('./src/wrapped/index.ts').parseWrappedArgs(['--year','20'])"]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.toString()).toContain('--year');
+  });
+
+  test('unknown flag dies', () => {
+    const r = Bun.spawnSync(['bun', '-e', "require('./src/wrapped/index.ts').parseWrappedArgs(['--nope'])"]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.toString()).toContain('unknown option');
+  });
+});
+
+describe('parseExtras', () => {
+  test('accepts well-formed slides and caps fields', () => {
+    const extras = parseExtras(
+      JSON.stringify([
+        { headline: 'You said "one more try" 11 times on a Tuesday', title: 'roast', subline: 'it did not work' },
+        { headline: '   ' }, // blank headline → dropped
+        { nope: true }, // no headline → dropped
+        'not an object',
+      ]),
+    );
+    expect(extras).toHaveLength(1);
+    expect(extras[0]!.title).toBe('roast');
+  });
+
+  test('caps the number of slides at 6', () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({ headline: `slide ${i}` }));
+    expect(parseExtras(JSON.stringify(many))).toHaveLength(6);
+  });
+
+  test('caps by code points — never splits a surrogate pair', () => {
+    const emoji = '🎉'.repeat(200); // 400 UTF-16 units, 200 code points
+    const [slide] = parseExtras(JSON.stringify([{ headline: emoji }]));
+    expect([...slide!.headline]).toHaveLength(120);
+    // No lone surrogate at the cut point.
+    expect(/[\uD800-\uDBFF]$/.test(slide!.headline)).toBe(false);
+  });
+});
+
+describe('runWrapped', () => {
+  test('computes a year-scoped, sitting-aware wrapped', async () => {
+    const res = await runWrapped({
+      tz: 'UTC',
+      stdout: true,
+      offline: true,
+      roots,
+      now: NOW,
+      noContent: true,
+    });
+    const data = JSON.parse(res.json);
+
+    expect(data.year).toBe(2026);
+    expect(data.period).toEqual({ from: '2026-01-01', to: '2026-07-13' });
+    // s3 is 2025 — filtered; s1 + s2 remain.
+    expect(data.totals.sessions).toBe(2);
+    expect(data.totals.messages).toBe(5);
+    // Longest sitting is the 20-minute run, not the 3-week session span.
+    expect(data.longestSession.durationMs).toBe(20 * 60_000);
+    expect(data.longestSession.replies).toBe(3);
+    // 03:30 UTC lands in the small-hours census.
+    expect(data.rhythm.nightsPastMidnight).toBe(1);
+    expect(data.rhythm.latestNight.clock).toContain('3:30');
+    // Token rule matches the report: input + output + cacheWrite, cacheRead excluded.
+    expect(data.totals.tokens).toBe(5 * (1000 + 500 + 200));
+    // Per-tool sessions are distinct (s1 spans June 1 + June 22 — aggregate's
+    // sum-of-daily would say 3; the headline total and tools[] must agree).
+    expect(data.tools[0].sessions).toBe(2);
+    expect(data.totals.cacheReadTokens).toBe(5 * 10_000);
+    expect(data.cacheHitRate).toBeCloseTo(10_000 / 11_000, 5);
+    // Model adoption dates observed.
+    const fable = data.models.find((m: { id: string }) => m.id === 'claude-fable-5');
+    expect(fable.firstSeen).toBe('2026-06-03');
+    expect(fable.firstTopDay).toBe('2026-06-03');
+    expect(data.dataBegins).toBe('2026-06-01');
+  });
+
+  test('--year selects a past calendar year in full', async () => {
+    const res = await runWrapped({
+      tz: 'UTC',
+      stdout: true,
+      offline: true,
+      roots,
+      now: NOW,
+      year: 2025,
+      noContent: true,
+    });
+    const data = JSON.parse(res.json);
+    expect(data.period).toEqual({ from: '2025-01-01', to: '2025-12-31' });
+    expect(data.totals.sessions).toBe(1);
+  });
+
+  test('writes self-contained HTML with no external requests and no innerHTML', async () => {
+    const out = join(tmp, 'wrapped.html');
+    const res = await runWrapped({
+      tz: 'UTC',
+      stdout: false,
+      offline: true,
+      roots,
+      now: NOW,
+      out,
+      noContent: true,
+    });
+    expect(res.htmlPath).toBe(out);
+    const html = readFileSync(out, 'utf8');
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('wrapped');
+    expect(html).toContain('2026');
+    expect(html).not.toContain('http://');
+    expect(html).not.toContain('https://');
+    expect(html).not.toContain('innerHTML');
+    // The story spine renders.
+    expect(html).toContain('id="cover"');
+    expect(html).toContain('id="tokens"');
+    expect(html).toContain('id="credits"');
+    // Mid-year runs disclose partial coverage.
+    expect(html).toContain('so far');
+  });
+
+  test('an empty year still renders a page — including any extras', async () => {
+    const extrasPath = join(tmp, 'empty-extras.json');
+    writeFileSync(extrasPath, JSON.stringify([{ headline: 'Even quiet years get a slide' }]));
+    const out = join(tmp, 'empty.html');
+    await runWrapped({
+      tz: 'UTC',
+      stdout: false,
+      offline: true,
+      roots,
+      now: NOW,
+      year: 2020,
+      out,
+      extras: extrasPath,
+      noContent: true,
+    });
+    const html = readFileSync(out, 'utf8');
+    expect(html).toContain('A quiet year');
+    expect(html).not.toContain('id="tokens"');
+    expect(html).toContain('Even quiet years get a slide');
+  });
+
+  test('--extras pointing at a missing file dies cleanly, not with a stack trace', () => {
+    const r = Bun.spawnSync(
+      [
+        'bun',
+        '-e',
+        "require('./src/wrapped/index.ts').runWrapped({tz:'UTC',stdout:true,offline:true,extras:'/nope/missing.json',noContent:true,roots:{claudeCode:'/nope',pi:'/nope',codex:'/nope'}})",
+      ],
+      { cwd: '/Users/nicknisi/Developer/sessions' },
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.toString()).toContain('--extras: cannot read');
+  });
+
+  test('extras are injected as cards', async () => {
+    const extrasPath = join(tmp, 'extras.json');
+    writeFileSync(extrasPath, JSON.stringify([{ headline: 'A bespoke roast', title: 'from your agent' }]));
+    const out = join(tmp, 'extras.html');
+    await runWrapped({
+      tz: 'UTC',
+      stdout: false,
+      offline: true,
+      roots,
+      now: NOW,
+      out,
+      extras: extrasPath,
+      noContent: true,
+    });
+    const html = readFileSync(out, 'utf8');
+    expect(html).toContain('A bespoke roast');
+    expect(html).toContain('id="extra-0"');
+  });
+});

--- a/src/wrapped/index.test.ts
+++ b/src/wrapped/index.test.ts
@@ -60,6 +60,23 @@ describe('parseWrappedArgs', () => {
     expect(o.offline).toBe(true);
   });
 
+  test('parses --roast and --roast-with', () => {
+    expect(parseWrappedArgs(['--roast']).roast).toBe(true);
+    const o = parseWrappedArgs(['--roast-with', 'codex']);
+    expect(o.roast).toBe(true);
+    expect(o.roastWith).toBe('codex');
+  });
+
+  test('rejects a bad --roast-with tool', () => {
+    const r = Bun.spawnSync([
+      'bun',
+      '-e',
+      "require('./src/wrapped/index.ts').parseWrappedArgs(['--roast-with','gemini'])",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.toString()).toContain('--roast-with');
+  });
+
   test('rejects a bad year in a child process', () => {
     const r = Bun.spawnSync(['bun', '-e', "require('./src/wrapped/index.ts').parseWrappedArgs(['--year','20'])"]);
     expect(r.exitCode).toBe(1);
@@ -212,6 +229,44 @@ describe('runWrapped', () => {
     );
     expect(r.exitCode).toBe(1);
     expect(r.stderr.toString()).toContain('--extras: cannot read');
+  });
+
+  test('--roast appends model-authored slides via the injected runner', async () => {
+    const out = join(tmp, 'roasted.html');
+    await runWrapped({
+      tz: 'UTC',
+      stdout: false,
+      offline: true,
+      roots,
+      now: NOW,
+      out,
+      roast: true,
+      roastWith: 'claude',
+      noContent: true,
+      roastRunner: async () => '[{"title":"the verdict","headline":"3 whole sessions. a titan of industry."}]',
+    });
+    const html = readFileSync(out, 'utf8');
+    expect(html).toContain('a titan of industry');
+    expect(html).toContain('improvised by Claude from your stats');
+  });
+
+  test('a failed roast leaves the page intact', async () => {
+    const out = join(tmp, 'roast-fail.html');
+    await runWrapped({
+      tz: 'UTC',
+      stdout: false,
+      offline: true,
+      roots,
+      now: NOW,
+      out,
+      roast: true,
+      roastWith: 'claude',
+      noContent: true,
+      roastRunner: async () => 'the model said no',
+    });
+    const html = readFileSync(out, 'utf8');
+    expect(html).toContain('id="credits"'); // page still renders end to end
+    expect(html).not.toContain('improvised by');
   });
 
   test('extras are injected as cards', async () => {

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -1,0 +1,353 @@
+// `sessions wrapped` — a Spotify-Wrapped-style year in review, rendered as a
+// self-contained HTML story and opened in the browser. Mirrors runReport's
+// sequence (gather → period filter → pricing → aggregate) and layers wrapped-
+// only passes on top: raw-event superlatives (compute.ts), index-backed content
+// stats (content.ts), and dynamic slide selection (select.ts).
+
+import { writeFile, mkdtemp, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ToolId } from '../report/types.ts';
+import { gatherEvents, defaultRoots, type ReportRoots } from '../report/extract.ts';
+import { aggregate } from '../report/aggregate.ts';
+import { drainPricingWarnings, resetPricingWarnings, mergeRuntimePricing } from '../report/pricing.ts';
+import { loadRuntimePricing } from '../report/pricing-cache.ts';
+import { localDate } from '../report/parsers/util.ts';
+import { computeEventStats, longestStreakRange } from './compute.ts';
+import { computeContentStats } from './content.ts';
+import { selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
+import { renderWrappedHtml } from './html.ts';
+import type { WrappedData, WrappedExtra } from './types.ts';
+
+export interface WrappedOptions {
+  year?: number;
+  tool?: ToolId;
+  tz: string;
+  out?: string;
+  stdout: boolean;
+  offline?: boolean;
+  refreshPricing?: boolean;
+  extras?: string;
+  /** Test injection, same convention as report. */
+  roots?: ReportRoots;
+  now?: string;
+  /** Skip the index-backed content pass (tests without an index). */
+  noContent?: boolean;
+}
+
+export interface WrappedResult {
+  htmlPath?: string;
+  json: string;
+}
+
+const TOOL_MAP: Record<string, ToolId> = { claude: 'claude-code', codex: 'codex', pi: 'pi' };
+
+function die(msg: string): never {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(1);
+}
+
+function help(): never {
+  process.stderr.write(`sessions wrapped — your year with AI agents, Spotify-Wrapped style
+
+Generates a scroll-through story page from your local session transcripts:
+tokens, cost, streaks, rhythm, top projects and models, plus fun stats mined
+from what you and your agents actually said. Everything is computed locally.
+
+Usage:
+  sessions wrapped                  This year, opened in your browser
+  sessions wrapped --year 2025      A past calendar year
+  sessions wrapped --out w.html     Write the page to a file instead of opening
+  sessions wrapped --stdout         Print the underlying JSON (no HTML)
+
+Options:
+  --year <YYYY>    Calendar year to wrap (default: current year)
+  --tool <name>    Only one tool: claude, codex, or pi
+  --tz <zone>      Timezone for day/hour bucketing (default: TIMEZONE env or America/Chicago)
+  --extras <path>  JSON file of extra slides: [{"headline": "...", "title"?, "subline"?, "footnote"?}]
+  --out <path>     Write HTML here instead of a temp file (implies no auto-open)
+  --stdout         Print wrapped data as JSON to stdout
+  --offline        Skip the pricing refresh (use cached/embedded rates)
+  --refresh-pricing  Force a pricing refresh even if the cache is fresh
+  -h, --help       Show this help
+`);
+  process.exit(0);
+}
+
+export function parseWrappedArgs(argv: string[]): WrappedOptions {
+  const opts: WrappedOptions = {
+    tz: process.env['TIMEZONE'] ?? 'America/Chicago',
+    stdout: false,
+  };
+  let i = 0;
+  while (i < argv.length) {
+    const a = argv[i]!;
+    switch (a) {
+      case '-h':
+      case '--help':
+        help();
+        break;
+      case '--year': {
+        const v = Number(argv[++i]);
+        if (!Number.isInteger(v) || v < 2000 || v > 2100) die('--year must be a four-digit year');
+        opts.year = v;
+        break;
+      }
+      case '--tool': {
+        const v = argv[++i] ?? '';
+        const mapped = TOOL_MAP[v];
+        if (!mapped) die('--tool must be claude|codex|pi');
+        opts.tool = mapped;
+        break;
+      }
+      case '--tz':
+        opts.tz = argv[++i] ?? opts.tz;
+        break;
+      case '--out':
+        opts.out = argv[++i];
+        break;
+      case '--stdout':
+        opts.stdout = true;
+        break;
+      case '--offline':
+        opts.offline = true;
+        break;
+      case '--refresh-pricing':
+        opts.refreshPricing = true;
+        break;
+      case '--extras':
+        opts.extras = argv[++i];
+        break;
+      default:
+        die(`unknown option: ${a}`);
+    }
+    i++;
+  }
+  return opts;
+}
+
+/** Parse and bound --extras: agent-authored slides are welcome, but the page
+ *  stays in control of shape and size. */
+export function parseExtras(raw: string): WrappedExtra[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    die('--extras file is not valid JSON');
+  }
+  if (!Array.isArray(parsed)) die('--extras must be a JSON array of slides');
+  // Cap by code points, not UTF-16 units — String.slice can split a surrogate
+  // pair and leave a lone half that renders as U+FFFD on the slide.
+  const cap = (s: unknown, n: number): string | undefined => {
+    if (typeof s !== 'string' || s.trim().length === 0) return undefined;
+    return [...s.trim()].slice(0, n).join('');
+  };
+  const out: WrappedExtra[] = [];
+  for (const item of parsed.slice(0, 6)) {
+    if (typeof item !== 'object' || item === null) continue;
+    const o = item as Record<string, unknown>;
+    const headline = cap(o['headline'], 120);
+    if (!headline) continue;
+    out.push({
+      headline,
+      title: cap(o['title'], 60),
+      subline: cap(o['subline'], 200),
+      footnote: cap(o['footnote'], 160),
+    });
+  }
+  return out;
+}
+
+export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
+  const now = opts.now ?? new Date().toISOString();
+  const tz = opts.tz;
+  const todayLocal = localDate(now, tz);
+  const year = opts.year ?? Number(todayLocal.slice(0, 4));
+  const from = `${year}-01-01`;
+  const yearEnd = `${year}-12-31`;
+  const to = todayLocal < yearEnd && todayLocal >= from ? todayLocal : yearEnd;
+
+  const tools = opts.tool ? new Set<ToolId>([opts.tool]) : undefined;
+  const events = await gatherEvents(opts.roots ?? defaultRoots(), tools);
+  const inRange = events.filter((e) => {
+    const d = localDate(e.timestamp, tz);
+    return d >= from && d <= to;
+  });
+  if (inRange.length === 0) {
+    process.stderr.write(`warning: no usage events found for ${year}; the page will be a quiet one\n`);
+  }
+
+  if (!opts.offline) {
+    const live = await loadRuntimePricing({ force: opts.refreshPricing });
+    if (live) mergeRuntimePricing(live);
+  }
+  resetPricingWarnings();
+  const agg = aggregate({ events: inRange, prs: [], now, tz, exclude: new Set<string>(), priorDaily: [] });
+  const warnings = drainPricingWarnings();
+  if (warnings.length > 0) {
+    const models = warnings.map((w) => w.model).join(', ');
+    process.stderr.write(`warning: ${warnings.length} model(s) had no pricing — cost may be understated: ${models}\n`);
+  }
+
+  const ev = computeEventStats(inRange, tz);
+
+  let extras: WrappedExtra[] = [];
+  if (opts.extras) {
+    // Size-check before reading — the per-field caps in parseExtras can't
+    // help if JSON.parse already swallowed a multi-gigabyte file.
+    let size = 0;
+    try {
+      ({ size } = await stat(opts.extras));
+    } catch {
+      die(`--extras: cannot read ${opts.extras}`);
+    }
+    if (size > 256 * 1024) die(`--extras: file too large (${size} bytes; max 256KB)`);
+    let raw: string;
+    try {
+      raw = await readFile(opts.extras, 'utf8');
+    } catch {
+      die(`--extras: cannot read ${opts.extras}`);
+    }
+    extras = parseExtras(raw);
+  }
+
+  // Content pass degrades gracefully: no index (or a broken one) simply means
+  // no fun cards — the dynamic selection treats absence like non-notability.
+  let content = null;
+  let sessionOfYear = null;
+  if (!opts.noContent && inRange.length > 0) {
+    try {
+      const c = await computeContentStats({ from, to, tool: opts.tool });
+      const { sessionOfYear: soy, ...rest } = c;
+      // An index with zero sessions for the period must not feed the fun
+      // cards — a "0 times" joke claiming to be counted from transcripts
+      // that were never indexed is a fabrication.
+      if (rest.indexedSessions > 0) {
+        content = rest;
+        sessionOfYear = soy;
+      }
+    } catch (err) {
+      process.stderr.write(`warning: could not read the search index — skipping conversation stats (${String(err)})\n`);
+    }
+  }
+
+  const totalTokens = agg.summary.totalTokens;
+  // aggregate sorts by cost; the page ranks by tokens — re-sort so bars are
+  // monotone. Session counts come from the event pass (distinct per project),
+  // never aggregate's sum-of-daily, which double-counts cross-midnight sessions.
+  const projects = agg.byProject
+    .slice()
+    .sort((a, b) => b.tokens - a.tokens)
+    .slice(0, 5)
+    .map((p) => ({
+      name: p.label,
+      tokens: p.tokens,
+      costUSD: p.costUSD,
+      sessions: ev.sessionsByProject.get(p.label) ?? p.sessions,
+      share: totalTokens > 0 ? p.tokens / totalTokens : 0,
+    }));
+
+  // aggregate keys byModel by tool|provider|id, so one model reached through
+  // two tools shows up as split rows — merge by model id before ranking.
+  const totalMessages = agg.summary.messages;
+  const byModelId = new Map<string, { id: string; label: string; messages: number; tokens: number }>();
+  for (const m of agg.byModel) {
+    const cur = byModelId.get(m.id);
+    if (cur) {
+      cur.messages += m.messages;
+      cur.tokens += m.tokens;
+    } else {
+      byModelId.set(m.id, { id: m.id, label: m.label, messages: m.messages, tokens: m.tokens });
+    }
+  }
+  const models = [...byModelId.values()]
+    .sort((a, b) => b.messages - a.messages)
+    .slice(0, 5)
+    .map((m) => {
+      const firsts = ev.modelFirsts.get(m.id);
+      return {
+        ...m,
+        share: totalMessages > 0 ? m.messages / totalMessages : 0,
+        firstSeen: firsts?.firstSeen ?? agg.period.from,
+        firstTopDay: firsts?.firstTopDay ?? null,
+      };
+    });
+
+  const toolTokens = agg.byTool.reduce((sum, t) => sum + t.tokens, 0);
+  const toolsOut = agg.byTool.map((t) => ({
+    id: t.id,
+    label: t.label,
+    sessions: ev.sessionsByTool.get(t.id) ?? t.sessions,
+    tokens: t.tokens,
+    share: toolTokens > 0 ? t.tokens / toolTokens : 0,
+  }));
+
+  const daily = agg.daily.map((d) => ({ date: d.date, tokens: d.tokens, messages: d.messages }));
+  const activeDaily = daily.filter((d) => d.messages > 0);
+  let biggestDay: WrappedData['biggestDay'] = null;
+  if (activeDaily.length > 0) {
+    const sorted = activeDaily.map((d) => d.tokens).sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const medianTokens = sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+    const peak = activeDaily.reduce((a, b) => (b.tokens > a.tokens ? b : a));
+    biggestDay = { ...peak, medianTokens };
+  }
+
+  const streak = longestStreakRange(activeDaily.map((d) => d.date));
+
+  const fun = selectFunCards(content, ev.rhythm);
+  const wordOfYear = selectWordOfYear(content);
+  const persona = selectPersona(ev, projects[0]?.share ?? 0, content);
+
+  const dataBegins = activeDaily[0]?.date ?? null;
+
+  const data: WrappedData = {
+    generator: 'sessions',
+    version: 1,
+    generatedAt: now,
+    year,
+    period: { from, to },
+    dataBegins,
+    tz,
+    warnings,
+    totals: {
+      tokens: totalTokens,
+      cacheReadTokens: ev.cacheReadTokens,
+      costUSD: agg.summary.totalCostUSD,
+      sessions: ev.distinctSessions,
+      messages: totalMessages,
+      activeDays: agg.summary.activeDays,
+      longestStreak: streak,
+    },
+    rhythm: ev.rhythm,
+    daily,
+    biggestDay,
+    projects,
+    models,
+    tools: toolsOut,
+    cacheHitRate: ev.cacheHitRate,
+    longestSession: ev.longestSession,
+    sessionOfYear,
+    content,
+    fun,
+    wordOfYear,
+    persona,
+    extras,
+  };
+
+  const json = JSON.stringify(data, null, 2);
+  const result: WrappedResult = { json };
+
+  if (opts.stdout) {
+    // Bun.write awaits the flush; process.stdout.write + the caller's
+    // process.exit(0) truncates piped output at the 64KB pipe buffer.
+    await Bun.write(Bun.stdout, json + '\n');
+    return result;
+  }
+
+  const html = renderWrappedHtml(data);
+  const p = opts.out ?? join(await mkdtemp(join(tmpdir(), 'sessions-wrapped-')), 'wrapped.html');
+  await writeFile(p, html, 'utf8');
+  result.htmlPath = p;
+  return result;
+}

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -17,6 +17,8 @@ import { computeEventStats, longestStreakRange } from './compute.ts';
 import { computeContentStats } from './content.ts';
 import { selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
 import { renderWrappedHtml } from './html.ts';
+import { coerceExtras } from './extras.ts';
+import { runRoast, type RoastRunner, type RoastToolId } from './roast.ts';
 import type { WrappedData, WrappedExtra } from './types.ts';
 
 export interface WrappedOptions {
@@ -28,12 +30,20 @@ export interface WrappedOptions {
   offline?: boolean;
   refreshPricing?: boolean;
   extras?: string;
+  /** Ask an installed agent CLI to write bespoke roast slides from the stats. */
+  roast?: boolean;
+  /** Force a specific roast CLI instead of autodetecting. */
+  roastWith?: RoastToolId;
   /** Test injection, same convention as report. */
   roots?: ReportRoots;
   now?: string;
   /** Skip the index-backed content pass (tests without an index). */
   noContent?: boolean;
+  /** Test injection: stub the roast CLI instead of spawning one. */
+  roastRunner?: RoastRunner;
 }
+
+const ROAST_TOOLS: Record<string, RoastToolId> = { claude: 'claude', codex: 'codex', pi: 'pi' };
 
 export interface WrappedResult {
   htmlPath?: string;
@@ -65,6 +75,10 @@ Options:
   --tool <name>    Only one tool: claude, codex, or pi
   --tz <zone>      Timezone for day/hour bucketing (default: TIMEZONE env or America/Chicago)
   --extras <path>  JSON file of extra slides: [{"headline": "...", "title"?, "subline"?, "footnote"?}]
+  --roast          Let an installed agent CLI (claude/codex/pi) improvise a few
+                   roast slides from your stats — opt-in, needs no setup, and the
+                   page still renders if it fails. Stats only; nothing else is sent.
+  --roast-with <tool>  Force the roast CLI: claude, codex, or pi
   --out <path>     Write HTML here instead of a temp file (implies no auto-open)
   --stdout         Print wrapped data as JSON to stdout
   --offline        Skip the pricing refresh (use cached/embedded rates)
@@ -118,6 +132,17 @@ export function parseWrappedArgs(argv: string[]): WrappedOptions {
       case '--extras':
         opts.extras = argv[++i];
         break;
+      case '--roast':
+        opts.roast = true;
+        break;
+      case '--roast-with': {
+        const v = argv[++i] ?? '';
+        const mapped = ROAST_TOOLS[v];
+        if (!mapped) die('--roast-with must be claude|codex|pi');
+        opts.roast = true;
+        opts.roastWith = mapped;
+        break;
+      }
       default:
         die(`unknown option: ${a}`);
     }
@@ -136,26 +161,7 @@ export function parseExtras(raw: string): WrappedExtra[] {
     die('--extras file is not valid JSON');
   }
   if (!Array.isArray(parsed)) die('--extras must be a JSON array of slides');
-  // Cap by code points, not UTF-16 units — String.slice can split a surrogate
-  // pair and leave a lone half that renders as U+FFFD on the slide.
-  const cap = (s: unknown, n: number): string | undefined => {
-    if (typeof s !== 'string' || s.trim().length === 0) return undefined;
-    return [...s.trim()].slice(0, n).join('');
-  };
-  const out: WrappedExtra[] = [];
-  for (const item of parsed.slice(0, 6)) {
-    if (typeof item !== 'object' || item === null) continue;
-    const o = item as Record<string, unknown>;
-    const headline = cap(o['headline'], 120);
-    if (!headline) continue;
-    out.push({
-      headline,
-      title: cap(o['title'], 60),
-      subline: cap(o['subline'], 200),
-      footnote: cap(o['footnote'], 160),
-    });
-  }
-  return out;
+  return coerceExtras(parsed);
 }
 
 export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
@@ -334,6 +340,14 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
     persona,
     extras,
   };
+
+  // The roast runs last: it needs the finished stats to riff on, and it appends
+  // to whatever --extras already supplied (capped at 6 total). Fail-open — a
+  // missing/failed CLI just leaves the deterministic page untouched.
+  if (opts.roast) {
+    const roasted = await runRoast(data, { preferred: opts.roastWith, runner: opts.roastRunner });
+    if (roasted.length > 0) data.extras = [...data.extras, ...roasted].slice(0, 6);
+  }
 
   const json = JSON.stringify(data, null, 2);
   const result: WrappedResult = { json };

--- a/src/wrapped/roast.test.ts
+++ b/src/wrapped/roast.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect } from 'bun:test';
+import { buildRoastPrompt, extractJsonArray, runRoast, detectRoastTool } from './roast.ts';
+import type { WrappedData } from './types.ts';
+
+const data = {
+  generator: 'sessions',
+  version: 1,
+  generatedAt: '2026-07-13T12:00:00Z',
+  year: 2026,
+  period: { from: '2026-01-01', to: '2026-07-13' },
+  dataBegins: '2026-01-09',
+  tz: 'UTC',
+  warnings: [],
+  totals: {
+    tokens: 656_000_000,
+    cacheReadTokens: 1_000_000,
+    costUSD: 13_427,
+    sessions: 2288,
+    messages: 134_056,
+    activeDays: 163,
+    longestStreak: { days: 54, from: '2026-03-02', to: '2026-04-24' },
+  },
+  rhythm: { heat: [], peakHour: 10, peakWeekday: 4, nightsPastMidnight: 13, latestNight: null },
+  daily: [],
+  biggestDay: null,
+  projects: [{ name: 'cli', tokens: 1, costUSD: 1, sessions: 1, share: 0.24 }],
+  models: [
+    {
+      id: 'claude-opus-4-8',
+      label: 'claude-opus-4-8',
+      messages: 1,
+      tokens: 1,
+      share: 1,
+      firstSeen: '2026-05-28',
+      firstTopDay: '2026-05-28',
+    },
+  ],
+  tools: [],
+  cacheHitRate: 0.99,
+  longestSession: null,
+  sessionOfYear: {
+    title: 'secret internal prompt text',
+    project: 'cli',
+    date: '2026-06-25',
+    messageCount: 4384,
+    filesTouched: 50,
+    shipped: true,
+  },
+  content: {
+    indexedSessions: 3939,
+    phrases: [{ id: 'interrupts', count: 524, role: 'user' }],
+    monologue: null,
+    driveBys: { count: 2047, total: 3935 },
+    abandoned: { name: 'ClaudeProbe', sessions: 990, lastSeen: '2026-03-07' },
+    errors: { sessionsErrored: 1, totalErrors: 5571, cursedWeekday: 2, cursedCount: 2038 },
+    topFiles: [],
+    topCommands: [{ name: 'git diff', sessions: 365 }],
+    words: [],
+    depthMedian: 93,
+  },
+  fun: [],
+  wordOfYear: { word: 'workos', count: 7516, sessions: 1038, runnersUp: [] },
+  persona: {
+    name: 'The Systems Gardener',
+    tagline: 't',
+    axes: [{ label: 'clock', value: '6%', lean: 'daylight' }],
+    flavor: null,
+  },
+  extras: [],
+} as unknown as WrappedData;
+
+describe('buildRoastPrompt', () => {
+  test('includes stats but never raw transcript text', () => {
+    const p = buildRoastPrompt(data);
+    expect(p).toContain('656000000'); // tokens
+    expect(p).toContain('workos'); // word of the year (aggregate)
+    expect(p).toContain('JSON array'); // schema instruction
+    // The session-of-the-year *title* is free text — it must not be sent.
+    expect(p).not.toContain('secret internal prompt text');
+  });
+});
+
+describe('extractJsonArray', () => {
+  test('pulls an array out of prose', () => {
+    expect(extractJsonArray('Sure! Here you go:\n[{"headline":"hi"}]\nEnjoy')).toEqual([{ headline: 'hi' }]);
+  });
+  test('handles a ```json fence', () => {
+    expect(extractJsonArray('```json\n[{"headline":"hi"}]\n```')).toEqual([{ headline: 'hi' }]);
+  });
+  test('returns null on garbage', () => {
+    expect(extractJsonArray('no json here')).toBeNull();
+    expect(extractJsonArray('[not valid')).toBeNull();
+  });
+});
+
+describe('runRoast', () => {
+  const runner = (out: string) => async () => out;
+
+  test('validates model output and stamps provenance on every slide', async () => {
+    const slides = await runRoast(data, {
+      preferred: 'claude',
+      runner: runner(
+        '[{"title":"ouch","headline":"$13,427 and you still say please","footnote":"model tried to lie here"}]',
+      ),
+      log: () => {},
+    });
+    expect(slides).toHaveLength(1);
+    expect(slides[0]!.headline).toContain('$13,427');
+    // The model's own footnote is overridden — provenance is guaranteed.
+    expect(slides[0]!.footnote).toBe('improvised by Claude from your stats');
+  });
+
+  test('fails open on unparseable output', async () => {
+    const warnings: string[] = [];
+    const slides = await runRoast(data, {
+      preferred: 'claude',
+      runner: runner('I refuse'),
+      log: (m) => warnings.push(m),
+    });
+    expect(slides).toEqual([]);
+    expect(warnings.some((w) => w.includes('nothing usable'))).toBe(true);
+  });
+
+  test('fails open when the runner throws', async () => {
+    const slides = await runRoast(data, {
+      preferred: 'claude',
+      runner: async () => {
+        throw new Error('spawn failed');
+      },
+      log: () => {},
+    });
+    expect(slides).toEqual([]);
+  });
+
+  test('caps at the shared 6-slide limit', async () => {
+    const many = JSON.stringify(Array.from({ length: 10 }, (_, i) => ({ headline: `roast ${i}` })));
+    const slides = await runRoast(data, { preferred: 'claude', runner: runner(many), log: () => {} });
+    expect(slides).toHaveLength(6);
+  });
+});
+
+describe('detectRoastTool', () => {
+  test('preferred tool that is not installed yields null, not a fallback', () => {
+    // 'pi' is very unlikely to be on the test PATH; a preferred-but-absent tool
+    // must not silently fall back to claude/codex.
+    const tool = detectRoastTool('pi');
+    if (tool) expect(tool.id).toBe('pi');
+  });
+});

--- a/src/wrapped/roast.ts
+++ b/src/wrapped/roast.ts
@@ -1,0 +1,148 @@
+// The --roast path: ask an installed agent CLI to write a few bespoke roast
+// slides from the already-computed stats, then run its output through the same
+// validation as --extras. This is the one non-deterministic, model-authored
+// seam in wrapped — deliberately opt-in, deliberately fail-open (any failure
+// drops the roast and the page still renders), and deliberately fed STATS ONLY
+// (no raw message text), with every slide stamped as model-authored so it can
+// never impersonate a computed stat (the "Pink Pilates Princess" lesson).
+
+import type { WrappedData, WrappedExtra } from './types.ts';
+import { coerceExtras } from './extras.ts';
+
+export type RoastToolId = 'claude' | 'codex' | 'pi';
+
+interface RoastTool {
+  id: RoastToolId;
+  label: string;
+  bin: string;
+  /** argv (after bin) that runs the CLI non-interactively with `prompt`. */
+  args: (prompt: string) => string[];
+}
+
+// Preference order when --roast-with isn't given: Claude first (best taste for
+// this), then Codex, then Pi. Each runs its own headless/exec mode.
+const ROAST_TOOLS: RoastTool[] = [
+  { id: 'claude', label: 'Claude', bin: 'claude', args: (p) => ['-p', p] },
+  { id: 'codex', label: 'Codex', bin: 'codex', args: (p) => ['exec', p] },
+  { id: 'pi', label: 'Pi', bin: 'pi', args: (p) => ['-p', p] },
+];
+
+/** First installed roast tool (honoring `preferred`), or null if none on PATH. */
+export function detectRoastTool(preferred?: RoastToolId): RoastTool | null {
+  const ordered = preferred ? [...ROAST_TOOLS].sort((a) => (a.id === preferred ? -1 : 1)) : ROAST_TOOLS;
+  for (const t of ordered) {
+    if (preferred && t.id !== preferred) continue;
+    if (Bun.which(t.bin)) return t;
+  }
+  return null;
+}
+
+// A compact, STATS-ONLY digest — counts, names, and already-computed stats that
+// already appear on the page. Deliberately excludes free-text (session titles,
+// message snippets): the model gets numbers to riff on, never transcript prose.
+function roastDigest(d: WrappedData): Record<string, unknown> {
+  return {
+    year: d.year,
+    tokens: d.totals.tokens,
+    costUSD: Math.round(d.totals.costUSD),
+    sessions: d.totals.sessions,
+    activeDays: d.totals.activeDays,
+    longestStreakDays: d.totals.longestStreak?.days ?? 0,
+    peakHour: d.rhythm.peakHour,
+    nightsPastMidnight: d.rhythm.nightsPastMidnight,
+    topProjects: d.projects.map((p) => ({ name: p.name, sharePct: Math.round(p.share * 100) })),
+    topModels: d.models.map((m) => m.label),
+    persona: d.persona ? { name: d.persona.name, axes: d.persona.axes.map((a) => `${a.label}: ${a.lean}`) } : null,
+    wordOfYear: d.wordOfYear ? { word: d.wordOfYear.word, count: d.wordOfYear.count } : null,
+    phraseCounts: Object.fromEntries((d.content?.phrases ?? []).map((p) => [p.id, p.count])),
+    driveBySessions: d.content?.driveBys?.count ?? null,
+    abandonedProject: d.content?.abandoned ? d.content.abandoned.name : null,
+    errors: d.content?.errors?.totalErrors ?? null,
+    topCommands: (d.content?.topCommands ?? []).map((c) => c.name),
+  };
+}
+
+export function buildRoastPrompt(d: WrappedData): string {
+  const digest = JSON.stringify(roastDigest(d), null, 2);
+  return `You are the closer at a roast battle, and the target is someone's year of using AI coding agents. Below are their stats (numbers only — no message content).
+
+Write 2-4 short, EDGY roast slides. Be genuinely cutting — sharp, dark, deadpan, a little mean. Land real punches at the absurdity in their numbers; twist the knife. Dry wit and savage one-liners over gentle ribbing. Mild profanity is fine if it lands. The one rule: roast their WORK and these HABITS (the numbers), never protected traits or anything hateful — this is affectionate underneath, like a friend who knows exactly where it hurts. Reference specific figures. No emoji.
+
+Output ONLY a JSON array, no prose around it, matching exactly this schema:
+[{"title": "short kicker, <=6 words", "headline": "the punchline, <=110 chars", "subline": "optional extra line, <=180 chars"}]
+
+Their stats:
+${digest}`;
+}
+
+/** Extract the first JSON array from CLI output (which may wrap it in prose or
+ *  a ```json fence). Greedy to the last ] so nested objects survive. */
+export function extractJsonArray(out: string): unknown {
+  const stripped = out.replace(/```json/gi, '').replace(/```/g, '');
+  const start = stripped.indexOf('[');
+  const end = stripped.lastIndexOf(']');
+  if (start < 0 || end <= start) return null;
+  try {
+    return JSON.parse(stripped.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+export type RoastRunner = (tool: RoastTool, prompt: string, timeoutMs: number) => Promise<string>;
+
+// Default runner: spawn the CLI, capture stdout, hard-kill on timeout. The child
+// rides the user's own auth/subscription — wrapped never handles credentials.
+const spawnRunner: RoastRunner = async (tool, prompt, timeoutMs) => {
+  const proc = Bun.spawn([tool.bin, ...tool.args(prompt)], { stdout: 'pipe', stderr: 'ignore', stdin: 'ignore' });
+  const timer = setTimeout(() => proc.kill(), timeoutMs);
+  try {
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    return out;
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export interface RoastOptions {
+  preferred?: RoastToolId;
+  timeoutMs?: number;
+  runner?: RoastRunner;
+  /** Sink for the one-line status/warning; defaults to stderr. */
+  log?: (msg: string) => void;
+}
+
+/** Generate roast slides, or [] on any failure (no tool, timeout, unparseable
+ *  output). Never throws — the roast is sugar, the page must survive without it. */
+export async function runRoast(d: WrappedData, opts: RoastOptions = {}): Promise<WrappedExtra[]> {
+  const log = opts.log ?? ((m: string) => process.stderr.write(m + '\n'));
+  const tool = detectRoastTool(opts.preferred);
+  if (!tool) {
+    log(
+      opts.preferred
+        ? `warning: --roast-with ${opts.preferred}: '${opts.preferred}' not found on PATH; skipping roast`
+        : 'warning: --roast: no agent CLI (claude, codex, pi) found on PATH; skipping roast',
+    );
+    return [];
+  }
+
+  log(`roasting your year with ${tool.label}… (this calls ${tool.bin}; may take a moment)`);
+  const runner = opts.runner ?? spawnRunner;
+  let out: string;
+  try {
+    out = await runner(tool, buildRoastPrompt(d), opts.timeoutMs ?? 120_000);
+  } catch {
+    log(`warning: --roast: ${tool.label} failed to run; skipping roast`);
+    return [];
+  }
+
+  const slides = coerceExtras(extractJsonArray(out));
+  if (slides.length === 0) {
+    log(`warning: --roast: ${tool.label} returned nothing usable; skipping roast`);
+    return [];
+  }
+  // Force the provenance footnote on every slide so a model-written line can
+  // never read as a counted stat, regardless of what the model returned.
+  return slides.map((s) => ({ ...s, footnote: `improvised by ${tool.label} from your stats` }));
+}

--- a/src/wrapped/select.test.ts
+++ b/src/wrapped/select.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect } from 'bun:test';
+import { buildCandidates, selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
+import { tokenEquivalence, prettyModel } from './html.ts';
+import { cleanTitle, commandFamily, mineWords } from './content.ts';
+import type { WrappedContentStats, WrappedRhythm } from './types.ts';
+import type { WrappedEventStats } from './compute.ts';
+
+const quietRhythm: WrappedRhythm = {
+  heat: Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0)),
+  peakHour: 10,
+  peakWeekday: 2,
+  nightsPastMidnight: 0,
+  latestNight: null,
+};
+
+function contentWith(phrases: Record<string, number>, over: Partial<WrappedContentStats> = {}): WrappedContentStats {
+  return {
+    indexedSessions: 100,
+    phrases: Object.entries(phrases).map(([id, count]) => ({
+      id,
+      count,
+      role: id === 'absolutelyRight' || id === 'assistantApology' ? 'assistant' : 'user',
+    })),
+    monologue: null,
+    driveBys: null,
+    abandoned: null,
+    errors: null,
+    topFiles: [],
+    topCommands: [],
+    words: [],
+    depthMedian: 50,
+    ...over,
+  };
+}
+
+function eventsWith(over: Partial<WrappedEventStats> = {}): WrappedEventStats {
+  return {
+    distinctSessions: 100,
+    rhythm: quietRhythm,
+    cacheReadTokens: 0,
+    cacheHitRate: null,
+    longestSession: null,
+    medianReplies: 10,
+    sessionsByTool: new Map(),
+    sessionsByProject: new Map(),
+    modelFirsts: new Map(),
+    nightShare: 0.05,
+    ...over,
+  };
+}
+
+describe('dynamic selection', () => {
+  test('no content and a quiet rhythm → no fun cards at all', () => {
+    expect(selectFunCards(null, quietRhythm)).toEqual([]);
+  });
+
+  test('zero-count stats never render as filler', () => {
+    const content = contentWith({ interrupts: 0, actually: 0, swears: 0, please: 0, thanks: 0 });
+    const cards = selectFunCards(content, quietRhythm);
+    // Only the "absolutely right" zero-joke is allowed to exist, and at score
+    // 0.45 it stays below the 0.4-lead… no: 0.45 ≥ 0.4, it may lead a card.
+    for (const card of cards) {
+      for (const stat of card.stats) {
+        if (stat.big === '0') expect(stat.label).toContain('absolutely right');
+      }
+    }
+  });
+
+  test('a night owl gets the night slide; a daylight coder never does', () => {
+    const nightRhythm: WrappedRhythm = {
+      ...quietRhythm,
+      nightsPastMidnight: 40,
+      latestNight: { date: '2026-03-03', clock: '3:47 AM', weekday: 3 },
+    };
+    const owl = buildCandidates(null, nightRhythm);
+    expect(owl.some((c) => c.stat.label.includes('past midnight'))).toBe(true);
+    const daylight = buildCandidates(null, quietRhythm);
+    expect(daylight.some((c) => c.stat.label.includes('past midnight'))).toBe(false);
+  });
+
+  test('bigger behavior scores higher', () => {
+    const mild = buildCandidates(contentWith({ interrupts: 10 }), quietRhythm);
+    const wild = buildCandidates(contentWith({ interrupts: 500 }), quietRhythm);
+    const score = (cs: ReturnType<typeof buildCandidates>) =>
+      cs.find((c) => c.stat.label.includes('cut Claude off'))!.score;
+    expect(score(wild)).toBeGreaterThan(score(mild));
+  });
+
+  test('apology scoreboard flips its punchline from the data', () => {
+    const humanSorry = buildCandidates(contentWith({ userSorry: 20, assistantApology: 5 }), quietRhythm);
+    const sb = humanSorry.find((c) => c.stat.label.includes('apology scoreboard'))!;
+    expect(sb.stat.sub).toContain('you apologized to the robot');
+    const aiSorry = buildCandidates(contentWith({ userSorry: 2, assistantApology: 20 }), quietRhythm);
+    const sb2 = aiSorry.find((c) => c.stat.label.includes('apology scoreboard'))!;
+    expect(sb2.stat.sub).not.toContain('you apologized to the robot');
+  });
+});
+
+describe('selectWordOfYear', () => {
+  test('requires spread, not just volume', () => {
+    expect(selectWordOfYear(contentWith({}, { words: [{ word: 'gnarly', count: 100, sessions: 3 }] }))).toBeNull();
+    const w = selectWordOfYear(
+      contentWith(
+        {},
+        {
+          words: [
+            { word: 'gnarly', count: 100, sessions: 30 },
+            { word: 'vibes', count: 40, sessions: 12 },
+          ],
+        },
+      ),
+    );
+    expect(w?.word).toBe('gnarly');
+    expect(w?.runnersUp).toEqual(['vibes']);
+  });
+});
+
+describe('selectPersona', () => {
+  test('too little behavior → no persona rather than a fake one', () => {
+    expect(selectPersona(eventsWith({ distinctSessions: 5 }), 0.5, null)).toBeNull();
+  });
+
+  test('axes combine into the right archetype', () => {
+    const p = selectPersona(eventsWith({ nightShare: 0.4 }), 0.6, contentWith({}, { depthMedian: 90 }));
+    expect(p?.name).toBe('The Midnight Machinist');
+    const q = selectPersona(eventsWith({ nightShare: 0.02 }), 0.1, contentWith({}, { depthMedian: 5 }));
+    expect(q?.name).toBe('The Rapid Prototyper');
+  });
+
+  test('evidence values are printed on the card', () => {
+    const p = selectPersona(eventsWith({ nightShare: 0.31 }), 0.42, contentWith({}, { depthMedian: 93 }));
+    expect(p?.axes.map((a) => a.value)).toEqual(['31% after dark', '42% one project', '93 turns per real session']);
+  });
+});
+
+describe('display helpers', () => {
+  test('tokenEquivalence picks a human scale', () => {
+    expect(tokenEquivalence(500)).toBeNull();
+    expect(tokenEquivalence(2_000_000)).toContain('War and Peace');
+    expect(tokenEquivalence(700_000_000)).toContain('Harry Potter');
+    expect(tokenEquivalence(20_000_000_000)).toContain('Wikipedia');
+  });
+
+  test('prettyModel prettifies known families and leaves the rest alone', () => {
+    expect(prettyModel('claude-opus-4-8')).toBe('Opus 4.8');
+    expect(prettyModel('claude-haiku-4-5-20251001')).toBe('Haiku 4.5');
+    expect(prettyModel('claude-fable-5')).toBe('Fable 5');
+    expect(prettyModel('gpt-5.5-codex')).toBe('GPT-5.5-codex');
+    expect(prettyModel('mystery-model-9')).toBe('mystery-model-9');
+    // A date suffix is not a minor version — never invent "Opus 4.20250514".
+    expect(prettyModel('claude-opus-4-20250514')).toBe('Opus 4');
+    expect(prettyModel('claude-sonnet-4-20250514')).toBe('Sonnet 4');
+  });
+
+  test('cleanTitle strips markdown noise and truncates', () => {
+    expect(cleanTitle('Read this: # Workflow: **Status:** ✅ done')).toBe('Read this: Workflow: Status: done');
+    expect(cleanTitle('x'.repeat(200)).length).toBeLessThanOrEqual(73);
+    expect(cleanTitle('   ')).toBe('untitled');
+  });
+
+  test('commandFamily groups by first two meaningful tokens', () => {
+    expect(commandFamily('git status -sb')).toBe('git status');
+    expect(commandFamily('git -C /tmp status')).toBe('git');
+    expect(commandFamily('bun test')).toBe('bun test');
+    expect(commandFamily('ls')).toBe('ls');
+  });
+
+  test('mineWords skips stopwords, code, and single-session obsessions', () => {
+    const texts = [
+      ...Array.from({ length: 12 }, (_, i) => ({ text: 'the gnarly function should work', file: `f${i}` })),
+      { text: '```\ngnarlyinternal secret\n```', file: 'f0' },
+      ...Array.from({ length: 15 }, () => ({ text: 'once more: gadget gadget', file: 'one-file' })),
+    ];
+    const words = mineWords(texts, 5);
+    expect(words[0]?.word).toBe('gnarly');
+    // "function"/"should"/"work" are stopworded; "gadget" is confined to one session.
+    expect(words.some((w) => w.word === 'function')).toBe(false);
+    expect(words.some((w) => w.word === 'gadget')).toBe(false);
+  });
+});

--- a/src/wrapped/select.ts
+++ b/src/wrapped/select.ts
@@ -1,0 +1,303 @@
+// Dynamic slide selection — the mechanism that makes wrapped personal. Every
+// fun stat is a scored candidate; only notable ones render, grouped into themed
+// cards. A user who never codes at 3 AM never sees a 3 AM slide, and an empty
+// index simply yields no fun cards — graceful degradation and personalization
+// are the same mechanism.
+
+import type { FunCard, FunStat, PhraseStat, WrappedContentStats, WrappedPersona, WrappedRhythm } from './types.ts';
+import type { WrappedEventStats } from './compute.ts';
+
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const fmtInt = (n: number): string => n.toLocaleString('en-US');
+
+interface Candidate {
+  theme: 'friction' | 'relationship' | 'bloopers';
+  score: number;
+  stat: FunStat;
+}
+
+function phrase(phrases: PhraseStat[], id: string): number {
+  return phrases.find((p) => p.id === id)?.count ?? 0;
+}
+
+/** Saturating notability: 0 at zero, ~0.63 at `mid`, →1 asymptotically. */
+function sat(count: number, mid: number): number {
+  return count <= 0 ? 0 : 1 - Math.exp(-count / mid);
+}
+
+export function buildCandidates(content: WrappedContentStats | null, rhythm: WrappedRhythm): Candidate[] {
+  const out: Candidate[] = [];
+  const p = content?.phrases ?? [];
+
+  // — friction —
+  const interrupts = phrase(p, 'interrupts');
+  if (interrupts > 0) {
+    out.push({
+      theme: 'friction',
+      score: 0.15 + 0.8 * sat(interrupts, 150),
+      stat: { big: fmtInt(interrupts), label: 'times you cut Claude off mid-task', sub: 'the Escape key remembers' },
+    });
+  }
+  if (content?.errors && content.errors.totalErrors > 0) {
+    const e = content.errors;
+    out.push({
+      theme: 'friction',
+      score: 0.1 + 0.75 * sat(e.totalErrors, 800),
+      stat: {
+        big: fmtInt(e.totalErrors),
+        label: 'errors weathered together',
+        sub:
+          e.cursedWeekday !== null
+            ? `${WEEKDAYS[e.cursedWeekday]} was your most cursed day (${fmtInt(e.cursedCount)} of them)`
+            : undefined,
+      },
+    });
+  }
+  const actually = phrase(p, 'actually');
+  if (actually >= 10) {
+    const tryAgain = phrase(p, 'tryAgain');
+    out.push({
+      theme: 'friction',
+      score: 0.1 + 0.7 * sat(actually, 200),
+      stat: {
+        big: fmtInt(actually),
+        label: 'prompts began with a change of heart — "actually…"',
+        sub: tryAgain > 0 ? `plus ${fmtInt(tryAgain)} rounds of "try again"` : undefined,
+      },
+    });
+  }
+  const swears = phrase(p, 'swears');
+  if (swears >= 5) {
+    out.push({
+      theme: 'friction',
+      score: 0.2 + 0.6 * sat(swears, 60),
+      stat: {
+        big: fmtInt(swears),
+        label: 'prompts contained… strong feedback',
+        sub: 'we counted so you don’t have to',
+      },
+    });
+  }
+
+  // — relationship —
+  // Base score is deliberately high: this is the pre-validated crowd-pleaser
+  // of the Claude-wrapped genre, and the joke works at any count — including 3.
+  const absolutely = phrase(p, 'absolutelyRight');
+  if (content) {
+    out.push({
+      theme: 'relationship',
+      score: absolutely > 0 ? 0.62 + 0.33 * sat(absolutely, 40) : 0.45,
+      stat:
+        absolutely > 0
+          ? {
+              big: fmtInt(absolutely),
+              label: 'times Claude said "you’re absolutely right"',
+              sub: 'you were, presumably',
+            }
+          : { big: '0', label: 'times Claude said "you’re absolutely right"', sub: 'who’s training whom?' },
+    });
+  }
+  const userSorry = phrase(p, 'userSorry');
+  const aiSorry = phrase(p, 'assistantApology');
+  if (userSorry + aiSorry >= 5) {
+    const flip = userSorry > aiSorry;
+    out.push({
+      theme: 'relationship',
+      score: 0.25 + 0.55 * sat(userSorry + aiSorry, 40) + (flip ? 0.1 : 0),
+      stat: {
+        big: `${fmtInt(userSorry)}–${fmtInt(aiSorry)}`,
+        label: 'the apology scoreboard, you vs. Claude',
+        sub: flip ? 'you apologized to the robot more than it apologized to you' : 'at least it knows when it’s wrong',
+      },
+    });
+  }
+  const please = phrase(p, 'please');
+  const thanks = phrase(p, 'thanks');
+  if (please + thanks >= 20) {
+    out.push({
+      theme: 'relationship',
+      score: 0.2 + 0.5 * sat(please + thanks, 250),
+      stat: {
+        big: fmtInt(please),
+        label: 'prompts said "please"',
+        sub: `and ${fmtInt(thanks)} said thanks — manners cost nothing`,
+      },
+    });
+  }
+  if (content?.monologue && content.monologue.assistantAvg > 0) {
+    const m = content.monologue;
+    const youTalkMore = m.userAvg > m.assistantAvg;
+    out.push({
+      theme: 'relationship',
+      score: 0.55,
+      stat: {
+        big: `${fmtInt(m.userAvg)} vs ${fmtInt(m.assistantAvg)}`,
+        label: 'characters per message — you vs. Claude',
+        sub: youTalkMore ? 'plot twist: you’re the chatty one (pastes count)' : 'Claude does love a thorough answer',
+      },
+    });
+  }
+
+  // — bloopers —
+  if (rhythm.nightsPastMidnight >= 5 && rhythm.latestNight) {
+    out.push({
+      theme: 'bloopers',
+      score: 0.2 + 0.75 * sat(rhythm.nightsPastMidnight, 30),
+      stat: {
+        big: fmtInt(rhythm.nightsPastMidnight),
+        label: 'nights you coded past midnight',
+        sub: `latest sign-off: ${rhythm.latestNight.clock} on a ${WEEKDAYS[rhythm.latestNight.weekday]}`,
+      },
+    });
+  }
+  if (content?.driveBys && content.driveBys.count >= 20 && content.driveBys.count / content.driveBys.total >= 0.15) {
+    out.push({
+      theme: 'bloopers',
+      score: 0.2 + 0.6 * sat(content.driveBys.count, 800),
+      stat: {
+        big: fmtInt(content.driveBys.count),
+        label: 'drive-by sessions: one question, answer, gone',
+        sub: 'the world’s most expensive search engine',
+      },
+    });
+  }
+  if (content?.abandoned) {
+    out.push({
+      theme: 'bloopers',
+      score: 0.3 + 0.4 * sat(content.abandoned.sessions, 30),
+      stat: {
+        big: content.abandoned.name,
+        label: `${fmtInt(content.abandoned.sessions)} sessions of love, then silence since ${content.abandoned.lastSeen}`,
+        sub: 'paused, not dead. definitely paused.',
+      },
+    });
+  }
+  const ultrathink = phrase(p, 'ultrathink');
+  if (ultrathink >= 3) {
+    out.push({
+      theme: 'bloopers',
+      score: 0.45 + 0.4 * sat(ultrathink, 15),
+      stat: { big: fmtInt(ultrathink), label: 'invocations of "ultrathink"', sub: 'it thought ultra hard' },
+    });
+  }
+
+  return out;
+}
+
+const THEME_META: Record<Candidate['theme'], { kicker: string; title: string }> = {
+  friction: { kicker: 'the friction reel', title: 'It wasn’t always pretty.' },
+  relationship: { kicker: 'the relationship', title: 'You two have a dynamic.' },
+  bloopers: { kicker: 'the bloopers', title: 'And then there’s… this.' },
+};
+
+const FOOTNOTES: Record<Candidate['theme'], string> = {
+  friction:
+    'errors include any failed command or grep — friction, not disasters · cursed day by session start date (UTC)',
+  relationship: 'counted from your local transcripts — messages containing each phrase',
+  bloopers: 'local timestamps, your timezone',
+};
+
+/** Assemble themed cards from the highest-scoring candidates. A card renders
+ *  only when its lead stat clears the bar — thresholds, not quotas. */
+export function selectFunCards(content: WrappedContentStats | null, rhythm: WrappedRhythm): FunCard[] {
+  const candidates = buildCandidates(content, rhythm);
+  const cards: FunCard[] = [];
+  for (const theme of ['friction', 'relationship', 'bloopers'] as const) {
+    const pool = candidates
+      .filter((c) => c.theme === theme && c.score >= 0.3)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 3);
+    const lead = pool[0];
+    if (!lead || lead.score < 0.4) continue;
+    cards.push({
+      id: theme,
+      kicker: THEME_META[theme].kicker,
+      title: THEME_META[theme].title,
+      stats: pool.map((c) => c.stat),
+      footnote: FOOTNOTES[theme],
+      score: lead.score,
+    });
+  }
+  return cards;
+}
+
+export function selectWordOfYear(
+  content: WrappedContentStats | null,
+): { word: string; count: number; sessions: number; runnersUp: string[] } | null {
+  const words = content?.words ?? [];
+  const top = words[0];
+  if (!top || top.count < 25 || top.sessions < 8) return null;
+  return { ...top, runnersUp: words.slice(1, 4).map((w) => w.word) };
+}
+
+// Persona: three median-split behavioral axes → eight archetypes, every one a
+// compliment (the Spotify Listening Personality recipe). The axis evidence is
+// printed on the card so the label never reads as hallucinated.
+const NIGHT_THRESHOLD = 0.25;
+const FOCUS_THRESHOLD = 0.4;
+const DEPTH_THRESHOLD = 40; // raw indexed message_count median (tool turns included)
+
+const ARCHETYPES: Record<string, { name: string; tagline: string }> = {
+  'night|focus|deep': { name: 'The Midnight Machinist', tagline: 'One project, zero daylight, total immersion.' },
+  'night|focus|quick': { name: 'The Nocturnal Sniper', tagline: 'In after dark, one clean shot, out.' },
+  'night|multi|deep': { name: 'The Moonlit Cartographer', tagline: 'Mapping every repo while the world sleeps.' },
+  'night|multi|quick': { name: 'The 3 AM Tinkerer', tagline: 'No project is safe from a small-hours "what if".' },
+  'day|focus|deep': { name: 'The Deep-Work Artisan', tagline: 'Long sessions, one obsession, real craft.' },
+  'day|focus|quick': { name: 'The Surgical Striker', tagline: 'Precise questions, fast exits, ruthless focus.' },
+  'day|multi|deep': { name: 'The Systems Gardener', tagline: 'Tending a dozen codebases until they all bloom.' },
+  'day|multi|quick': { name: 'The Rapid Prototyper', tagline: 'A hundred sparks a week — some catch fire.' },
+};
+
+export function selectPersona(
+  events: WrappedEventStats,
+  topProjectShare: number,
+  content: WrappedContentStats | null,
+): WrappedPersona | null {
+  if (events.distinctSessions < 10) return null; // too little behavior to name
+
+  const night = events.nightShare;
+  const depth = content?.depthMedian ?? null;
+  const deep = depth !== null ? depth >= DEPTH_THRESHOLD : events.medianReplies >= 20;
+  const key = [
+    night >= NIGHT_THRESHOLD ? 'night' : 'day',
+    topProjectShare >= FOCUS_THRESHOLD ? 'focus' : 'multi',
+    deep ? 'deep' : 'quick',
+  ].join('|');
+  const archetype = ARCHETYPES[key]!;
+
+  const interrupts = phrase(content?.phrases ?? [], 'interrupts');
+  const interruptRate = content && content.indexedSessions > 0 ? interrupts / content.indexedSessions : 0;
+  const flavor =
+    interruptRate >= 0.2
+      ? 'trust style: hands on the wheel — you interrupt and steer'
+      : interruptRate > 0
+        ? 'trust style: delegator — you mostly let it cook'
+        : null;
+
+  return {
+    name: archetype.name,
+    tagline: archetype.tagline,
+    axes: [
+      {
+        label: 'clock',
+        value: `${Math.round(night * 100)}% after dark`,
+        lean: night >= NIGHT_THRESHOLD ? 'night owl' : 'daylight',
+      },
+      {
+        label: 'focus',
+        value: `${Math.round(topProjectShare * 100)}% one project`,
+        lean: topProjectShare >= FOCUS_THRESHOLD ? 'devoted' : 'explorer',
+      },
+      {
+        label: 'depth',
+        value:
+          depth !== null
+            ? `${Math.round(depth)} turns per real session`
+            : `${Math.round(events.medianReplies)} replies per session`,
+        lean: deep ? 'marathoner' : 'sprinter',
+      },
+    ],
+    flavor,
+  };
+}

--- a/src/wrapped/types.ts
+++ b/src/wrapped/types.ts
@@ -1,0 +1,172 @@
+// Data contract for `sessions wrapped` — a Spotify-Wrapped-style year in review.
+// Assembled from two sources with different truths: the report pipeline's raw
+// UsageEvent[] (full timestamps: durations, rhythm, model adoption) and the
+// search index (message content: phrase censuses, mined vocabulary). Each stat
+// notes its source so the two never silently disagree.
+
+import type { ToolId } from '../report/types.ts';
+import type { PricingWarning } from '../report/schema.ts';
+
+export interface WrappedTotals {
+  /** input + output + cacheWrite — same rule as `sessions report` (cacheRead excluded). */
+  tokens: number;
+  cacheReadTokens: number;
+  costUSD: number;
+  /** Distinct `${tool}|${sessionId}` over raw events — no cross-midnight double count. */
+  sessions: number;
+  messages: number;
+  activeDays: number;
+  longestStreak: { days: number; from: string; to: string } | null;
+}
+
+export interface WrappedRhythm {
+  /** [weekday 0=Sun][hour 0-23] message counts, local tz. */
+  heat: number[][];
+  peakHour: number;
+  peakWeekday: number;
+  /** Distinct local dates with any event in hours 0-4. */
+  nightsPastMidnight: number;
+  /** The latest small-hours moment of the year (closest to 5 AM). */
+  latestNight: { date: string; clock: string; weekday: number } | null;
+}
+
+export interface WrappedDay {
+  date: string;
+  tokens: number;
+  messages: number;
+}
+
+export interface WrappedProject {
+  name: string;
+  tokens: number;
+  costUSD: number;
+  sessions: number;
+  /** Share of total tokens, 0-1. */
+  share: number;
+}
+
+export interface WrappedModel {
+  id: string;
+  label: string;
+  messages: number;
+  tokens: number;
+  /** Share of total messages, 0-1. */
+  share: number;
+  firstSeen: string;
+  /** First local date this model was the day's most-used — the adoption story. */
+  firstTopDay: string | null;
+}
+
+export interface WrappedTool {
+  id: ToolId;
+  label: string;
+  sessions: number;
+  tokens: number;
+  share: number;
+}
+
+export interface WrappedLongestSession {
+  /** Longest continuous sitting (events ≤ 30 min apart), not wall-clock session span. */
+  durationMs: number;
+  /** Assistant replies within that sitting. */
+  replies: number;
+  date: string;
+  project: string;
+}
+
+export interface WrappedSessionOfYear {
+  title: string;
+  project: string;
+  date: string;
+  messageCount: number;
+  filesTouched: number;
+  /** Closing text contains a PR/commit artifact (significance.ts). */
+  shipped: boolean;
+}
+
+export interface PhraseStat {
+  id: string;
+  /** Messages containing the phrase (rows, not occurrences). */
+  count: number;
+  role: 'user' | 'assistant';
+}
+
+export interface WrappedContentStats {
+  indexedSessions: number;
+  phrases: PhraseStat[];
+  monologue: { userAvg: number; assistantAvg: number; longestUser: number } | null;
+  driveBys: { count: number; total: number } | null;
+  abandoned: { name: string; sessions: number; lastSeen: string } | null;
+  errors: { sessionsErrored: number; totalErrors: number; cursedWeekday: number | null; cursedCount: number } | null;
+  topFiles: { name: string; sessions: number }[];
+  topCommands: { name: string; sessions: number }[];
+  /** Mined from genuine user prompts: distinctive vocabulary, not stopwords. */
+  words: { word: string; count: number; sessions: number }[];
+  /** Median raw message_count per engaged session (drive-bys excluded) — the persona depth axis. */
+  depthMedian: number | null;
+}
+
+export interface FunStat {
+  big: string;
+  label: string;
+  sub?: string;
+}
+
+/** A themed fun slide assembled from the highest-scoring candidates — only
+ *  notable stats render, so nobody sees "0 times" filler. */
+export interface FunCard {
+  id: string;
+  kicker: string;
+  title: string;
+  stats: FunStat[];
+  footnote?: string;
+  score: number;
+}
+
+export interface PersonaAxis {
+  label: string;
+  value: string;
+  lean: string;
+}
+
+export interface WrappedPersona {
+  name: string;
+  tagline: string;
+  axes: PersonaAxis[];
+  flavor: string | null;
+}
+
+/** Extra slides injected via --extras — the hook for agent-authored roasts. */
+export interface WrappedExtra {
+  title?: string;
+  headline: string;
+  subline?: string;
+  footnote?: string;
+}
+
+export interface WrappedData {
+  generator: 'sessions';
+  version: 1;
+  generatedAt: string;
+  year: number;
+  period: { from: string; to: string };
+  /** First event's local date — disclosed when transcript retention truncates the year. */
+  dataBegins: string | null;
+  tz: string;
+  warnings: PricingWarning[];
+  totals: WrappedTotals;
+  rhythm: WrappedRhythm;
+  daily: WrappedDay[];
+  biggestDay: (WrappedDay & { medianTokens: number }) | null;
+  projects: WrappedProject[];
+  models: WrappedModel[];
+  tools: WrappedTool[];
+  cacheHitRate: number | null;
+  longestSession: WrappedLongestSession | null;
+  sessionOfYear: WrappedSessionOfYear | null;
+  content: WrappedContentStats | null;
+  fun: FunCard[];
+  wordOfYear: { word: string; count: number; sessions: number; runnersUp: string[] } | null;
+  persona: WrappedPersona | null;
+  extras: WrappedExtra[];
+}


### PR DESCRIPTION
## What

`sessions wrapped` — a Spotify-Wrapped-style year in review rendered as a self-contained, scroll-snap HTML story and opened in the browser. Computed entirely locally from the same sources the rest of the tool uses.

```sh
sessions wrapped                     # this year, opens in your browser
sessions wrapped --year 2025        # a past calendar year
sessions wrapped --roast            # let an installed agent CLI improvise roast slides
sessions wrapped --stdout           # the underlying JSON, for piping
sessions wrapped --extras roast.json # inject your own extra slides
```

**The story (15 cards):** cover → tokens (with human-scale equivalence: "469 read-throughs of the Harry Potter series") → API-rate receipt + cache hit rate → attendance with a streak calendar strip → weekday×hour rhythm heatmap → project countdown → model cast with adoption dates ("Opus 4.8 arrived May 28 — your daily #1 the day it landed") → session of the year (significance-ranked, with longest sitting) → three themed fun cards → word of the year → any roast/extra slides → persona reveal → movie-style credits.

**Dynamic fun slides:** every silly stat is a notability-scored candidate — interrupt census, two-sided apology scoreboard, "you're absolutely right" counter, drive-by sessions, most-abandoned project, ultrathink invocations. Only stats notable in *your* data render (thresholds, not quotas), so a daylight coder never sees a 3 AM slide and an empty index degrades gracefully. The word of the year is corpus-mined from your own prompts against a stop list.

**Persona:** three median-split axes (night share / project focus / engaged-session depth) → eight flattering archetypes, with the axis evidence printed on the card so the label never reads as hallucinated.

## Roast mode (`--roast`)

`--roast` hands the computed stats to an agent CLI you already have installed (`claude` → `codex` → `pi`, or force one with `--roast-with <tool>`) and appends its improvised, edgy roast slides to the story. It's a flag rather than a separate `/wrapped` plugin skill because anyone with transcripts to wrap definitionally has an agent CLI installed and authed — so it rides the existing subscription with no API key and no setup, and stays tool-agnostic.

Three guardrails:
- **Stats only** — a curated numbers-only digest is sent (counts, project names, figures already on the page); raw transcript text (session titles, message snippets) is never included.
- **Fail-open** — no CLI on PATH, a timeout, or unparseable output drops the roast with one stderr warning; the deterministic page always renders.
- **Provenance forced** — model output runs through the same `coerceExtras` validation as `--extras` (shape/length/count caps), then every slide's footnote is overwritten to "improvised by \<tool\>" so a generated line can never pose as a counted stat.

Verified end-to-end against the real `claude` CLI (~66s). Sample:

> **Emotional Damage Report** — You interrupted it 524 times, swore 110 times, and said thanks 22. The robot is keeping a file on you.
> **$13,492 Well Spent** — Your top commands: git diff, git log, git add, git status. You bought a Ferrari to check your mirrors.

`--extras <path>` is the manual version of the same seam: a JSON array of up to six slides (`[{"headline", "title"?, "subline"?, "footnote"?}]`) injected by hand.

## How

- Two data sources, deliberately split: raw `UsageEvent[]` from the report pipeline (full timestamps: sittings via 30-min gap-splitting, night census, adoption dates, cache ratio) and the search index via a new narrow `getIndexDb()` read-only accessor (phrase censuses, session-of-the-year, mining). Phrase counts use `LIKE`, not FTS `MATCH` — porter stemming makes phrase matching fuzzy and `MATCH` counts rows anyway.
- Token/cost math matches `sessions report` exactly (input + output + cacheWrite; cacheRead disclosed separately). Session counts are distinct `tool|sessionId` — aggregate's sum-of-daily double-counts cross-midnight sessions, and per-tool/project counts now use the same definition so they sum to the headline.
- Vendored report files untouched; wrapped layers on `aggregate()` output plus its own passes.
- Research + design notes (metric catalog, precedents, roast rationale, accepted limitations): `docs/ideation/wrapped/research.md`.

## Fixes that reach beyond wrapped

Surfaced by the review passes (fable-5 four-lens adversarial workflow + independent codex/gpt-5.5 review; 18 distinct confirmed findings, all addressed):

- **Command dispatch matched anywhere in argv** — `sessions wrapped --out cleanup` would have run the destructive `cleanup` command (uninstall + index wipe). All commands now dispatch on the positional word only. Note: flag-before-command invocations (`sessions --tool claude report`) no longer dispatch the command; they fall through to search, matching the documented command-first usage.
- **`--stdout` truncated piped JSON at the 64KB pipe buffer** (`sessions report --stdout | jq` demonstrably emitted exactly 65536 bytes). Both report and wrapped now flush via `Bun.write` before the dispatcher exits.
- **Pricing warnings printed one entry per unpriced event** ("67 model(s) had no pricing" listing 2 ids 67 times). `drainPricingWarnings` now merges per model; benefits report stderr/JSON/HTML too.

Known limitations reviewed and accepted (documented in the research doc): index dates are UTC-sliced while event stats bucket in local tz (cursed-weekday card footnotes UTC attribution); forked Claude transcripts duplicate history in the FTS index so phrase counts include copies.

## Test plan

- `bun test` — 286 pass, including 40 wrapped-specific: arg parsing (incl. `--roast`/`--roast-with`), sitting gap-splitting, year scoping, tz-sensitive night census, dynamic selection thresholds, persona axes, extras validation (surrogate-safe truncation, missing-file error), roast (digest excludes free text, JSON extraction from prose/fences, fail-open paths, provenance stamping, 6-slide cap) via an injected runner so CI never spawns a CLI, and self-contained-HTML assertions (no external URLs, no innerHTML).
- `bun run typecheck` / `lint` / `format:check` — clean
- Verified end-to-end against a real 2,288-session index; all cards screenshot-reviewed via headless Chromium with zero console errors, including live `--roast` output.