### PR TITLE
feat(wrapped): adaptive roast slide type and a new round of unhinged stats

### DIFF
--- a/src/wrapped/compute.ts
+++ b/src/wrapped/compute.ts
@@ -207,6 +207,26 @@ export function computeEventStats(events: UsageEvent[], tz: string): WrappedEven
   };
 }
 
+/** Longest run of silent days strictly between two active dates — the
+ *  disappearance. Edges of the period don't count: silence before the first
+ *  session or after the last one is "hadn't started" / "hasn't happened yet". */
+export function longestGapRange(activeDates: string[]): { days: number; from: string; to: string } | null {
+  const dates = [...new Set(activeDates)].sort();
+  let best: { days: number; from: string; to: string } | null = null;
+  for (let i = 1; i < dates.length; i++) {
+    const prev = Date.parse(dates[i - 1]!);
+    const gap = (Date.parse(dates[i]!) - prev) / 86_400_000 - 1;
+    if (gap > (best?.days ?? 0)) {
+      best = {
+        days: gap,
+        from: new Date(prev + 86_400_000).toISOString().slice(0, 10),
+        to: new Date(prev + gap * 86_400_000).toISOString().slice(0, 10),
+      };
+    }
+  }
+  return best;
+}
+
 /** Longest run of consecutive active dates, with its range. */
 export function longestStreakRange(activeDates: string[]): { days: number; from: string; to: string } | null {
   const dates = [...new Set(activeDates)].sort();

--- a/src/wrapped/content.ts
+++ b/src/wrapped/content.ts
@@ -36,6 +36,17 @@ const PHRASES: PhraseSpec[] = [
   { id: 'userSorry', role: 'user', patterns: ['%sorry%', '%apolog%'] },
   { id: 'assistantApology', role: 'assistant', patterns: ['%apolog%'] },
   { id: 'ultrathink', role: 'user', patterns: ['%ultrathink%'] },
+  { id: 'quickQuestion', role: 'user', patterns: ['%quick question%', '%real quick%', '%just a quick%'] },
+  { id: 'oneMoreThing', role: 'user', patterns: ['%one more thing%', '%one last thing%', '%last thing%'] },
+  { id: 'shouldWork', role: 'user', patterns: ['%should work%'] },
+  {
+    id: 'stillBroken',
+    role: 'user',
+    patterns: ['%still not working%', '%still broken%', '%still failing%', '%same error%'],
+  },
+  { id: 'areYouSure', role: 'user', patterns: ['%are you sure%'] },
+  { id: 'hallucinate', role: 'user', patterns: ['%hallucinat%'] },
+  { id: 'perfectExclaim', role: 'assistant', patterns: ['%perfect!%'] },
 ];
 
 // Vocabulary mining: words we never crown. Common English + generic dev terms —

--- a/src/wrapped/html.ts
+++ b/src/wrapped/html.ts
@@ -93,6 +93,36 @@ export function tokenEquivalence(tokens: number): string | null {
   return tokens >= 400_000 ? 'that’s most of War and Peace' : null;
 }
 
+/** The receipt's version of tokenEquivalence — the bill, in things. */
+export function costEquivalence(costUSD: number): string | null {
+  const scales: { unit: number; many: string }[] = [
+    { unit: 1999, many: 'MacBook Airs' },
+    { unit: 249, many: 'pairs of AirPods Pro' },
+    { unit: 6, many: 'oat-milk lattes' },
+  ];
+  for (const s of scales) {
+    const x = costUSD / s.unit;
+    if (x >= 1.5) {
+      const n = x >= 10 ? fmtInt(Math.round(x)) : x.toFixed(1);
+      return `about ${n} ${s.many}`;
+    }
+  }
+  return null;
+}
+
+/** Pick the type ramp that fits — hero numerals for short strings, then
+ *  progressively smaller word ramps, so a long line (a roast punchline, an
+ *  abandoned project's name) never becomes a wall of 9rem type that outgrows
+ *  its viewport-height card. `min: 'word'` skips the numeral ramp for text
+ *  that is never a number. */
+export function heroClass(text: string, min: 'num' | 'word' = 'num'): string {
+  const cp = [...text].length;
+  if (cp <= 8 && min === 'num') return 'big';
+  if (cp <= 28) return 'big bigword';
+  if (cp <= 80) return 'big midword';
+  return 'big punchline';
+}
+
 interface Card {
   id: string;
   cls?: string;
@@ -191,14 +221,14 @@ function funCard(card: FunCard): Card {
     .join('');
   return {
     id: `fun-${card.id}`,
-    body: `${echo(lead!.big.length <= 8 ? lead!.big : '!?')}<div class="panel">${kicker(card.kicker)}<h2>${esc(card.title)}</h2><div class="big"><span class="n">${esc(lead!.big)}</span></div><p class="lede">${esc(lead!.label)}${lead!.sub ? ` <em>· ${esc(lead!.sub)}</em>` : ''}</p>${restRows}${card.footnote ? foot(card.footnote) : ''}</div>`,
+    body: `${echo(lead!.big.length <= 8 ? lead!.big : '!?')}<div class="panel">${kicker(card.kicker)}<h2>${esc(card.title)}</h2><div class="${heroClass(lead!.big)}"><span class="n">${esc(lead!.big)}</span></div><p class="lede">${esc(lead!.label)}${lead!.sub ? ` <em>· ${esc(lead!.sub)}</em>` : ''}</p>${restRows}${card.footnote ? foot(card.footnote) : ''}</div>`,
   };
 }
 
 function extraCard(x: WrappedExtra, i: number): Card {
   return {
     id: `extra-${i}`,
-    body: `<div class="panel">${kicker(x.title ?? 'guest appearance')}<div class="big bigword"><span class="n">${esc(x.headline)}</span></div>${x.subline ? `<p class="lede">${esc(x.subline)}</p>` : ''}${x.footnote ? foot(x.footnote) : ''}</div>`,
+    body: `<div class="panel">${kicker(x.title ?? 'guest appearance')}<div class="${heroClass(x.headline, 'word')}"><span class="n">${esc(x.headline)}</span></div>${x.subline ? `<p class="lede">${esc(x.subline)}</p>` : ''}${x.footnote ? foot(x.footnote) : ''}</div>`,
   };
 }
 
@@ -231,9 +261,10 @@ ${empty ? `<p class="lede">A quiet year — no sessions found. The mystery of yo
     });
 
     const cachePct = d.cacheHitRate !== null ? Math.round(d.cacheHitRate * 100) : null;
+    const costEq = costEquivalence(d.totals.costUSD);
     cards.push({
       id: 'cost',
-      body: `${echo(fmtUSD(d.totals.costUSD))}<div class="panel center">${kicker('the receipt')}<h2>All of that, à la carte?</h2>${bigNum(d.totals.costUSD, 'usd')}<p class="lede">what this year would have cost at API list prices</p>${
+      body: `${echo(fmtUSD(d.totals.costUSD))}<div class="panel center">${kicker('the receipt')}<h2>All of that, à la carte?</h2>${bigNum(d.totals.costUSD, 'usd')}<p class="lede">what this year would have cost at API list prices${costEq ? ` — ${esc(costEq)}` : ''}</p>${
         cachePct !== null
           ? `<div class="substat" style="--i:1"><span class="sn">${cachePct}%</span><span class="sl">cache hit rate — ${fmtTokens(d.totals.cacheReadTokens)} tokens re-read from cache instead of full price</span></div>`
           : ''
@@ -313,7 +344,13 @@ ${heatmap(d.rhythm.heat)}
             detail: `${fmtTokens(m.tokens)} tokens · first seen ${shortDate(m.firstSeen)}`,
           })),
           'tok',
-        )}${story}${toolStrip}${foot('ranked by replies · bars show reply volume')}</div>`,
+        )}${story}${toolStrip}${foot(
+          `ranked by replies · bars show reply volume${
+            d.modelsTried > d.models.length
+              ? ` · ${fmtInt(d.modelsTried)} models auditioned, ${d.models.length} made the cut`
+              : ''
+          }`,
+        )}</div>`,
       });
     }
 
@@ -324,6 +361,13 @@ ${heatmap(d.rhythm.heat)}
         body: `${echo(shortDate(d.biggestDay.date))}<div class="panel center">${kicker('the bender')}<h2>Then there was ${esc(formatDate(d.biggestDay.date))}.</h2>${bigNum(d.biggestDay.tokens, 'tok')}<p class="lede">tokens in a single day${
           ratio >= 2 ? ` — <b>${ratio >= 10 ? Math.round(ratio) : ratio.toFixed(1)}×</b> your median day` : ''
         }</p></div>`,
+      });
+    }
+
+    if (d.longestGap && d.longestGap.days >= 7) {
+      cards.push({
+        id: 'vanish',
+        body: `${echo(`${d.longestGap.days}d`)}<div class="panel center">${kicker('the disappearance')}<h2>And then one day — nothing.</h2>${bigNum(d.longestGap.days, 'int')}<p class="lede">days of total silence, <b>${esc(shortDate(d.longestGap.from))}</b> → <b>${esc(shortDate(d.longestGap.to))}</b> — the agents waited</p>${foot('your longest gap between active days · touching grass, presumably')}</div>`,
       });
     }
 
@@ -385,6 +429,7 @@ ${foot('a description of how you worked this year, not who you are · this card 
 
   const creditRows: [string, string][] = [];
   if (d.models[0]) creditRows.push(['starring', prettyModel(d.models[0].label)]);
+  if (d.models[1]) creditRows.push(['the understudy', prettyModel(d.models[1].label)]);
   if (d.content?.topCommands[0]) {
     creditRows.push([
       'featuring',
@@ -393,8 +438,30 @@ ${foot('a description of how you worked this year, not who you are · this card 
   }
   if (d.projects[0]) creditRows.push(['on location', d.projects[0].name]);
   if (d.content?.topFiles[0]) creditRows.push(['set dressing', d.content.topFiles[0].name]);
+  // Busiest month, straight from the daily series — the shooting schedule.
+  const byMonth = new Map<string, number>();
+  for (const day of d.daily) {
+    const mo = day.date.slice(0, 7);
+    byMonth.set(mo, (byMonth.get(mo) ?? 0) + day.tokens);
+  }
+  let peakMonth: { mo: string; tokens: number } | null = null;
+  for (const [mo, tokens] of byMonth) {
+    if (tokens > (peakMonth?.tokens ?? 0)) peakMonth = { mo, tokens };
+  }
+  if (peakMonth) {
+    creditRows.push([
+      'principal photography',
+      `${MONTHS[Number(peakMonth.mo.slice(5)) - 1]} ${peakMonth.mo.slice(0, 4)} — ${fmtTokens(peakMonth.tokens)} tokens`,
+    ]);
+  }
   if (d.content?.errors && d.content.errors.totalErrors > 0) {
     creditRows.push(['stunts', `${fmtInt(d.content.errors.totalErrors)} errors, all survived`]);
+  }
+  if (d.content?.abandoned) {
+    creditRows.push([
+      'in memoriam',
+      `${d.content.abandoned.name} — last seen ${shortDate(d.content.abandoned.lastSeen)}`,
+    ]);
   }
   creditRows.push(['directed by', 'you']);
   cards.push({
@@ -449,7 +516,9 @@ h1 span{display:block;}
 h2{font-size:clamp(1.5rem,4vw,2.2rem);font-weight:800;letter-spacing:-.01em;line-height:1.15;margin:0 0 18px;text-wrap:balance;}
 .big{margin:10px 0 14px;}
 .big .n{font-size:clamp(4rem,14vw,9.5rem);font-weight:900;letter-spacing:-.04em;line-height:1;color:var(--a);text-shadow:0 0 70px color-mix(in oklch,var(--a) 40%,transparent);}
-.big.bigword .n{font-size:clamp(2.4rem,9vw,5.5rem);letter-spacing:-.02em;text-wrap:balance;}
+.big.bigword .n{font-size:clamp(2.4rem,9vw,5.5rem);letter-spacing:-.02em;text-wrap:balance;overflow-wrap:break-word;}
+.big.midword .n{font-size:clamp(1.8rem,6vw,3.4rem);letter-spacing:-.015em;line-height:1.15;text-wrap:balance;overflow-wrap:break-word;}
+.big.punchline .n{font-size:clamp(1.35rem,4.5vw,2.1rem);font-weight:800;letter-spacing:-.01em;line-height:1.3;text-wrap:balance;overflow-wrap:break-word;}
 .lede{font-size:clamp(1.05rem,2.2vw,1.3rem);color:var(--ink);margin:10px 0 0;text-wrap:balance;}
 .lede em,.sl em{color:var(--muted);font-style:normal;}
 .lede b{color:var(--a);font-weight:800;}

--- a/src/wrapped/index.test.ts
+++ b/src/wrapped/index.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runWrapped, parseWrappedArgs, parseExtras } from './index.ts';
+import { longestGapRange } from './compute.ts';
 
 const tmp = mkdtempSync(join(tmpdir(), 'sessions-wrapped-run-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
@@ -118,6 +119,21 @@ describe('parseExtras', () => {
   });
 });
 
+describe('longestGapRange', () => {
+  test('finds the widest silence strictly between active days', () => {
+    expect(longestGapRange(['2026-01-01', '2026-01-02', '2026-01-10'])).toEqual({
+      days: 7,
+      from: '2026-01-03',
+      to: '2026-01-09',
+    });
+  });
+  test('consecutive or single days have no gap', () => {
+    expect(longestGapRange(['2026-01-01', '2026-01-02'])).toBeNull();
+    expect(longestGapRange(['2026-01-01'])).toBeNull();
+    expect(longestGapRange([])).toBeNull();
+  });
+});
+
 describe('runWrapped', () => {
   test('computes a year-scoped, sitting-aware wrapped', async () => {
     const res = await runWrapped({
@@ -153,6 +169,10 @@ describe('runWrapped', () => {
     expect(fable.firstSeen).toBe('2026-06-03');
     expect(fable.firstTopDay).toBe('2026-06-03');
     expect(data.dataBegins).toBe('2026-06-01');
+    // Active days are Jun 1, 3, and 22 — the 18 silent days between the 3rd
+    // and the 22nd are the year's longest disappearance.
+    expect(data.longestGap).toEqual({ days: 18, from: '2026-06-04', to: '2026-06-21' });
+    expect(data.modelsTried).toBe(2);
   });
 
   test('--year selects a past calendar year in full', async () => {
@@ -193,6 +213,8 @@ describe('runWrapped', () => {
     expect(html).toContain('id="cover"');
     expect(html).toContain('id="tokens"');
     expect(html).toContain('id="credits"');
+    // The 18-day silence clears the 7-day bar for the disappearance card.
+    expect(html).toContain('id="vanish"');
     // Mid-year runs disclose partial coverage.
     expect(html).toContain('so far');
   });
@@ -286,5 +308,25 @@ describe('runWrapped', () => {
     const html = readFileSync(out, 'utf8');
     expect(html).toContain('A bespoke roast');
     expect(html).toContain('id="extra-0"');
+  });
+
+  test('a long extra headline steps down to the punchline ramp instead of overflowing', async () => {
+    const extrasPath = join(tmp, 'long-extras.json');
+    const long = 'You spent $13,427 asking a machine to fix bugs you introduced while it watched you introduce more';
+    writeFileSync(extrasPath, JSON.stringify([{ headline: long }, { headline: 'Short and mean' }]));
+    const out = join(tmp, 'long-extras.html');
+    await runWrapped({
+      tz: 'UTC',
+      stdout: false,
+      offline: true,
+      roots,
+      now: NOW,
+      out,
+      extras: extrasPath,
+      noContent: true,
+    });
+    const html = readFileSync(out, 'utf8');
+    expect(html).toContain('big punchline');
+    expect(html).toContain('big bigword');
   });
 });

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -13,7 +13,7 @@ import { aggregate } from '../report/aggregate.ts';
 import { drainPricingWarnings, resetPricingWarnings, mergeRuntimePricing } from '../report/pricing.ts';
 import { loadRuntimePricing } from '../report/pricing-cache.ts';
 import { localDate } from '../report/parsers/util.ts';
-import { computeEventStats, longestStreakRange } from './compute.ts';
+import { computeEventStats, longestGapRange, longestStreakRange } from './compute.ts';
 import { computeContentStats } from './content.ts';
 import { selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
 import { renderWrappedHtml } from './html.ts';
@@ -299,7 +299,9 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
     biggestDay = { ...peak, medianTokens };
   }
 
-  const streak = longestStreakRange(activeDaily.map((d) => d.date));
+  const activeDates = activeDaily.map((d) => d.date);
+  const streak = longestStreakRange(activeDates);
+  const longestGap = longestGapRange(activeDates);
 
   const fun = selectFunCards(content, ev.rhythm);
   const wordOfYear = selectWordOfYear(content);
@@ -328,8 +330,10 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
     rhythm: ev.rhythm,
     daily,
     biggestDay,
+    longestGap,
     projects,
     models,
+    modelsTried: ev.modelFirsts.size,
     tools: toolsOut,
     cacheHitRate: ev.cacheHitRate,
     longestSession: ev.longestSession,

--- a/src/wrapped/roast.test.ts
+++ b/src/wrapped/roast.test.ts
@@ -75,6 +75,8 @@ describe('buildRoastPrompt', () => {
     expect(p).toContain('656000000'); // tokens
     expect(p).toContain('workos'); // word of the year (aggregate)
     expect(p).toContain('JSON array'); // schema instruction
+    // Headlines render as full-screen type — the prompt must demand brevity.
+    expect(p).toContain('<=80 chars');
     // The session-of-the-year *title* is free text — it must not be sent.
     expect(p).not.toContain('secret internal prompt text');
   });

--- a/src/wrapped/roast.ts
+++ b/src/wrapped/roast.ts
@@ -52,6 +52,12 @@ function roastDigest(d: WrappedData): Record<string, unknown> {
     nightsPastMidnight: d.rhythm.nightsPastMidnight,
     topProjects: d.projects.map((p) => ({ name: p.name, sharePct: Math.round(p.share * 100) })),
     topModels: d.models.map((m) => m.label),
+    modelsTried: d.modelsTried,
+    biggestDayTokens: d.biggestDay?.tokens ?? null,
+    longestSittingMinutes: d.longestSession ? Math.round(d.longestSession.durationMs / 60_000) : null,
+    longestGapDays: d.longestGap?.days ?? null,
+    longestUserMessageChars: d.content?.monologue?.longestUser ?? null,
+    cacheHitPct: d.cacheHitRate !== null ? Math.round(d.cacheHitRate * 100) : null,
     persona: d.persona ? { name: d.persona.name, axes: d.persona.axes.map((a) => `${a.label}: ${a.lean}`) } : null,
     wordOfYear: d.wordOfYear ? { word: d.wordOfYear.word, count: d.wordOfYear.count } : null,
     phraseCounts: Object.fromEntries((d.content?.phrases ?? []).map((p) => [p.id, p.count])),
@@ -66,10 +72,12 @@ export function buildRoastPrompt(d: WrappedData): string {
   const digest = JSON.stringify(roastDigest(d), null, 2);
   return `You are the closer at a roast battle, and the target is someone's year of using AI coding agents. Below are their stats (numbers only — no message content).
 
-Write 2-4 short, EDGY roast slides. Be genuinely cutting — sharp, dark, deadpan, a little mean. Land real punches at the absurdity in their numbers; twist the knife. Dry wit and savage one-liners over gentle ribbing. Mild profanity is fine if it lands. The one rule: roast their WORK and these HABITS (the numbers), never protected traits or anything hateful — this is affectionate underneath, like a friend who knows exactly where it hurts. Reference specific figures. No emoji.
+Write 3-5 short, EDGY roast slides. Be genuinely cutting — sharp, dark, deadpan, a little mean. Land real punches at the absurdity in their numbers; twist the knife. Dry wit and savage one-liners over gentle ribbing. Mild profanity is fine if it lands. The one rule: roast their WORK and these HABITS (the numbers), never protected traits or anything hateful — this is affectionate underneath, like a friend who knows exactly where it hurts. Reference specific figures. No emoji.
+
+Each headline renders as full-screen display type, so brevity IS the punch: a headline over 80 characters gets shrunk to fit and lands soft. Setup-then-twist? Setup in the headline, twist in the subline.
 
 Output ONLY a JSON array, no prose around it, matching exactly this schema:
-[{"title": "short kicker, <=6 words", "headline": "the punchline, <=110 chars", "subline": "optional extra line, <=180 chars"}]
+[{"title": "short kicker, <=4 words", "headline": "the punchline, <=80 chars", "subline": "optional second beat, <=160 chars"}]
 
 Their stats:
 ${digest}`;

--- a/src/wrapped/select.test.ts
+++ b/src/wrapped/select.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { buildCandidates, selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
-import { tokenEquivalence, prettyModel } from './html.ts';
+import { tokenEquivalence, costEquivalence, heroClass, prettyModel } from './html.ts';
 import { cleanTitle, commandFamily, mineWords } from './content.ts';
 import type { WrappedContentStats, WrappedRhythm } from './types.ts';
 import type { WrappedEventStats } from './compute.ts';
@@ -86,6 +86,45 @@ describe('dynamic selection', () => {
     expect(score(wild)).toBeGreaterThan(score(mild));
   });
 
+  test('the lies card assembles from famous last words', () => {
+    const cards = selectFunCards(contentWith({ quickQuestion: 40, shouldWork: 120, oneMoreThing: 25 }), quietRhythm);
+    const lies = cards.find((c) => c.id === 'lies');
+    expect(lies).toBeDefined();
+    expect(lies!.kicker).toBe('famous last words');
+    expect(lies!.stats).toHaveLength(3);
+    expect(lies!.stats[0]!.label).toContain('should work');
+    expect(lies!.stats.some((s) => s.label.includes('quick'))).toBe(true);
+  });
+
+  test('the H-word is notable at low counts, but never at one', () => {
+    const cs = buildCandidates(contentWith({ hallucinate: 3 }), quietRhythm);
+    expect(cs.some((c) => c.stat.label.includes('hallucinate'))).toBe(true);
+    const none = buildCandidates(contentWith({ hallucinate: 1 }), quietRhythm);
+    expect(none.some((c) => c.stat.label.includes('hallucinate'))).toBe(false);
+  });
+
+  test('a manifesto-length message becomes a blooper; a normal one never does', () => {
+    const manifesto = contentWith({}, { monologue: { userAvg: 300, assistantAvg: 900, longestUser: 15_000 } });
+    expect(buildCandidates(manifesto, quietRhythm).some((c) => c.stat.label.includes('longest single message'))).toBe(
+      true,
+    );
+    const modest = contentWith({}, { monologue: { userAvg: 300, assistantAvg: 900, longestUser: 500 } });
+    expect(buildCandidates(modest, quietRhythm).some((c) => c.stat.label.includes('longest single message'))).toBe(
+      false,
+    );
+  });
+
+  test('weekend warriors get called out; weekday coders never do', () => {
+    const heat = Array.from({ length: 7 }, () => Array.from({ length: 24 }, () => 0));
+    heat[6]![14] = 120; // Saturday afternoon
+    heat[0]![10] = 40; // Sunday morning
+    heat[2]![10] = 240; // Tuesday
+    const cs = buildCandidates(null, { ...quietRhythm, heat });
+    const weekend = cs.find((c) => c.stat.label.includes('weekend'));
+    expect(weekend?.stat.big).toBe('40%');
+    expect(buildCandidates(null, quietRhythm).some((c) => c.stat.label.includes('weekend'))).toBe(false);
+  });
+
   test('apology scoreboard flips its punchline from the data', () => {
     const humanSorry = buildCandidates(contentWith({ userSorry: 20, assistantApology: 5 }), quietRhythm);
     const sb = humanSorry.find((c) => c.stat.label.includes('apology scoreboard'))!;
@@ -139,6 +178,21 @@ describe('display helpers', () => {
     expect(tokenEquivalence(2_000_000)).toContain('War and Peace');
     expect(tokenEquivalence(700_000_000)).toContain('Harry Potter');
     expect(tokenEquivalence(20_000_000_000)).toContain('Wikipedia');
+  });
+
+  test('costEquivalence scales the bill to street prices', () => {
+    expect(costEquivalence(5)).toBeNull();
+    expect(costEquivalence(60)).toContain('oat-milk lattes');
+    expect(costEquivalence(600)).toContain('AirPods');
+    expect(costEquivalence(13_427)).toContain('MacBook Airs');
+  });
+
+  test('heroClass steps the type ramp down as text grows', () => {
+    expect(heroClass('1,024')).toBe('big');
+    expect(heroClass('1,024', 'word')).toBe('big bigword'); // roast text never gets the numeral ramp
+    expect(heroClass('an-abandoned-project-name')).toBe('big bigword');
+    expect(heroClass('x'.repeat(60), 'word')).toBe('big midword');
+    expect(heroClass('x'.repeat(100), 'word')).toBe('big punchline');
   });
 
   test('prettyModel prettifies known families and leaves the rest alone', () => {

--- a/src/wrapped/select.ts
+++ b/src/wrapped/select.ts
@@ -12,7 +12,7 @@ const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Frida
 const fmtInt = (n: number): string => n.toLocaleString('en-US');
 
 interface Candidate {
-  theme: 'friction' | 'relationship' | 'bloopers';
+  theme: 'friction' | 'relationship' | 'lies' | 'bloopers';
   score: number;
   stat: FunStat;
 }
@@ -79,6 +79,18 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       },
     });
   }
+  const stillBroken = phrase(p, 'stillBroken');
+  if (stillBroken >= 3) {
+    out.push({
+      theme: 'friction',
+      score: 0.2 + 0.65 * sat(stillBroken, 60),
+      stat: {
+        big: fmtInt(stillBroken),
+        label: '“still broken” status reports filed',
+        sub: 'same error, new hope',
+      },
+    });
+  }
 
   // — relationship —
   // Base score is deliberately high: this is the pre-validated crowd-pleaser
@@ -138,6 +150,80 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       },
     });
   }
+  const areYouSure = phrase(p, 'areYouSure');
+  if (areYouSure >= 3) {
+    out.push({
+      theme: 'relationship',
+      score: 0.3 + 0.5 * sat(areYouSure, 25),
+      stat: {
+        big: fmtInt(areYouSure),
+        label: 'times you asked “are you sure?”',
+        sub: 'trust, but verify',
+      },
+    });
+  }
+  const hallucinate = phrase(p, 'hallucinate');
+  if (hallucinate >= 2) {
+    out.push({
+      theme: 'relationship',
+      score: 0.4 + 0.45 * sat(hallucinate, 12),
+      stat: {
+        big: fmtInt(hallucinate),
+        label: 'times you used the H-word — “hallucinate”',
+        sub: 'it prefers the term “creative recall”',
+      },
+    });
+  }
+  const perfect = phrase(p, 'perfectExclaim');
+  if (perfect >= 10) {
+    out.push({
+      theme: 'relationship',
+      score: 0.2 + 0.5 * sat(perfect, 150),
+      stat: {
+        big: fmtInt(perfect),
+        label: 'times Claude declared “Perfect!”',
+        sub: 'grade pending independent verification',
+      },
+    });
+  }
+
+  // — lies (famous last words) —
+  const quickQuestion = phrase(p, 'quickQuestion');
+  if (quickQuestion >= 3) {
+    out.push({
+      theme: 'lies',
+      score: 0.25 + 0.6 * sat(quickQuestion, 40),
+      stat: {
+        big: fmtInt(quickQuestion),
+        label: 'prompts promised it would be quick',
+        sub: 'narrator: it was not quick',
+      },
+    });
+  }
+  const shouldWork = phrase(p, 'shouldWork');
+  if (shouldWork >= 5) {
+    out.push({
+      theme: 'lies',
+      score: 0.2 + 0.6 * sat(shouldWork, 40),
+      stat: {
+        big: fmtInt(shouldWork),
+        label: 'messages contained “should work”',
+        sub: 'the four most cursed words in software',
+      },
+    });
+  }
+  const oneMore = phrase(p, 'oneMoreThing');
+  if (oneMore >= 3) {
+    out.push({
+      theme: 'lies',
+      score: 0.2 + 0.55 * sat(oneMore, 40),
+      stat: {
+        big: fmtInt(oneMore),
+        label: 'rounds of “one more thing”',
+        sub: 'there is always one more thing',
+      },
+    });
+  }
 
   // — bloopers —
   if (rhythm.nightsPastMidnight >= 5 && rhythm.latestNight) {
@@ -181,6 +267,39 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: { big: fmtInt(ultrathink), label: 'invocations of "ultrathink"', sub: 'it thought ultra hard' },
     });
   }
+  if (content?.monologue && content.monologue.longestUser >= 2000) {
+    out.push({
+      theme: 'bloopers',
+      score: 0.2 + 0.5 * sat(content.monologue.longestUser, 12_000),
+      stat: {
+        big: fmtInt(content.monologue.longestUser),
+        label: 'characters in your longest single message',
+        sub: 'that’s not a prompt, that’s a manifesto (pastes count)',
+      },
+    });
+  }
+  // Weekend share straight off the heatmap — column 0 is Sunday, 6 is Saturday.
+  let weekendMsgs = 0;
+  let totalMsgs = 0;
+  for (let wd = 0; wd < 7; wd++) {
+    for (let h = 0; h < 24; h++) {
+      const v = rhythm.heat[wd]?.[h] ?? 0;
+      totalMsgs += v;
+      if (wd === 0 || wd === 6) weekendMsgs += v;
+    }
+  }
+  const weekendShare = totalMsgs > 0 ? weekendMsgs / totalMsgs : 0;
+  if (totalMsgs >= 200 && weekendShare >= 0.2) {
+    out.push({
+      theme: 'bloopers',
+      score: 0.15 + weekendShare,
+      stat: {
+        big: `${Math.round(weekendShare * 100)}%`,
+        label: 'of your messages were sent on a weekend',
+        sub: 'the repo doesn’t know what a Saturday is',
+      },
+    });
+  }
 
   return out;
 }
@@ -188,6 +307,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
 const THEME_META: Record<Candidate['theme'], { kicker: string; title: string }> = {
   friction: { kicker: 'the friction reel', title: 'It wasn’t always pretty.' },
   relationship: { kicker: 'the relationship', title: 'You two have a dynamic.' },
+  lies: { kicker: 'famous last words', title: 'The lies you told yourself.' },
   bloopers: { kicker: 'the bloopers', title: 'And then there’s… this.' },
 };
 
@@ -195,6 +315,7 @@ const FOOTNOTES: Record<Candidate['theme'], string> = {
   friction:
     'errors include any failed command or grep — friction, not disasters · cursed day by session start date (UTC)',
   relationship: 'counted from your local transcripts — messages containing each phrase',
+  lies: 'counted from your own prompts — messages containing each phrase, in any context',
   bloopers: 'local timestamps, your timezone',
 };
 
@@ -203,7 +324,7 @@ const FOOTNOTES: Record<Candidate['theme'], string> = {
 export function selectFunCards(content: WrappedContentStats | null, rhythm: WrappedRhythm): FunCard[] {
   const candidates = buildCandidates(content, rhythm);
   const cards: FunCard[] = [];
-  for (const theme of ['friction', 'relationship', 'bloopers'] as const) {
+  for (const theme of ['friction', 'relationship', 'lies', 'bloopers'] as const) {
     const pool = candidates
       .filter((c) => c.theme === theme && c.score >= 0.3)
       .sort((a, b) => b.score - a.score)

--- a/src/wrapped/types.ts
+++ b/src/wrapped/types.ts
@@ -158,8 +158,12 @@ export interface WrappedData {
   rhythm: WrappedRhythm;
   daily: WrappedDay[];
   biggestDay: (WrappedDay & { medianTokens: number }) | null;
+  /** Longest run of consecutive silent days between two active days. */
+  longestGap: { days: number; from: string; to: string } | null;
   projects: WrappedProject[];
   models: WrappedModel[];
+  /** Distinct model ids seen all year — the top-5 list is the cast, this is the audition count. */
+  modelsTried: number;
   tools: WrappedTool[];
   cacheHitRate: number | null;
   longestSession: WrappedLongestSession | null;


### PR DESCRIPTION
## What

Two things, both aimed at making `sessions wrapped` funnier without losing the plot:

### 1. Roast slides are readable now

Every extra/roast headline rendered at the giant `bigword` ramp (up to 5.5rem, weight 900). A 110-char punchline became a wall of type taller than the viewport-height card, and `.card` has `overflow:hidden` — so long roasts got clipped and required awkward scrolling.

- **`heroClass()`** steps the type ramp down by code-point length: `bigword` (≤28) → `midword` (≤80) → `punchline` (>80, guaranteed to fit). Applied to roast/extras slides *and* fun-card leads (a long abandoned-project name had the same bug at the even bigger numeral ramp).
- **Roast prompt** now caps headlines at ≤80 chars ("brevity IS the punch") and pushes the second beat into the subline. In a live run all headlines came back at 39–58 chars.

### 2. More unhinged, still evidence-backed

All new content is deterministic, hedged per the design rules, and sits behind the existing notability thresholds — nobody sees filler:

- **Seven new phrase censuses**: "quick question", "should work", "one more thing", "still broken/same error", "are you sure?", "hallucinate" accusations, and Claude's "Perfect!" declarations
- **New themed card** — *famous last words / "The lies you told yourself."*
- **"The disappearance"** — longest gap between active days (≥7 days), "the agents waited"
- **Bloopers**: longest single message ("that's not a prompt, that's a manifesto (pastes count)"), weekend share
- **The receipt**: cost equivalences ("about 7.0 MacBook Airs")
- **The cast**: "19 models auditioned, 5 made the cut"
- **Roll credits**: *the understudy* (#2 model), *principal photography* (peak month), *in memoriam* (the abandoned project)
- **Richer roast digest**: biggest day, longest sitting, longest gap, longest message chars, models tried, cache hit rate — still stats-only, no transcript text ever leaves the machine

## Verification

- 49 tests pass (12 new), `tsc --noEmit`, `oxlint`, `oxfmt` all clean
- Live run against real transcripts: lies card fires, credits rows render, roast came back with all headlines ≤58 chars at the readable ramp, and immediately weaponized the new digest ("166 active days. Longest time clean: 3.")