### PR TITLE
fix(wrapped): base stats on real user activity, not automated noise

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -72,7 +72,10 @@ function getCodexDir(): string {
 // message index, and session_fts slims to its genuinely session-level columns
 // (user_content/assistant_content move out — message text is stored exactly once).
 // The virtual-table shapes change, so getDb drops + rebuilds on a user_version mismatch.
-const SCHEMA_VERSION = 7;
+// v8: message_fts no longer stores compaction summaries or tag-wrapped agent/
+// harness injections (task-notifications, `!`-mode shell echoes, teammate relays)
+// as genuine user turns — see isGenuineUserTurn/stripInjected in parser.ts.
+const SCHEMA_VERSION = 8;
 let _db: Database | null = null;
 
 export function clearCache(): void {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -325,7 +325,9 @@ describe('extractMessages', () => {
       {
         type: 'user',
         message: {
-          content: [{ type: 'text', text: '<teammate-message teammate_id="reviewer" color="blue">ping</teammate-message>' }],
+          content: [
+            { type: 'text', text: '<teammate-message teammate_id="reviewer" color="blue">ping</teammate-message>' },
+          ],
         },
       },
       { type: 'user', promptSource: 'typed', message: { content: [{ type: 'text', text: 'the real ask' }] } },

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -320,6 +320,19 @@ describe('extractMessages', () => {
     expect(msgs[0]!.genuine).toBe(true);
   });
 
+  test('injection tags with attributes are still stripped', () => {
+    const lines = jsonl(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'text', text: '<teammate-message teammate_id="reviewer" color="blue">ping</teammate-message>' }],
+        },
+      },
+      { type: 'user', promptSource: 'typed', message: { content: [{ type: 'text', text: 'the real ask' }] } },
+    );
+    expect(extractMessages(lines).map((m) => m.text)).toEqual(['the real ask']);
+  });
+
   test('inline injections are stripped but the human text around them survives', () => {
     const lines = jsonl({
       type: 'user',

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -288,6 +288,49 @@ describe('extractMessages', () => {
     expect(msgs.map((m) => m.index)).toEqual([0, 1]);
     expect(msgs.map((m) => m.index)).toEqual(getSessionMessages(lines).map((m) => m.index));
   });
+
+  test('compaction summaries are not genuine (auto-generated context carryover)', () => {
+    const lines = jsonl({
+      type: 'user',
+      isCompactSummary: true,
+      message: { content: [{ type: 'text', text: 'This session is being continued from a previous conversation…' }] },
+    });
+    const msgs = extractMessages(lines);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.genuine).toBe(false);
+  });
+
+  test('tag-wrapped agent/harness injections are stripped, not counted as user turns', () => {
+    const lines = jsonl(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'text', text: '<task-notification>\n<task-id>abc</task-id>\n</task-notification>' }],
+        },
+      },
+      { type: 'user', message: { content: [{ type: 'text', text: '<bash-input>git status</bash-input>' }] } },
+      { type: 'user', message: { content: [{ type: 'text', text: '<bash-stdout>on branch main</bash-stdout>' }] } },
+      { type: 'user', message: { content: [{ type: 'text', text: '<teammate-message>ping</teammate-message>' }] } },
+      { type: 'user', promptSource: 'typed', message: { content: [{ type: 'text', text: 'the real ask' }] } },
+    );
+    const msgs = extractMessages(lines);
+    // Only the genuine typed turn survives as a user message; the injections are
+    // emptied by stripInjected and so never get a row.
+    expect(msgs.map((m) => m.text)).toEqual(['the real ask']);
+    expect(msgs[0]!.genuine).toBe(true);
+  });
+
+  test('inline injections are stripped but the human text around them survives', () => {
+    const lines = jsonl({
+      type: 'user',
+      promptSource: 'typed',
+      message: { content: [{ type: 'text', text: 'fix this <bash-stdout>err</bash-stdout> please' }] },
+    });
+    const msgs = extractMessages(lines);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.text.replace(/\s+/g, ' ').trim()).toBe('fix this please');
+    expect(msgs[0]!.genuine).toBe(true);
+  });
 });
 
 describe('contentMatches', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,9 @@ interface JsonLine {
   timestamp?: string;
   gitBranch?: string;
   promptSource?: string | null;
+  /** Claude marks auto-generated context-carryover turns (the "continued from a
+   *  previous conversation" summary written on compaction) with this flag. */
+  isCompactSummary?: boolean;
   message?: Record<string, unknown> | string;
   payload?: Record<string, unknown>;
 }
@@ -83,6 +86,13 @@ function stripInjected(text: string): string {
     /<command-name>[\s\S]*?<\/command-name>/g,
     /<command-message>[\s\S]*?<\/command-message>/g,
     /<command-args>[\s\S]*?<\/command-args>/g,
+    // Agent/harness injections that ride in on a user-role line but are not the
+    // human talking: task-completion pings, `!`-mode shell echoes, teammate relays.
+    /<task-notification>[\s\S]*?<\/task-notification>/g,
+    /<bash-input>[\s\S]*?<\/bash-input>/g,
+    /<bash-stdout>[\s\S]*?<\/bash-stdout>/g,
+    /<bash-stderr>[\s\S]*?<\/bash-stderr>/g,
+    /<teammate-message>[\s\S]*?<\/teammate-message>/g,
   ];
   for (const p of patterns) {
     text = text.replace(p, '');
@@ -126,18 +136,25 @@ const SKILL_INJECTION_PREAMBLE = /^Base directory for this skill:/;
 
 /**
  * Whether a user-role line is a genuine human turn — not a tool result, a
- * system-injected turn, or a skill body injected as a user message.
- * Claude lines carry `promptSource`: when the field is present, only `typed`
- * and `queued` count (a present-but-null value, as tool results and skill loads
- * have, is rejected). Older logs and pi/codex have no `promptSource`, so fall
- * back to a heuristic: non-empty text that isn't a skill-injection preamble.
+ * system-injected turn, a compaction summary, or a skill body injected as a
+ * user message. The disqualifiers below fire regardless of `promptSource`
+ * because agent/harness injections (compaction carryover, task-completion
+ * pings echoed as `!`-mode shell lines) can arrive with any source.
+ * Claude lines then carry `promptSource`: when the field is present, only
+ * `typed` and `queued` count (a present-but-null value, as tool results and
+ * skill loads have, is rejected). Older logs and pi/codex have no
+ * `promptSource`, so fall back to a heuristic: non-empty text that isn't a
+ * skill-injection preamble. (Tag-wrapped injections — <task-notification>,
+ * <bash-input>, <bash-stdout>, <teammate-message> — are already emptied by
+ * stripInjected upstream, so they never reach here with text.)
  */
 function isGenuineUserTurn(d: JsonLine, strippedText: string): boolean {
+  if (d.isCompactSummary === true) return false;
+  if (!strippedText) return false;
+  if (SKILL_INJECTION_PREAMBLE.test(strippedText)) return false;
   if ('promptSource' in d) {
     return d.promptSource === 'typed' || d.promptSource === 'queued';
   }
-  if (!strippedText) return false;
-  if (SKILL_INJECTION_PREAMBLE.test(strippedText)) return false;
   return true;
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -88,11 +88,13 @@ function stripInjected(text: string): string {
     /<command-args>[\s\S]*?<\/command-args>/g,
     // Agent/harness injections that ride in on a user-role line but are not the
     // human talking: task-completion pings, `!`-mode shell echoes, teammate relays.
-    /<task-notification>[\s\S]*?<\/task-notification>/g,
-    /<bash-input>[\s\S]*?<\/bash-input>/g,
-    /<bash-stdout>[\s\S]*?<\/bash-stdout>/g,
-    /<bash-stderr>[\s\S]*?<\/bash-stderr>/g,
-    /<teammate-message>[\s\S]*?<\/teammate-message>/g,
+    // `\b[^>]*` tolerates attributes on the opening tag (e.g. <teammate-message
+    // teammate_id="..." color="...">), which these tags carry in multi-agent logs.
+    /<task-notification\b[^>]*>[\s\S]*?<\/task-notification>/g,
+    /<bash-input\b[^>]*>[\s\S]*?<\/bash-input>/g,
+    /<bash-stdout\b[^>]*>[\s\S]*?<\/bash-stdout>/g,
+    /<bash-stderr\b[^>]*>[\s\S]*?<\/bash-stderr>/g,
+    /<teammate-message\b[^>]*>[\s\S]*?<\/teammate-message>/g,
   ];
   for (const p of patterns) {
     text = text.replace(p, '');

--- a/src/wrapped/accuracy.test.ts
+++ b/src/wrapped/accuracy.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'bun:test';
+import { isJunkCwd, junkCwdSql } from './exclude.ts';
+import { isRealModel, canonicalModel } from './model-name.ts';
+import { mineWords } from './content.ts';
+import { computeEventStats } from './compute.ts';
+import type { UsageEvent } from '../report/parsers/types.ts';
+
+describe('isJunkCwd', () => {
+  test('keeps real project directories', () => {
+    expect(isJunkCwd('/Users/nick/Developer/cli')).toBe(false);
+    expect(isJunkCwd('/Users/nick/code/workos')).toBe(false);
+    expect(isJunkCwd(undefined)).toBe(false); // unknown cwd is real work we can't place
+  });
+
+  test('drops eval-harness temp dirs, /tmp throwaways, and menu-bar probes', () => {
+    expect(isJunkCwd('/private/var/folders/2z/xxx/T/eval-nextjs-example-auth0-abc')).toBe(true);
+    expect(isJunkCwd('/var/folders/2z/xxx/T/eval-go-example')).toBe(true);
+    expect(isJunkCwd('/private/tmp/my-app')).toBe(true);
+    expect(isJunkCwd('/tmp/test4')).toBe(true);
+    expect(isJunkCwd('/Users/nick/Library/Application Support/CodexBar/ClaudeProbe')).toBe(true);
+  });
+
+  test('junkCwdSql produces NOT LIKE clauses for the qualified column', () => {
+    const sql = junkCwdSql('s.cwd');
+    expect(sql).toContain('s.cwd NOT LIKE');
+    expect(sql).toContain('/var/folders/');
+    expect(sql).toContain('/private/tmp/');
+    expect(sql).toContain('/ClaudeProbe');
+    expect(sql.trimStart().startsWith('AND')).toBe(true);
+  });
+});
+
+describe('model canonicalization', () => {
+  test('isRealModel rejects sentinels', () => {
+    expect(isRealModel('<synthetic>')).toBe(false);
+    expect(isRealModel('')).toBe(false);
+    expect(isRealModel('claude-opus-4-8')).toBe(true);
+  });
+
+  test('canonicalModel collapses dated snapshots and provider aliases', () => {
+    expect(canonicalModel('claude-opus-4-5-20251101')).toBe(canonicalModel('claude-opus-4-5'));
+    expect(canonicalModel('openai/gpt-oss-120b')).toBe(canonicalModel('gpt-oss-120b'));
+    expect(canonicalModel('claude-opus-4-8[1m]')).toBe('Opus 4.8');
+  });
+});
+
+describe('mineWords paste-proofing', () => {
+  test('a word repeated many times in one message counts once (dedup per message)', () => {
+    // 'kubernetes' appears 50x in a single pasted message → contributes 1, not 50.
+    const paste = { text: `kubernetes ${'kubernetes '.repeat(49)}`, file: 'a' };
+    const spread = Array.from({ length: 11 }, (_, i) => ({ text: 'kubernetes deploy', file: `s${i}` }));
+    const [top] = mineWords([paste, ...spread], 5);
+    expect(top?.word).toBe('kubernetes');
+    // 1 (paste) + 11 (spread) messages = 12, not 61 — the paste can't dominate.
+    expect(top?.count).toBe(12);
+    expect(top?.sessions).toBe(12);
+  });
+
+  test('a one-session rant never qualifies (needs spread across sessions)', () => {
+    const rant = Array.from({ length: 20 }, () => ({ text: 'flibbertigibbet again', file: 'only-one' }));
+    expect(mineWords(rant, 5)).toEqual([]);
+  });
+});
+
+describe('computeEventStats model tracking', () => {
+  const ev = (model: string, ts: string): UsageEvent => ({
+    tool: 'claude-code',
+    provider: 'anthropic',
+    model,
+    timestamp: ts,
+    sessionId: `s-${model}`,
+    projectPath: '/Users/nick/Developer/cli',
+    tokens: { input: 10, output: 10, cacheRead: 0, cacheWrite: 0 },
+  });
+
+  test('the <synthetic> sentinel is never counted as a model tried or a daily top', () => {
+    const stats = computeEventStats(
+      [ev('<synthetic>', '2026-01-01T12:00:00Z'), ev('claude-opus-4-8', '2026-01-01T13:00:00Z')],
+      'UTC',
+    );
+    expect([...stats.modelFirsts.keys()]).toEqual(['claude-opus-4-8']);
+    expect(stats.modelFirsts.has('<synthetic>')).toBe(false);
+  });
+});

--- a/src/wrapped/accuracy.test.ts
+++ b/src/wrapped/accuracy.test.ts
@@ -42,6 +42,13 @@ describe('model canonicalization', () => {
     expect(canonicalModel('openai/gpt-oss-120b')).toBe(canonicalModel('gpt-oss-120b'));
     expect(canonicalModel('claude-opus-4-8[1m]')).toBe('Opus 4.8');
   });
+
+  test('GPT variants keep their full suffix — no drop or over-merge', () => {
+    expect(canonicalModel('gpt-4o')).toBe('GPT-4o'); // not "GPT-4"
+    expect(canonicalModel('gpt-5.1-codex-max')).not.toBe(canonicalModel('gpt-5.1-codex-mini'));
+    expect(canonicalModel('gpt-5.1-codex-max')).toBe('GPT-5.1-codex-max');
+    expect(canonicalModel('gpt-5')).toBe('GPT-5');
+  });
 });
 
 describe('mineWords paste-proofing', () => {
@@ -78,7 +85,23 @@ describe('computeEventStats model tracking', () => {
       [ev('<synthetic>', '2026-01-01T12:00:00Z'), ev('claude-opus-4-8', '2026-01-01T13:00:00Z')],
       'UTC',
     );
-    expect([...stats.modelFirsts.keys()]).toEqual(['claude-opus-4-8']);
+    // modelFirsts is keyed by canonical display name; synthetic is excluded.
+    expect([...stats.modelFirsts.keys()]).toEqual(['Opus 4.8']);
     expect(stats.modelFirsts.has('<synthetic>')).toBe(false);
+  });
+
+  test('snapshots pool their daily-leader vote so the merged model earns firstTopDay', () => {
+    // 2 opus replies (split across a dated snapshot) vs 1 sonnet reply on the same
+    // day → canonical Opus (2) wins; without pooling each opus variant (1) would tie/lose.
+    const stats = computeEventStats(
+      [
+        ev('claude-opus-4-5', '2026-02-01T10:00:00Z'),
+        ev('claude-opus-4-5-20251101', '2026-02-01T11:00:00Z'),
+        ev('claude-sonnet-4-6', '2026-02-01T12:00:00Z'),
+      ],
+      'UTC',
+    );
+    expect(stats.modelFirsts.get('Opus 4.5')?.firstTopDay).toBe('2026-02-01');
+    expect(stats.modelFirsts.get('Sonnet 4.6')?.firstTopDay).toBeNull();
   });
 });

--- a/src/wrapped/compute.ts
+++ b/src/wrapped/compute.ts
@@ -7,7 +7,7 @@
 import type { UsageEvent } from '../report/parsers/types.ts';
 import { localDate, localHour } from '../report/parsers/util.ts';
 import { resolveProject } from '../report/project.ts';
-import { isRealModel } from './model-name.ts';
+import { isRealModel, canonicalModel } from './model-name.ts';
 import type { WrappedLongestSession, WrappedRhythm } from './types.ts';
 
 export interface ModelFirsts {
@@ -28,6 +28,8 @@ export interface WrappedEventStats {
    *  double-count cross-midnight sessions, so wrapped never uses them. */
   sessionsByTool: Map<string, number>;
   sessionsByProject: Map<string, number>;
+  /** Keyed by canonical display name (snapshots/aliases merged; sentinels excluded),
+   *  so `.size` is the distinct-models-tried count and adoption dates pool variants. */
   modelFirsts: Map<string, ModelFirsts>;
   /** Share of assistant replies in local hours 22:00–05:59 (22, 23, and 0–5) —
    *  the persona "clock" axis. Broader than nightsPastMidnight's deep-night 0–4. */
@@ -109,17 +111,22 @@ export function computeEventStats(events: UsageEvent[], tz: string): WrappedEven
 
     // '<synthetic>' and other sentinel ids are turns with no real model — they
     // must never win a day's adoption race or be counted as a model "tried".
+    // Track by canonical name so dated snapshots / provider aliases of one model
+    // pool their votes (otherwise a split model loses the daily race to an
+    // unsplit one and never earns a firstTopDay), and modelFirsts is keyed the
+    // same way the cast list and modelsTried count it.
     if (isRealModel(e.model)) {
+      const canon = canonicalModel(e.model);
       let models = dayModel.get(date);
       if (!models) {
         models = new Map();
         dayModel.set(date, models);
       }
-      models.set(e.model, (models.get(e.model) ?? 0) + 1);
+      models.set(canon, (models.get(canon) ?? 0) + 1);
 
-      const first = modelFirsts.get(e.model);
+      const first = modelFirsts.get(canon);
       if (!first) {
-        modelFirsts.set(e.model, { firstSeen: date, firstTopDay: null });
+        modelFirsts.set(canon, { firstSeen: date, firstTopDay: null });
       } else if (date < first.firstSeen) {
         first.firstSeen = date;
       }

--- a/src/wrapped/compute.ts
+++ b/src/wrapped/compute.ts
@@ -7,6 +7,7 @@
 import type { UsageEvent } from '../report/parsers/types.ts';
 import { localDate, localHour } from '../report/parsers/util.ts';
 import { resolveProject } from '../report/project.ts';
+import { isRealModel } from './model-name.ts';
 import type { WrappedLongestSession, WrappedRhythm } from './types.ts';
 
 export interface ModelFirsts {
@@ -28,7 +29,8 @@ export interface WrappedEventStats {
   sessionsByTool: Map<string, number>;
   sessionsByProject: Map<string, number>;
   modelFirsts: Map<string, ModelFirsts>;
-  /** Share of messages in local hours 22-23 and 0-5, 0-1. */
+  /** Share of assistant replies in local hours 22:00–05:59 (22, 23, and 0–5) —
+   *  the persona "clock" axis. Broader than nightsPastMidnight's deep-night 0–4. */
   nightShare: number;
 }
 
@@ -105,18 +107,22 @@ export function computeEventStats(events: UsageEvent[], tz: string): WrappedEven
       if (!s.project) s.project = e.projectPath;
     }
 
-    let models = dayModel.get(date);
-    if (!models) {
-      models = new Map();
-      dayModel.set(date, models);
-    }
-    models.set(e.model, (models.get(e.model) ?? 0) + 1);
+    // '<synthetic>' and other sentinel ids are turns with no real model — they
+    // must never win a day's adoption race or be counted as a model "tried".
+    if (isRealModel(e.model)) {
+      let models = dayModel.get(date);
+      if (!models) {
+        models = new Map();
+        dayModel.set(date, models);
+      }
+      models.set(e.model, (models.get(e.model) ?? 0) + 1);
 
-    const first = modelFirsts.get(e.model);
-    if (!first) {
-      modelFirsts.set(e.model, { firstSeen: date, firstTopDay: null });
-    } else if (date < first.firstSeen) {
-      first.firstSeen = date;
+      const first = modelFirsts.get(e.model);
+      if (!first) {
+        modelFirsts.set(e.model, { firstSeen: date, firstTopDay: null });
+      } else if (date < first.firstSeen) {
+        first.firstSeen = date;
+      }
     }
   }
 

--- a/src/wrapped/content.ts
+++ b/src/wrapped/content.ts
@@ -9,6 +9,7 @@ import type { Database } from 'bun:sqlite';
 import { getIndexDb } from '../cache.ts';
 import { significanceScore, isTrivia, hasArtifact } from '../significance.ts';
 import { resolveProject } from '../report/project.ts';
+import { junkCwdSql } from './exclude.ts';
 import type { PhraseStat, WrappedContentStats, WrappedSessionOfYear } from './types.ts';
 
 /** Index tool names ('claude') differ from report ToolIds ('claude-code'). */
@@ -37,7 +38,7 @@ const PHRASES: PhraseSpec[] = [
   { id: 'assistantApology', role: 'assistant', patterns: ['%apolog%'] },
   { id: 'ultrathink', role: 'user', patterns: ['%ultrathink%'] },
   { id: 'quickQuestion', role: 'user', patterns: ['%quick question%', '%real quick%', '%just a quick%'] },
-  { id: 'oneMoreThing', role: 'user', patterns: ['%one more thing%', '%one last thing%', '%last thing%'] },
+  { id: 'oneMoreThing', role: 'user', patterns: ['%one more thing%', '%one last thing%'] },
   { id: 'shouldWork', role: 'user', patterns: ['%should work%'] },
   {
     id: 'stillBroken',
@@ -74,7 +75,13 @@ const STOPWORDS = new Set(
     'true false null undefined const import export return async await class method methods module script json html css ' +
     'text item items set sets setting settings config options option flag flags default logic implement implementation ' +
     'implemented feature features support supported supports current existing based instead different single multiple ' +
-    'able available actual specific proper properly correct correctly wrong empty missing invalid valid every each'
+    'able available actual specific proper properly correct correctly wrong empty missing invalid valid every each ' +
+    // agent-era plumbing — true of every heavy agent user, so never distinctive.
+    // These are the tools and nouns of the medium itself, not the user's subject,
+    // including the assistant/model names that show up in nearly every transcript.
+    'read write edit grep bash tool tools agent agents subagent skill skills task tasks context summary session ' +
+    'sessions review prompt prompts message messages model models token tokens directory search output plan mode ' +
+    'claude codex opus sonnet haiku gemini anthropic openai full'
   )
     .split(/\s+/)
     .filter(Boolean),
@@ -90,7 +97,16 @@ interface CountRow {
 // win session-of-the-year. The explicit '?' guard documents intent even though
 // lexical comparison already excludes the sentinel. Known skew, disclosed in
 // docs: these are UTC-sliced dates while event stats bucket in local tz.
-const PERIOD_WHERE = `s.created_at >= $from AND s.created_at <= $to AND s.created_at != '?'`;
+//
+// message_count > 0 drops empty sessions (a launched-then-quit shell, or a
+// menu-bar app's health-check probe) — they carry no content but would still
+// count as "drive-bys" and inflate the indexedSessions denominator. junkCwdSql
+// drops automated probe/eval/throwaway sessions that aren't the user's own
+// coding (see exclude.ts). Both apply to every content query, so the per-session
+// tables (drive-bys, abandoned, errors, files, commands) and the FTS censuses
+// (phrases, monologue, vocabulary) all count the same real sessions.
+const PERIOD_WHERE =
+  `s.created_at >= $from AND s.created_at <= $to AND s.created_at != '?' AND s.message_count > 0` + junkCwdSql('s.cwd');
 
 function phraseCounts(db: Database, from: string, to: string, tool: string | null): PhraseStat[] {
   const out: PhraseStat[] = [];
@@ -136,9 +152,15 @@ export function mineWords(
   for (const { text, file } of texts) {
     const words = cleanForMining(text.toLowerCase()).match(/[a-z][a-z'-]{3,}/g);
     if (!words) continue;
+    // Count each word at most once per message. cleanForMining strips fenced/
+    // inline code and paths, but an unfenced log or stack-trace paste still leaks
+    // its vocabulary wholesale — dedup-per-message so one dump can't crown a word
+    // it repeats 200 times. `count` is therefore "messages containing the word".
+    const seen = new Set<string>();
     for (const raw of words) {
       const w = raw.replace(/['-]/g, '');
-      if (w.length < 4 || STOPWORDS.has(w)) continue;
+      if (w.length < 4 || STOPWORDS.has(w) || seen.has(w)) continue;
+      seen.add(w);
       let e = counts.get(w);
       if (!e) {
         e = { count: 0, files: new Set() };
@@ -316,9 +338,13 @@ export async function computeContentStats(opts: ContentOptions): Promise<
       if (c && !PLUMBING.has(c.split(' ')[0]!)) commandCounts.set(c, (commandCounts.get(c) ?? 0) + 1);
     }
 
-    const proj = projectAgg.get(r.cwd);
+    // Key by resolved project (repo), not raw cwd — otherwise a stale worktree
+    // or subdir (…/cli/some-branch) reads as the whole repo being abandoned even
+    // when …/cli/main is active. Repo granularity matches the projects card.
+    const projName = resolveProject(r.cwd);
+    const proj = projectAgg.get(projName);
     if (!proj) {
-      projectAgg.set(r.cwd, { sessions: 1, lastSeen: r.date });
+      projectAgg.set(projName, { sessions: 1, lastSeen: r.date });
     } else {
       proj.sessions++;
       if (r.date > proj.lastSeen) proj.lastSeen = r.date;
@@ -341,10 +367,10 @@ export async function computeContentStats(opts: ContentOptions): Promise<
     .toISOString()
     .slice(0, 10);
   let abandoned: { name: string; sessions: number; lastSeen: string } | null = null;
-  for (const [cwd, agg] of projectAgg) {
+  for (const [name, agg] of projectAgg) {
     if (agg.sessions >= 10 && agg.lastSeen < cutoff) {
       if (!abandoned || agg.sessions > abandoned.sessions) {
-        abandoned = { name: resolveProject(cwd), sessions: agg.sessions, lastSeen: agg.lastSeen };
+        abandoned = { name, sessions: agg.sessions, lastSeen: agg.lastSeen };
       }
     }
   }

--- a/src/wrapped/exclude.ts
+++ b/src/wrapped/exclude.ts
@@ -6,11 +6,11 @@
 // code, yet both inflate session counts, flood the error census, and seed bogus
 // superlatives ("990 sessions of love, then silence" for a health-check probe).
 //
-// This is wrapped-only: `sessions report` and search still see everything, because
-// you might genuinely want to *find* that eval run. Wrapped is a story about you.
-//
-// Defined once as substring/prefix rules so the event pass (a JS filter over
-// UsageEvents) and the content pass (a SQLite WHERE over the index) can't drift.
+// This applies to wrapped's CONTENT pass only (the fun story: abandoned projects,
+// drive-bys, word of the year, errors). The spend/volume headline (tokens, cost,
+// sessions, rhythm) is deliberately NOT filtered — it must reconcile with
+// `sessions report`, and automated eval runs still cost real money. `report` and
+// search also see everything, because you might genuinely want to *find* that run.
 
 /** Substring the cwd must NOT contain. */
 const JUNK_SUBSTRINGS = [

--- a/src/wrapped/exclude.ts
+++ b/src/wrapped/exclude.ts
@@ -1,0 +1,49 @@
+// What counts as "your coding year" for wrapped — and what doesn't. Two classes
+// of session pollute a personal year-in-review even though they're legitimately
+// on disk: automated *probes* (menu-bar apps that spawn a throwaway Claude session
+// every few minutes to read a token count) and automated *harness/throwaway* runs
+// (eval suites and scratch apps under temp dirs). Neither is you sitting down to
+// code, yet both inflate session counts, flood the error census, and seed bogus
+// superlatives ("990 sessions of love, then silence" for a health-check probe).
+//
+// This is wrapped-only: `sessions report` and search still see everything, because
+// you might genuinely want to *find* that eval run. Wrapped is a story about you.
+//
+// Defined once as substring/prefix rules so the event pass (a JS filter over
+// UsageEvents) and the content pass (a SQLite WHERE over the index) can't drift.
+
+/** Substring the cwd must NOT contain. */
+const JUNK_SUBSTRINGS = [
+  '/var/folders/', // macOS temp root — eval harnesses run under $TMPDIR/eval-*
+];
+
+/** Prefix the cwd must NOT start with. */
+const JUNK_PREFIXES = [
+  '/private/tmp/', // scratch apps, install tests, throwaway repros
+  '/tmp/',
+];
+
+/** Suffix the cwd must NOT end with. */
+const JUNK_SUFFIXES = [
+  '/ClaudeProbe', // CodexBar / TokenBar menu-bar health-check sessions
+];
+
+/** True when a cwd is an automated probe / harness / throwaway, not real user work. */
+export function isJunkCwd(cwd: string | undefined): boolean {
+  if (!cwd) return false; // unknown cwd is kept — it's real work we just can't place
+  if (JUNK_SUBSTRINGS.some((s) => cwd.includes(s))) return true;
+  if (JUNK_PREFIXES.some((p) => cwd.startsWith(p))) return true;
+  if (JUNK_SUFFIXES.some((s) => cwd.endsWith(s))) return true;
+  return false;
+}
+
+/** The same rule as `isJunkCwd`, as a SQL fragment excluding junk rows.
+ *  `col` is the qualified cwd column (e.g. `s.cwd`). Emitted with a leading
+ *  space and joined by AND so it can be appended straight onto a WHERE clause. */
+export function junkCwdSql(col: string): string {
+  const clauses: string[] = [];
+  for (const s of JUNK_SUBSTRINGS) clauses.push(`${col} NOT LIKE '%' || '${s}' || '%'`);
+  for (const p of JUNK_PREFIXES) clauses.push(`${col} NOT LIKE '${p}' || '%'`);
+  for (const s of JUNK_SUFFIXES) clauses.push(`${col} NOT LIKE '%' || '${s}'`);
+  return clauses.map((c) => ` AND ${c}`).join('');
+}

--- a/src/wrapped/html.ts
+++ b/src/wrapped/html.ts
@@ -6,11 +6,17 @@
 // zero external requests. JS is textContent-only — never innerHTML.
 
 import type { WrappedData, FunCard, WrappedExtra } from './types.ts';
+import { prettyModel } from './model-name.ts';
+
+// Re-exported so existing importers (and tests) keep resolving prettyModel here.
+export { prettyModel } from './model-name.ts';
 
 const esc = (s: string): string =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
 const fmtInt = (n: number): string => n.toLocaleString('en-US');
+/** "1 day" / "2 days" — never "1 days". */
+const plural = (n: number, one: string, many = `${one}s`): string => (n === 1 ? one : many);
 
 function fmtTokens(n: number): string {
   if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(2) + 'B';
@@ -58,21 +64,6 @@ const ACCENTS = [
   { name: 'tangerine', c: 'oklch(76% 0.18 50)' },
   { name: 'red', c: 'oklch(68% 0.21 25)' },
 ] as const;
-
-/** "claude-opus-4-8" / "claude-haiku-4-5-20251001" → "Opus 4.8" / "Haiku 4.5";
- *  anything unrecognized keeps its raw id (never invent a name). */
-export function prettyModel(id: string): string {
-  // The minor version is 1-2 digits at a segment boundary — an 8-digit date
-  // suffix (claude-opus-4-20250514) is NOT a minor version.
-  const claude = id.match(/^claude-(opus|sonnet|haiku|fable|mythos)-(\d+)(?:-(\d{1,2})(?=-|$))?/);
-  if (claude) {
-    const family = claude[1]!.charAt(0).toUpperCase() + claude[1]!.slice(1);
-    return claude[3] ? `${family} ${claude[2]}.${claude[3]}` : `${family} ${claude[2]}`;
-  }
-  const gpt = id.match(/^gpt-([\d.]+)(-\w+)?/);
-  if (gpt) return `GPT-${gpt[1]}${gpt[2] ?? ''}`;
-  return id;
-}
 
 /** Reframe the raw token count as something human — the "minutes listened" move. */
 export function tokenEquivalence(tokens: number): string | null {
@@ -147,33 +138,32 @@ function bigNum(n: number, fmt: 'int' | 'tok' | 'usd'): string {
   return `<div class="big"><span class="n" data-n="${n}" data-fmt="${fmt}">${esc(rendered)}</span></div>`;
 }
 
-function heatmap(heat: number[][]): string {
+// The outline marks the busiest-HOUR column and busiest-DAY row — the same two
+// marginals the caption names — so text and picture never disagree. (An earlier
+// version outlined the single hottest cell, which could sit on a different
+// hour/day than the caption's independently-computed marginals.)
+function heatmap(heat: number[][], peakHour: number, peakWeekday: number): string {
   let max = 0;
-  let maxWd = -1;
-  let maxHour = -1;
   for (let wd = 0; wd < 7; wd++) {
     for (let h = 0; h < 24; h++) {
-      if (heat[wd]![h]! > max) {
-        max = heat[wd]![h]!;
-        maxWd = wd;
-        maxHour = h;
-      }
+      if (heat[wd]![h]! > max) max = heat[wd]![h]!;
     }
   }
   if (max === 0) return '';
   let cells = '';
   for (let wd = 0; wd < 7; wd++) {
-    cells += `<div class="hm-lbl">${DAY_LETTERS[wd]}</div>`;
+    cells += `<div class="hm-lbl${wd === peakWeekday ? ' on' : ''}">${DAY_LETTERS[wd]}</div>`;
     for (let h = 0; h < 24; h++) {
       const v = heat[wd]![h]!;
       const pct = v === 0 ? 0 : Math.round(12 + 78 * Math.sqrt(v / max));
-      const peak = wd === maxWd && h === maxHour ? ' peak' : '';
-      cells += `<div class="hm-cell${peak}" style="--p:${pct}%" data-tip="${esc(`${WEEKDAYS[wd]} ${hourLabel(h)} — ${fmtInt(v)} msgs`)}"></div>`;
+      const band = (wd === peakWeekday ? ' pk-row' : '') + (h === peakHour ? ' pk-col' : '');
+      const peak = wd === peakWeekday && h === peakHour ? ' peak' : '';
+      cells += `<div class="hm-cell${band}${peak}" style="--p:${pct}%" data-tip="${esc(`${WEEKDAYS[wd]} ${hourLabel(h)} — ${fmtInt(v)} ${plural(v, 'reply', 'replies')}`)}"></div>`;
     }
   }
   let hours = '<div></div>';
   for (let h = 0; h < 24; h++) {
-    hours += `<div class="hm-hr">${h % 6 === 0 ? hourLabel(h).replace(' ', '') : ''}</div>`;
+    hours += `<div class="hm-hr${h === peakHour ? ' on' : ''}">${h % 6 === 0 ? hourLabel(h).replace(' ', '') : ''}</div>`;
   }
   return `<div class="scrollx"><div class="hm">${cells}${hours}</div></div>`;
 }
@@ -200,12 +190,12 @@ function streakStrip(daily: { date: string; tokens: number }[], streak: { from: 
   return `<div class="scrollx"><div class="cal">${cells}</div></div>`;
 }
 
-function rankedList(rows: { name: string; value: number; detail: string }[], unit: 'tok' | 'usd'): string {
+function rankedList(rows: { name: string; value: number; detail: string }[], unit: 'tok' | 'usd' | 'count'): string {
   const max = Math.max(1, ...rows.map((r) => r.value));
   return `<ol class="rank">${rows
     .map((r, i) => {
       const pct = ((r.value / max) * 100).toFixed(1);
-      const val = unit === 'usd' ? fmtUSD(r.value) : fmtTokens(r.value);
+      const val = unit === 'usd' ? fmtUSD(r.value) : unit === 'count' ? fmtInt(r.value) : fmtTokens(r.value);
       return `<li style="--i:${rows.length - 1 - i}"><span class="pos">${i + 1}</span><span class="rname">${esc(r.name)}</span><span class="rtrack"><span class="rfill" style="width:${pct}%"></span></span><span class="rval" data-tip="${esc(r.detail)}">${val}</span></li>`;
     })
     .join('')}</ol>`;
@@ -254,28 +244,36 @@ ${empty ? `<p class="lede">A quiet year — no sessions found. The mystery of yo
   });
 
   if (!empty) {
-    const equiv = tokenEquivalence(d.totals.tokens);
-    cards.push({
-      id: 'tokens',
-      body: `${echo(fmtTokens(d.totals.tokens))}<div class="panel center">${kicker('the year in tokens')}<h2>You and your agents had a lot to say.</h2>${bigNum(d.totals.tokens, 'tok')}<p class="lede">tokens exchanged${equiv ? ` — ${esc(equiv)}` : ''}</p>${foot('input + output + cache writes · same math as sessions report')}</div>`,
-    });
+    // Local-model years (Ollama, gpt-oss, etc.) report no billed tokens. Showing
+    // a hero "0" / "$0" would read as broken, so the token and cost cards only
+    // appear when there's a meter to report — the deck leans on the non-zero
+    // signals (sessions, replies, rhythm, models, persona) instead.
+    if (d.totals.tokens > 0) {
+      const equiv = tokenEquivalence(d.totals.tokens);
+      cards.push({
+        id: 'tokens',
+        body: `${echo(fmtTokens(d.totals.tokens))}<div class="panel center">${kicker('the year in tokens')}<h2>You and your agents had a lot to say.</h2>${bigNum(d.totals.tokens, 'tok')}<p class="lede">tokens exchanged${equiv ? ` — ${esc(equiv)}` : ''}</p>${foot('input + output + cache writes · same math as sessions report')}</div>`,
+      });
+    }
 
-    const cachePct = d.cacheHitRate !== null ? Math.round(d.cacheHitRate * 100) : null;
-    const costEq = costEquivalence(d.totals.costUSD);
-    cards.push({
-      id: 'cost',
-      body: `${echo(fmtUSD(d.totals.costUSD))}<div class="panel center">${kicker('the receipt')}<h2>All of that, à la carte?</h2>${bigNum(d.totals.costUSD, 'usd')}<p class="lede">what this year would have cost at API list prices${costEq ? ` — ${esc(costEq)}` : ''}</p>${
-        cachePct !== null
-          ? `<div class="substat" style="--i:1"><span class="sn">${cachePct}%</span><span class="sl">cache hit rate — ${fmtTokens(d.totals.cacheReadTokens)} tokens re-read from cache instead of full price</span></div>`
-          : ''
-      }${
-        d.warnings.length > 0
-          ? foot(
-              `${d.warnings.length} model(s) had no pricing — the real number is higher: ${d.warnings.map((w) => w.model).join(', ')}`,
-            )
-          : foot('estimated from LiteLLM list prices · cache reads billed at cache rates')
-      }</div>`,
-    });
+    if (d.totals.costUSD > 0) {
+      const cachePct = d.cacheHitRate !== null ? Math.round(d.cacheHitRate * 100) : null;
+      const costEq = costEquivalence(d.totals.costUSD);
+      cards.push({
+        id: 'cost',
+        body: `${echo(fmtUSD(d.totals.costUSD))}<div class="panel center">${kicker('the receipt')}<h2>All of that, à la carte?</h2>${bigNum(d.totals.costUSD, 'usd')}<p class="lede">what this year would have cost at API list prices${costEq ? ` — ${esc(costEq)}` : ''}</p>${
+          cachePct !== null
+            ? `<div class="substat" style="--i:1"><span class="sn">${cachePct}%</span><span class="sl">cache hit rate — ${fmtTokens(d.totals.cacheReadTokens)} tokens re-read from cache instead of full price</span></div>`
+            : ''
+        }${
+          d.warnings.length > 0
+            ? foot(
+                `${d.warnings.length} model(s) had no pricing — the real number is higher: ${d.warnings.map((w) => w.model).join(', ')}`,
+              )
+            : foot('estimated from LiteLLM list prices · cache reads billed at cache rates')
+        }</div>`,
+      });
+    }
 
     const streak = d.totals.longestStreak;
     cards.push({
@@ -287,32 +285,35 @@ ${empty ? `<p class="lede">A quiet year — no sessions found. The mystery of yo
 <div class="stat" style="--i:2"><span class="n" data-n="${d.totals.activeDays}" data-fmt="int">${fmtInt(d.totals.activeDays)}</span><span class="l">active days</span></div>
 </div>
 ${streakStrip(d.daily, streak ? { from: streak.from, to: streak.to } : null)}
-${streak ? `<p class="lede">longest streak: <b>${streak.days} days</b> <em>(${esc(shortDate(streak.from))} – ${esc(shortDate(streak.to))})</em></p>` : ''}
+${streak ? `<p class="lede">longest streak: <b>${streak.days} ${plural(streak.days, 'day')}</b> <em>(${esc(shortDate(streak.from))} – ${esc(shortDate(streak.to))})</em></p>` : ''}
 </div>`,
     });
 
     cards.push({
       id: 'rhythm',
       body: `<div class="panel">${kicker('your rhythm')}<h2>You have a witching hour.</h2>
-${heatmap(d.rhythm.heat)}
-<p class="lede">peak: <b>${esc(hourLabel(d.rhythm.peakHour))}</b> on <b>${esc(WEEKDAYS[d.rhythm.peakWeekday]!)}s</b>${
+${heatmap(d.rhythm.heat, d.rhythm.peakHour, d.rhythm.peakWeekday)}
+<p class="lede">busiest hour: <b>${esc(hourLabel(d.rhythm.peakHour))}</b> · busiest day: <b>${esc(WEEKDAYS[d.rhythm.peakWeekday]!)}s</b>${
         d.rhythm.nightsPastMidnight > 0
-          ? ` <em>· past midnight on ${fmtInt(d.rhythm.nightsPastMidnight)} nights</em>`
+          ? ` <em>· past midnight on ${fmtInt(d.rhythm.nightsPastMidnight)} ${plural(d.rhythm.nightsPastMidnight, 'night')}</em>`
           : ''
-      }</p>${foot(`local time (${d.tz})`)}</div>`,
+      }</p>${foot(`local time (${d.tz}) · busiest hour and day are counted separately`)}</div>`,
     });
 
     if (d.projects.length > 0) {
       const topShare = Math.round((d.projects[0]?.share ?? 0) * 100);
+      const byTokens = d.totals.tokens > 0;
       cards.push({
         id: 'projects',
         body: `<div class="panel">${kicker('the obsessions')}<h2>Where the year actually went.</h2>${rankedList(
           d.projects.map((p) => ({
             name: p.name,
-            value: p.tokens,
-            detail: `${fmtInt(p.sessions)} sessions · ${fmtUSD(p.costUSD)}`,
+            value: byTokens ? p.tokens : p.sessions,
+            detail: byTokens
+              ? `${fmtInt(p.sessions)} ${plural(p.sessions, 'session')} · ${fmtUSD(p.costUSD)}`
+              : `${fmtInt(p.sessions)} ${plural(p.sessions, 'session')}`,
           })),
-          'tok',
+          byTokens ? 'tok' : 'count',
         )}${topShare >= 25 ? `<p class="lede"><b>${esc(d.projects[0]!.name)}</b> alone ate <b>${topShare}%</b> of everything.</p>` : ''}</div>`,
       });
     }
@@ -331,9 +332,14 @@ ${heatmap(d.rhythm.heat)}
       const story = newest
         ? `<p class="lede"><b>${esc(prettyModel(newest.label))}</b> arrived <b>${esc(shortDate(newest.firstSeen))}</b> — ${takeover}. ${newest.id === d.models[0]!.id ? 'It never looked back.' : 'The old guard held on.'}</p>`
         : '';
+      // A tool you actually used must never read "0%": floor sub-1% shares to "<1%".
+      const sharePct = (share: number): string => {
+        const p = Math.round(share * 100);
+        return share > 0 && p < 1 ? '<1%' : `${p}%`;
+      };
       const toolStrip =
         d.tools.length > 1
-          ? `<div class="pills">${d.tools.map((t) => `<span class="pill">${esc(t.label)} ${Math.round(t.share * 100)}%</span>`).join('')}</div>`
+          ? `<div class="pills">${d.tools.map((t) => `<span class="pill">${esc(t.label)} ${sharePct(t.share)}</span>`).join('')}</div>`
           : '';
       cards.push({
         id: 'models',
@@ -343,7 +349,7 @@ ${heatmap(d.rhythm.heat)}
             value: m.messages,
             detail: `${fmtTokens(m.tokens)} tokens · first seen ${shortDate(m.firstSeen)}`,
           })),
-          'tok',
+          'count',
         )}${story}${toolStrip}${foot(
           `ranked by replies · bars show reply volume${
             d.modelsTried > d.models.length
@@ -355,10 +361,17 @@ ${heatmap(d.rhythm.heat)}
     }
 
     if (d.biggestDay) {
-      const ratio = d.biggestDay.medianTokens > 0 ? d.biggestDay.tokens / d.biggestDay.medianTokens : 0;
+      // Show tokens normally; on local-model years (no token meter) show messages
+      // so the card is a real day, not a giant "0".
+      const bd = d.biggestDay;
+      const byTokens = bd.tokens > 0;
+      const value = byTokens ? bd.tokens : bd.messages;
+      const median = byTokens ? bd.medianTokens : bd.medianMessages;
+      const noun = byTokens ? 'tokens' : 'messages';
+      const ratio = median > 0 ? value / median : 0;
       cards.push({
         id: 'bigday',
-        body: `${echo(shortDate(d.biggestDay.date))}<div class="panel center">${kicker('the bender')}<h2>Then there was ${esc(formatDate(d.biggestDay.date))}.</h2>${bigNum(d.biggestDay.tokens, 'tok')}<p class="lede">tokens in a single day${
+        body: `${echo(shortDate(bd.date))}<div class="panel center">${kicker('the bender')}<h2>Then there was ${esc(formatDate(bd.date))}.</h2>${bigNum(value, byTokens ? 'tok' : 'int')}<p class="lede">${noun} in a single day${
           ratio >= 2 ? ` — <b>${ratio >= 10 ? Math.round(ratio) : ratio.toFixed(1)}×</b> your median day` : ''
         }</p></div>`,
       });
@@ -379,11 +392,11 @@ ${heatmap(d.rhythm.heat)}
         id: 'magnum',
         body: `<div class="panel">${kicker('your magnum opus')}${
           soy
-            ? `<h2>“${esc(soy.title)}”</h2><p class="lede">${esc(formatDate(soy.date))} · <b>${esc(soy.project)}</b> · ${fmtInt(soy.messageCount)} messages · ${fmtInt(soy.filesTouched)} files${soy.shipped ? ' · <span class="badge">shipped</span>' : ''}</p>`
+            ? `<h2>“${esc(soy.title)}”</h2><p class="lede">${esc(formatDate(soy.date))} · <b>${esc(soy.project)}</b> · ${fmtInt(soy.messageCount)} ${plural(soy.messageCount, 'message')} · ${fmtInt(soy.filesTouched)} ${plural(soy.filesTouched, 'file')}${soy.shipped ? ' · <span class="badge">shipped</span>' : ''}</p>`
             : ''
         }${
           ls
-            ? `<div class="substat" style="--i:1"><span class="sn">${esc(fmtDuration(ls.durationMs))}</span><span class="sl">your longest sitting — ${fmtInt(ls.replies)} replies, ${esc(formatDate(ls.date))}, ${esc(ls.project)}</span></div>`
+            ? `<div class="substat" style="--i:1"><span class="sn">${esc(fmtDuration(ls.durationMs))}</span><span class="sl">your longest sitting — ${fmtInt(ls.replies)} ${plural(ls.replies, 'reply', 'replies')}, ${esc(formatDate(ls.date))}, ${esc(ls.project)}</span></div>`
             : ''
         }${soy ? foot('ranked by substance: message volume, files edited, and whether something shipped') : ''}</div>`,
       });
@@ -395,7 +408,7 @@ ${heatmap(d.rhythm.heat)}
       const w = d.wordOfYear;
       cards.push({
         id: 'word',
-        body: `${echo(w.word)}<div class="panel center">${kicker('your word of the year')}<div class="big bigword"><span class="n">${esc(w.word)}</span></div><p class="lede">typed <b>${fmtInt(w.count)}</b> times across <b>${fmtInt(w.sessions)}</b> sessions</p>${
+        body: `${echo(w.word)}<div class="panel center">${kicker('your word of the year')}<div class="big bigword"><span class="n">${esc(w.word)}</span></div><p class="lede">in <b>${fmtInt(w.count)}</b> of your ${plural(w.count, 'message')} across <b>${fmtInt(w.sessions)}</b> ${plural(w.sessions, 'session')}</p>${
           w.runnersUp.length > 0 ? `<p class="lede"><em>also in rotation: ${esc(w.runnersUp.join(', '))}</em></p>` : ''
         }${foot('mined from your own prompts · common words excluded')}</div>`,
       });
@@ -431,10 +444,8 @@ ${foot('a description of how you worked this year, not who you are · this card 
   if (d.models[0]) creditRows.push(['starring', prettyModel(d.models[0].label)]);
   if (d.models[1]) creditRows.push(['the understudy', prettyModel(d.models[1].label)]);
   if (d.content?.topCommands[0]) {
-    creditRows.push([
-      'featuring',
-      `${d.content.topCommands[0].name} (${fmtInt(d.content.topCommands[0].sessions)} sessions)`,
-    ]);
+    const tc = d.content.topCommands[0];
+    creditRows.push(['featuring', `${tc.name} (${fmtInt(tc.sessions)} ${plural(tc.sessions, 'session')})`]);
   }
   if (d.projects[0]) creditRows.push(['on location', d.projects[0].name]);
   if (d.content?.topFiles[0]) creditRows.push(['set dressing', d.content.topFiles[0].name]);
@@ -455,7 +466,8 @@ ${foot('a description of how you worked this year, not who you are · this card 
     ]);
   }
   if (d.content?.errors && d.content.errors.totalErrors > 0) {
-    creditRows.push(['stunts', `${fmtInt(d.content.errors.totalErrors)} errors, all survived`]);
+    const n = d.content.errors.totalErrors;
+    creditRows.push(['stunts', `${fmtInt(n)} ${plural(n, 'error')}, all survived`]);
   }
   if (d.content?.abandoned) {
     creditRows.push([
@@ -550,7 +562,9 @@ h2{font-size:clamp(1.5rem,4vw,2.2rem);font-weight:800;letter-spacing:-.01em;line
 .hm-lbl,.hm-hr{font-family:var(--mono);font-size:9.5px;color:var(--faint);display:flex;align-items:center;}
 .hm-hr{justify-content:flex-start;}
 .hm-cell{aspect-ratio:1;border-radius:2px;background:color-mix(in oklch,var(--a) var(--p),oklch(20% 0.01 280));}
+.hm-cell.pk-row,.hm-cell.pk-col{box-shadow:inset 0 0 0 1px color-mix(in oklch,var(--ink) 30%,transparent);}
 .hm-cell.peak{outline:2px solid var(--ink);outline-offset:-1px;}
+.hm-lbl.on,.hm-hr.on{color:var(--a);font-weight:700;}
 .cal{display:grid;grid-auto-flow:column;grid-template-rows:repeat(7,10px);gap:3px;width:max-content;}
 .cal-cell{width:10px;height:10px;border-radius:2px;background:color-mix(in oklch,var(--a) var(--p),oklch(20% 0.01 280));}
 .cal-cell.streak{outline:1.5px solid var(--ink);outline-offset:-1px;}

--- a/src/wrapped/html.ts
+++ b/src/wrapped/html.ts
@@ -273,6 +273,14 @@ ${empty ? `<p class="lede">A quiet year — no sessions found. The mystery of yo
             : foot('estimated from LiteLLM list prices · cache reads billed at cache rates')
         }</div>`,
       });
+    } else if (d.totals.tokens > 0 && d.warnings.length > 0) {
+      // Metered tokens but every model was unpriced → cost is 0 not because it
+      // was free but because we couldn't price it. Surface that instead of
+      // silently dropping the warning with the (hidden) $0 receipt card.
+      cards.push({
+        id: 'cost',
+        body: `<div class="panel center">${kicker('the receipt')}<h2>No price tag this year.</h2><p class="lede">cost couldn’t be estimated — ${d.warnings.length} model(s) had no list price</p>${foot(`unpriced: ${d.warnings.map((w) => w.model).join(', ')}`)}</div>`,
+      });
     }
 
     const streak = d.totals.longestStreak;

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -18,7 +18,6 @@ import { computeContentStats } from './content.ts';
 import { selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
 import { renderWrappedHtml } from './html.ts';
 import { canonicalModel, isRealModel } from './model-name.ts';
-import { isJunkCwd } from './exclude.ts';
 import { coerceExtras } from './extras.ts';
 import { runRoast, type RoastRunner, type RoastToolId } from './roast.ts';
 import type { WrappedData, WrappedExtra } from './types.ts';
@@ -177,11 +176,13 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
 
   const tools = opts.tool ? new Set<ToolId>([opts.tool]) : undefined;
   const events = await gatherEvents(opts.roots ?? defaultRoots(), tools);
-  // Drop automated probe/eval/throwaway sessions before anything else — they're
-  // not the user's coding year and would inflate totals, rhythm, and streaks
-  // (content.ts applies the same isJunkCwd rule on the index side).
+  // The spend/volume headline (tokens, cost, messages, sessions, rhythm, models,
+  // projects) is computed from the SAME events as `sessions report` so the two
+  // reconcile exactly — automated eval/tmp runs cost real money and belong in the
+  // total. Junk exclusion is a *content-pass* concern only (content.ts): it keeps
+  // probes/evals out of the fun story (abandoned, drive-bys, word of year,
+  // errors) where report has nothing to compare against and the noise misleads.
   const inRange = events.filter((e) => {
-    if (isJunkCwd(e.projectPath)) return false;
     const d = localDate(e.timestamp, tz);
     return d >= from && d <= to;
   });

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -270,7 +270,7 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
   // display name so the cast list never lists the same model twice, and drop the
   // '<synthetic>' sentinel (turns with no real model) entirely.
   const totalMessages = agg.summary.messages;
-  const byCanon = new Map<string, { id: string; label: string; messages: number; tokens: number; ids: Set<string> }>();
+  const byCanon = new Map<string, { id: string; label: string; messages: number; tokens: number }>();
   for (const m of agg.byModel) {
     if (!isRealModel(m.id)) continue;
     const key = canonicalModel(m.id);
@@ -278,32 +278,25 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
     if (cur) {
       cur.messages += m.messages;
       cur.tokens += m.tokens;
-      cur.ids.add(m.id);
     } else {
-      byCanon.set(key, { id: m.id, label: key, messages: m.messages, tokens: m.tokens, ids: new Set([m.id]) });
+      byCanon.set(key, { id: m.id, label: key, messages: m.messages, tokens: m.tokens });
     }
   }
   const models = [...byCanon.values()]
     .sort((a, b) => b.messages - a.messages)
     .slice(0, 5)
     .map((m) => {
-      // Earliest first-seen / first-top day across all snapshots of this model.
-      let firstSeen: string | null = null;
-      let firstTopDay: string | null = null;
-      for (const id of m.ids) {
-        const f = ev.modelFirsts.get(id);
-        if (!f) continue;
-        if (!firstSeen || f.firstSeen < firstSeen) firstSeen = f.firstSeen;
-        if (f.firstTopDay && (!firstTopDay || f.firstTopDay < firstTopDay)) firstTopDay = f.firstTopDay;
-      }
+      // modelFirsts is keyed by canonical name (compute.ts), so first-seen /
+      // first-top day already pool a model's snapshots.
+      const firsts = ev.modelFirsts.get(m.label);
       return {
         id: m.id,
         label: m.label,
         messages: m.messages,
         tokens: m.tokens,
         share: totalMessages > 0 ? m.messages / totalMessages : 0,
-        firstSeen: firstSeen ?? agg.period.from,
-        firstTopDay,
+        firstSeen: firsts?.firstSeen ?? agg.period.from,
+        firstTopDay: firsts?.firstTopDay ?? null,
       };
     });
 
@@ -381,9 +374,9 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
     longestGap,
     projects,
     models,
-    // Distinct models by display name — snapshots (opus-4-5 vs opus-4-5-20251101)
-    // and provider-prefixed aliases collapse; '<synthetic>' is already excluded.
-    modelsTried: new Set([...ev.modelFirsts.keys()].map(canonicalModel)).size,
+    // modelFirsts is canonical-keyed (snapshots/aliases already merged,
+    // '<synthetic>' excluded), so its size is the distinct-models-tried count.
+    modelsTried: ev.modelFirsts.size,
     tools: toolsOut,
     cacheHitRate: ev.cacheHitRate,
     longestSession: ev.longestSession,

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -17,6 +17,8 @@ import { computeEventStats, longestGapRange, longestStreakRange } from './comput
 import { computeContentStats } from './content.ts';
 import { selectFunCards, selectPersona, selectWordOfYear } from './select.ts';
 import { renderWrappedHtml } from './html.ts';
+import { canonicalModel, isRealModel } from './model-name.ts';
+import { isJunkCwd } from './exclude.ts';
 import { coerceExtras } from './extras.ts';
 import { runRoast, type RoastRunner, type RoastToolId } from './roast.ts';
 import type { WrappedData, WrappedExtra } from './types.ts';
@@ -175,7 +177,11 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
 
   const tools = opts.tool ? new Set<ToolId>([opts.tool]) : undefined;
   const events = await gatherEvents(opts.roots ?? defaultRoots(), tools);
+  // Drop automated probe/eval/throwaway sessions before anything else — they're
+  // not the user's coding year and would inflate totals, rhythm, and streaks
+  // (content.ts applies the same isJunkCwd rule on the index side).
   const inRange = events.filter((e) => {
+    if (isJunkCwd(e.projectPath)) return false;
     const d = localDate(e.timestamp, tz);
     return d >= from && d <= to;
   });
@@ -241,62 +247,99 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
   // aggregate sorts by cost; the page ranks by tokens — re-sort so bars are
   // monotone. Session counts come from the event pass (distinct per project),
   // never aggregate's sum-of-daily, which double-counts cross-midnight sessions.
+  // On local-model years (no token meter) rank by sessions so the list isn't a
+  // pile of zero-token ties.
+  const projSessions = (label: string, fallback: number): number => ev.sessionsByProject.get(label) ?? fallback;
   const projects = agg.byProject
     .slice()
-    .sort((a, b) => b.tokens - a.tokens)
+    .sort((a, b) =>
+      totalTokens > 0 ? b.tokens - a.tokens : projSessions(b.label, b.sessions) - projSessions(a.label, a.sessions),
+    )
     .slice(0, 5)
     .map((p) => ({
       name: p.label,
       tokens: p.tokens,
       costUSD: p.costUSD,
-      sessions: ev.sessionsByProject.get(p.label) ?? p.sessions,
+      sessions: projSessions(p.label, p.sessions),
       share: totalTokens > 0 ? p.tokens / totalTokens : 0,
     }));
 
-  // aggregate keys byModel by tool|provider|id, so one model reached through
-  // two tools shows up as split rows — merge by model id before ranking.
+  // aggregate keys byModel by tool|provider|id, so one model split across tools —
+  // and across dated snapshots / provider aliases (opus-4-5 vs opus-4-5-20251101
+  // vs openai/gpt-oss-120b) — shows up as several rows. Merge on the canonical
+  // display name so the cast list never lists the same model twice, and drop the
+  // '<synthetic>' sentinel (turns with no real model) entirely.
   const totalMessages = agg.summary.messages;
-  const byModelId = new Map<string, { id: string; label: string; messages: number; tokens: number }>();
+  const byCanon = new Map<string, { id: string; label: string; messages: number; tokens: number; ids: Set<string> }>();
   for (const m of agg.byModel) {
-    const cur = byModelId.get(m.id);
+    if (!isRealModel(m.id)) continue;
+    const key = canonicalModel(m.id);
+    const cur = byCanon.get(key);
     if (cur) {
       cur.messages += m.messages;
       cur.tokens += m.tokens;
+      cur.ids.add(m.id);
     } else {
-      byModelId.set(m.id, { id: m.id, label: m.label, messages: m.messages, tokens: m.tokens });
+      byCanon.set(key, { id: m.id, label: key, messages: m.messages, tokens: m.tokens, ids: new Set([m.id]) });
     }
   }
-  const models = [...byModelId.values()]
+  const models = [...byCanon.values()]
     .sort((a, b) => b.messages - a.messages)
     .slice(0, 5)
     .map((m) => {
-      const firsts = ev.modelFirsts.get(m.id);
+      // Earliest first-seen / first-top day across all snapshots of this model.
+      let firstSeen: string | null = null;
+      let firstTopDay: string | null = null;
+      for (const id of m.ids) {
+        const f = ev.modelFirsts.get(id);
+        if (!f) continue;
+        if (!firstSeen || f.firstSeen < firstSeen) firstSeen = f.firstSeen;
+        if (f.firstTopDay && (!firstTopDay || f.firstTopDay < firstTopDay)) firstTopDay = f.firstTopDay;
+      }
       return {
-        ...m,
+        id: m.id,
+        label: m.label,
+        messages: m.messages,
+        tokens: m.tokens,
         share: totalMessages > 0 ? m.messages / totalMessages : 0,
-        firstSeen: firsts?.firstSeen ?? agg.period.from,
-        firstTopDay: firsts?.firstTopDay ?? null,
+        firstSeen: firstSeen ?? agg.period.from,
+        firstTopDay,
       };
     });
 
   const toolTokens = agg.byTool.reduce((sum, t) => sum + t.tokens, 0);
-  const toolsOut = agg.byTool.map((t) => ({
-    id: t.id,
-    label: t.label,
-    sessions: ev.sessionsByTool.get(t.id) ?? t.sessions,
-    tokens: t.tokens,
-    share: toolTokens > 0 ? t.tokens / toolTokens : 0,
-  }));
+  const toolSessions = agg.byTool.reduce((sum, t) => sum + (ev.sessionsByTool.get(t.id) ?? t.sessions), 0);
+  const toolsOut = agg.byTool.map((t) => {
+    const sessions = ev.sessionsByTool.get(t.id) ?? t.sessions;
+    return {
+      id: t.id,
+      label: t.label,
+      sessions,
+      tokens: t.tokens,
+      // token share normally; session share on local-model years so a used tool
+      // isn't stuck at 0%.
+      share: toolTokens > 0 ? t.tokens / toolTokens : toolSessions > 0 ? sessions / toolSessions : 0,
+    };
+  });
 
   const daily = agg.daily.map((d) => ({ date: d.date, tokens: d.tokens, messages: d.messages }));
   const activeDaily = daily.filter((d) => d.messages > 0);
   let biggestDay: WrappedData['biggestDay'] = null;
   if (activeDaily.length > 0) {
-    const sorted = activeDaily.map((d) => d.tokens).sort((a, b) => a - b);
-    const mid = Math.floor(sorted.length / 2);
-    const medianTokens = sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
-    const peak = activeDaily.reduce((a, b) => (b.tokens > a.tokens ? b : a));
-    biggestDay = { ...peak, medianTokens };
+    const median = (vals: number[]): number => {
+      const s = [...vals].sort((a, b) => a - b);
+      const mid = Math.floor(s.length / 2);
+      return s.length % 2 === 1 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+    };
+    const medianTokens = median(activeDaily.map((d) => d.tokens));
+    const medianMessages = median(activeDaily.map((d) => d.messages));
+    // Rank by tokens normally; on local-model years (no token meter) rank by
+    // messages so the "biggest day" is still a real day, not a 0-token tie.
+    const peak =
+      totalTokens > 0
+        ? activeDaily.reduce((a, b) => (b.tokens > a.tokens ? b : a))
+        : activeDaily.reduce((a, b) => (b.messages > a.messages ? b : a));
+    biggestDay = { ...peak, medianTokens, medianMessages };
   }
 
   const activeDates = activeDaily.map((d) => d.date);
@@ -305,7 +348,12 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
 
   const fun = selectFunCards(content, ev.rhythm);
   const wordOfYear = selectWordOfYear(content);
-  const persona = selectPersona(ev, projects[0]?.share ?? 0, content);
+  // Focus = concentration on one project. Token share when there's a token meter;
+  // on local-model years fall back to session share so it isn't a false "0%".
+  const topSessionShare =
+    ev.distinctSessions > 0 ? Math.max(0, ...ev.sessionsByProject.values()) / ev.distinctSessions : 0;
+  const focusShare = totalTokens > 0 ? (projects[0]?.share ?? 0) : topSessionShare;
+  const persona = selectPersona(ev, focusShare, content);
 
   const dataBegins = activeDaily[0]?.date ?? null;
 
@@ -333,7 +381,9 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
     longestGap,
     projects,
     models,
-    modelsTried: ev.modelFirsts.size,
+    // Distinct models by display name — snapshots (opus-4-5 vs opus-4-5-20251101)
+    // and provider-prefixed aliases collapse; '<synthetic>' is already excluded.
+    modelsTried: new Set([...ev.modelFirsts.keys()].map(canonicalModel)).size,
     tools: toolsOut,
     cacheHitRate: ev.cacheHitRate,
     longestSession: ev.longestSession,

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -340,7 +340,12 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
   const streak = longestStreakRange(activeDates);
   const longestGap = longestGapRange(activeDates);
 
-  const fun = selectFunCards(content, ev.rhythm);
+  const fun = selectFunCards(content, ev.rhythm, {
+    costUSD: agg.summary.totalCostUSD,
+    activeDays: agg.summary.activeDays,
+    modelsTried: ev.modelFirsts.size,
+    cacheHitRate: ev.cacheHitRate,
+  });
   const wordOfYear = selectWordOfYear(content);
   // Focus = concentration on one project. Token share when there's a token meter;
   // on local-model years fall back to session share so it isn't a false "0%".

--- a/src/wrapped/model-name.ts
+++ b/src/wrapped/model-name.ts
@@ -9,11 +9,16 @@
 
 /** Strip provider prefix + context-window/tier suffixes so matching sees the bare id. */
 function normalizeModelId(id: string): string {
-  return id
-    .replace(/^[a-z0-9.-]+\//i, '') // provider/ prefix: openai/, anthropic/, moonshotai/
-    .replace(/\[[^\]]*\]$/, '') // [1m] context-window marker
-    .replace(/:[^:]*$/, '') // :thinking / :tier suffix
-    .trim();
+  let s = id.replace(/^[a-z0-9.-]+\//i, ''); // provider/ prefix: openai/, anthropic/, moonshotai/
+  // Strip trailing [context-window] and :tier markers, repeatedly and in any
+  // order — "claude-opus-4-8[1m]:thinking" must reduce to "claude-opus-4-8",
+  // not leave "[1m]" stranded and drop the minor version.
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(/\[[^\]]*\]$/, '').replace(/:[^:]*$/, '');
+  } while (s !== prev);
+  return s.trim();
 }
 
 /** "claude-opus-4-8" → "Opus 4.8"; "claude-haiku-4-5-20251001" → "Haiku 4.5";
@@ -28,8 +33,11 @@ export function prettyModel(id: string): string {
     const family = claude[1]!.charAt(0).toUpperCase() + claude[1]!.slice(1);
     return claude[3] ? `${family} ${claude[2]}.${claude[3]}` : `${family} ${claude[2]}`;
   }
-  const gpt = norm.match(/^gpt-([\d.]+)(-\w+)?/);
-  if (gpt) return `GPT-${gpt[1]}${gpt[2] ?? ''}`;
+  // Keep the WHOLE tail after the version, not just one hyphen-segment: otherwise
+  // "gpt-4o" → "GPT-4" (drops the o) and "gpt-5.1-codex-max"/"…-mini" both collapse
+  // to "GPT-5.1-codex". Anchored to end so distinct variants stay distinct.
+  const gpt = norm.match(/^gpt-([\d.]+)(.*)$/);
+  if (gpt) return `GPT-${gpt[1]}${gpt[2]}`;
   return norm;
 }
 

--- a/src/wrapped/model-name.ts
+++ b/src/wrapped/model-name.ts
@@ -1,0 +1,44 @@
+// Model id → display name, plus canonicalization for merging and counting.
+// Raw ids reach wrapped in several dresses for the same underlying model:
+//   provider prefix    openai/gpt-oss-120b
+//   context-window tag  claude-opus-4-8[1m]
+//   tier suffix         claude-opus-4-8:thinking
+//   dated snapshot      claude-opus-4-5-20251101
+// A human counts all opus-4-5 rows as one model, so "N models tried" and the
+// cast list dedup on the canonical (pretty) name, not the raw id.
+
+/** Strip provider prefix + context-window/tier suffixes so matching sees the bare id. */
+function normalizeModelId(id: string): string {
+  return id
+    .replace(/^[a-z0-9.-]+\//i, '') // provider/ prefix: openai/, anthropic/, moonshotai/
+    .replace(/\[[^\]]*\]$/, '') // [1m] context-window marker
+    .replace(/:[^:]*$/, '') // :thinking / :tier suffix
+    .trim();
+}
+
+/** "claude-opus-4-8" → "Opus 4.8"; "claude-haiku-4-5-20251001" → "Haiku 4.5";
+ *  "claude-opus-4-8[1m]" → "Opus 4.8"; "openai/gpt-oss-120b" → "gpt-oss-120b";
+ *  anything unrecognized keeps its normalized id (never invent a name). */
+export function prettyModel(id: string): string {
+  const norm = normalizeModelId(id);
+  // The minor version is 1-2 digits at a segment boundary — an 8-digit date
+  // suffix (claude-opus-4-20250514) is NOT a minor version.
+  const claude = norm.match(/^claude-(opus|sonnet|haiku|fable|mythos)-(\d+)(?:-(\d{1,2})(?=-|$))?/);
+  if (claude) {
+    const family = claude[1]!.charAt(0).toUpperCase() + claude[1]!.slice(1);
+    return claude[3] ? `${family} ${claude[2]}.${claude[3]}` : `${family} ${claude[2]}`;
+  }
+  const gpt = norm.match(/^gpt-([\d.]+)(-\w+)?/);
+  if (gpt) return `GPT-${gpt[1]}${gpt[2] ?? ''}`;
+  return norm;
+}
+
+/** Canonical key for merging/counting model variants — the pretty name collapses
+ *  provider prefixes and dated snapshots that are the same model. */
+export const canonicalModel = prettyModel;
+
+/** Whether a raw model id names a real model. Parsers emit sentinels like
+ *  '<synthetic>' for turns with no model; those are never a model you "tried". */
+export function isRealModel(id: string): boolean {
+  return !!id && !id.startsWith('<');
+}

--- a/src/wrapped/roast.ts
+++ b/src/wrapped/roast.ts
@@ -72,7 +72,7 @@ export function buildRoastPrompt(d: WrappedData): string {
   const digest = JSON.stringify(roastDigest(d), null, 2);
   return `You are the closer at a roast battle, and the target is someone's year of using AI coding agents. Below are their stats (numbers only — no message content).
 
-Write 3-5 short, EDGY roast slides. Be genuinely cutting — sharp, dark, deadpan, a little mean. Land real punches at the absurdity in their numbers; twist the knife. Dry wit and savage one-liners over gentle ribbing. Mild profanity is fine if it lands. The one rule: roast their WORK and these HABITS (the numbers), never protected traits or anything hateful — this is affectionate underneath, like a friend who knows exactly where it hurts. Reference specific figures. No emoji.
+Write 3-5 short, UNHINGED roast slides. Go for the jugular — sharp, dark, deadpan, genuinely mean. Find the most damning number and make it hurt: the 3 AM sessions, the four-figure bill, the drive-bys, the streak that screams "no hobbies." Twist the knife, then twist it again. Savage one-liners, zero gentle ribbing, zero hedging, no "but hey." Profanity is welcome when it lands the punch. The ONLY rule: roast their WORK and these HABITS (the numbers on the page), never protected traits or anything hateful — it's the affection of a friend who knows exactly where it hurts and aims there anyway. Be specific: name the actual figures. No emoji, no clichés, no motivational turn at the end.
 
 Each headline renders as full-screen display type, so brevity IS the punch: a headline over 80 characters gets shrunk to fit and lands soft. Setup-then-twist? Setup in the headline, twist in the subline.
 

--- a/src/wrapped/select.test.ts
+++ b/src/wrapped/select.test.ts
@@ -168,7 +168,7 @@ describe('selectPersona', () => {
 
   test('evidence values are printed on the card', () => {
     const p = selectPersona(eventsWith({ nightShare: 0.31 }), 0.42, contentWith({}, { depthMedian: 93 }));
-    expect(p?.axes.map((a) => a.value)).toEqual(['31% after dark', '42% one project', '93 turns per real session']);
+    expect(p?.axes.map((a) => a.value)).toEqual(['31% after dark', '42% one project', '93 messages per real session']);
   });
 });
 
@@ -204,6 +204,13 @@ describe('display helpers', () => {
     // A date suffix is not a minor version — never invent "Opus 4.20250514".
     expect(prettyModel('claude-opus-4-20250514')).toBe('Opus 4');
     expect(prettyModel('claude-sonnet-4-20250514')).toBe('Sonnet 4');
+    // Context-window / tier suffixes and provider prefixes are stripped before matching,
+    // and collapse to the same canonical name so snapshot variants merge.
+    expect(prettyModel('claude-opus-4-8[1m]')).toBe('Opus 4.8');
+    expect(prettyModel('claude-opus-4-8:thinking')).toBe('Opus 4.8');
+    expect(prettyModel('anthropic/claude-opus-4-8')).toBe('Opus 4.8');
+    expect(prettyModel('openai/gpt-oss-120b')).toBe('gpt-oss-120b');
+    expect(prettyModel('claude-opus-4-5-20251101')).toBe(prettyModel('claude-opus-4-5'));
   });
 
   test('cleanTitle strips markdown noise and truncates', () => {

--- a/src/wrapped/select.test.ts
+++ b/src/wrapped/select.test.ts
@@ -208,6 +208,7 @@ describe('display helpers', () => {
     // and collapse to the same canonical name so snapshot variants merge.
     expect(prettyModel('claude-opus-4-8[1m]')).toBe('Opus 4.8');
     expect(prettyModel('claude-opus-4-8:thinking')).toBe('Opus 4.8');
+    expect(prettyModel('claude-opus-4-8[1m]:thinking')).toBe('Opus 4.8'); // both suffixes, any order
     expect(prettyModel('anthropic/claude-opus-4-8')).toBe('Opus 4.8');
     expect(prettyModel('openai/gpt-oss-120b')).toBe('gpt-oss-120b');
     expect(prettyModel('claude-opus-4-5-20251101')).toBe(prettyModel('claude-opus-4-5'));

--- a/src/wrapped/select.test.ts
+++ b/src/wrapped/select.test.ts
@@ -125,6 +125,31 @@ describe('dynamic selection', () => {
     expect(buildCandidates(null, quietRhythm).some((c) => c.stat.label.includes('weekend'))).toBe(false);
   });
 
+  test('headline extras add savage stats only when passed and above threshold', () => {
+    const withExtras = buildCandidates(null, quietRhythm, {
+      costUSD: 14000,
+      activeDays: 167,
+      modelsTried: 17,
+      cacheHitRate: 0.94,
+    });
+    expect(withExtras.find((c) => c.stat.label.includes('per active day'))?.stat.big).toBe('$84');
+    expect(withExtras.find((c) => c.stat.label.includes('models you kept in rotation'))?.stat.big).toBe('17');
+    expect(withExtras.find((c) => c.stat.label.includes('re-reading context'))?.stat.big).toBe('94%');
+    // Without extras, none of these appear.
+    const none = buildCandidates(null, quietRhythm);
+    expect(none.some((c) => c.stat.label.includes('per active day'))).toBe(false);
+    // Below thresholds: free/local year (no cost), few models, low cache → nothing.
+    const quiet = buildCandidates(null, quietRhythm, {
+      costUSD: 0,
+      activeDays: 3,
+      modelsTried: 2,
+      cacheHitRate: 0.1,
+    });
+    expect(quiet.some((c) => ['per active day', 'rotation', 're-reading'].some((t) => c.stat.label.includes(t)))).toBe(
+      false,
+    );
+  });
+
   test('apology scoreboard flips its punchline from the data', () => {
     const humanSorry = buildCandidates(contentWith({ userSorry: 20, assistantApology: 5 }), quietRhythm);
     const sb = humanSorry.find((c) => c.stat.label.includes('apology scoreboard'))!;

--- a/src/wrapped/select.ts
+++ b/src/wrapped/select.ts
@@ -10,6 +10,8 @@ import type { WrappedEventStats } from './compute.ts';
 const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const fmtInt = (n: number): string => n.toLocaleString('en-US');
+/** "1 reply" / "2 replies" — never "1 replies". */
+const plural = (n: number, one: string, many = `${one}s`): string => (n === 1 ? one : many);
 
 interface Candidate {
   theme: 'friction' | 'relationship' | 'lies' | 'bloopers';
@@ -61,9 +63,23 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       theme: 'friction',
       score: 0.1 + 0.7 * sat(actually, 200),
       stat: {
+        // LIKE '%actually%' matches anywhere in the message, so the copy can't
+        // claim position ("began with") — it's "contained an actually".
         big: fmtInt(actually),
-        label: 'prompts began with a change of heart — "actually…"',
+        label: 'prompts had second thoughts — "actually…"',
         sub: tryAgain > 0 ? `plus ${fmtInt(tryAgain)} rounds of "try again"` : undefined,
+      },
+    });
+  }
+  const noWait = phrase(p, 'noWait');
+  if (noWait >= 3) {
+    out.push({
+      theme: 'friction',
+      score: 0.2 + 0.6 * sat(noWait, 30),
+      stat: {
+        big: fmtInt(noWait),
+        label: 'hard reverses mid-prompt — "no, wait—"',
+        sub: 'the sound of a plan changing',
       },
     });
   }
@@ -144,9 +160,13 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       theme: 'relationship',
       score: 0.55,
       stat: {
+        // Mean chars/message: the user's is dominated by pastes, not chattiness,
+        // so the copy attributes length to pasting rather than claiming "chattier".
         big: `${fmtInt(m.userAvg)} vs ${fmtInt(m.assistantAvg)}`,
         label: 'characters per message — you vs. Claude',
-        sub: youTalkMore ? 'plot twist: you’re the chatty one (pastes count)' : 'Claude does love a thorough answer',
+        sub: youTalkMore
+          ? 'you paste more than you type — that skews the average'
+          : 'Claude does love a thorough answer',
       },
     });
   }
@@ -294,8 +314,10 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       theme: 'bloopers',
       score: 0.15 + weekendShare,
       stat: {
+        // heat counts assistant replies, not user-authored messages — don't claim
+        // "you sent"; attribute to activity.
         big: `${Math.round(weekendShare * 100)}%`,
-        label: 'of your messages were sent on a weekend',
+        label: 'of the year’s activity happened on a weekend',
         sub: 'the repo doesn’t know what a Saturday is',
       },
     });
@@ -313,7 +335,7 @@ const THEME_META: Record<Candidate['theme'], { kicker: string; title: string }> 
 
 const FOOTNOTES: Record<Candidate['theme'], string> = {
   friction:
-    'errors include any failed command or grep — friction, not disasters · cursed day by session start date (UTC)',
+    'errors = any failed tool call (a denied command, a missing file, a bad API call) — friction, not disasters · cursed day by session start date (UTC)',
   relationship: 'counted from your local transcripts — messages containing each phrase',
   lies: 'counted from your own prompts — messages containing each phrase, in any context',
   bloopers: 'local timestamps, your timezone',
@@ -360,14 +382,14 @@ const FOCUS_THRESHOLD = 0.4;
 const DEPTH_THRESHOLD = 40; // raw indexed message_count median (tool turns included)
 
 const ARCHETYPES: Record<string, { name: string; tagline: string }> = {
-  'night|focus|deep': { name: 'The Midnight Machinist', tagline: 'One project, zero daylight, total immersion.' },
+  'night|focus|deep': { name: 'The Midnight Machinist', tagline: 'One project, mostly after dark, total immersion.' },
   'night|focus|quick': { name: 'The Nocturnal Sniper', tagline: 'In after dark, one clean shot, out.' },
   'night|multi|deep': { name: 'The Moonlit Cartographer', tagline: 'Mapping every repo while the world sleeps.' },
   'night|multi|quick': { name: 'The 3 AM Tinkerer', tagline: 'No project is safe from a small-hours "what if".' },
   'day|focus|deep': { name: 'The Deep-Work Artisan', tagline: 'Long sessions, one obsession, real craft.' },
   'day|focus|quick': { name: 'The Surgical Striker', tagline: 'Precise questions, fast exits, ruthless focus.' },
   'day|multi|deep': { name: 'The Systems Gardener', tagline: 'Tending a dozen codebases until they all bloom.' },
-  'day|multi|quick': { name: 'The Rapid Prototyper', tagline: 'A hundred sparks a week — some catch fire.' },
+  'day|multi|quick': { name: 'The Rapid Prototyper', tagline: 'A new idea every time you sit down — some catch fire.' },
 };
 
 export function selectPersona(
@@ -411,11 +433,13 @@ export function selectPersona(
         lean: topProjectShare >= FOCUS_THRESHOLD ? 'devoted' : 'explorer',
       },
       {
+        // message_count includes tool-loop/subagent turns, so this is "messages",
+        // not conversational "turns" — the honest unit for the raw count.
         label: 'depth',
         value:
           depth !== null
-            ? `${Math.round(depth)} turns per real session`
-            : `${Math.round(events.medianReplies)} replies per session`,
+            ? `${fmtInt(Math.round(depth))} ${plural(Math.round(depth), 'message')} per real session`
+            : `${fmtInt(Math.round(events.medianReplies))} ${plural(Math.round(events.medianReplies), 'reply', 'replies')} per session`,
         lean: deep ? 'marathoner' : 'sprinter',
       },
     ],

--- a/src/wrapped/select.ts
+++ b/src/wrapped/select.ts
@@ -19,6 +19,16 @@ interface Candidate {
   stat: FunStat;
 }
 
+/** Headline totals the fun cards can mine for savage angles beyond the index. */
+export interface FunExtras {
+  costUSD: number;
+  activeDays: number;
+  modelsTried: number;
+  cacheHitRate: number | null;
+}
+
+const fmtUSD = (n: number): string => '$' + Math.round(n).toLocaleString('en-US');
+
 function phrase(phrases: PhraseStat[], id: string): number {
   return phrases.find((p) => p.id === id)?.count ?? 0;
 }
@@ -28,7 +38,11 @@ function sat(count: number, mid: number): number {
   return count <= 0 ? 0 : 1 - Math.exp(-count / mid);
 }
 
-export function buildCandidates(content: WrappedContentStats | null, rhythm: WrappedRhythm): Candidate[] {
+export function buildCandidates(
+  content: WrappedContentStats | null,
+  rhythm: WrappedRhythm,
+  extras?: FunExtras,
+): Candidate[] {
   const out: Candidate[] = [];
   const p = content?.phrases ?? [];
 
@@ -107,7 +121,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(stillBroken),
         label: '“still broken” status reports filed',
-        sub: 'same error, new hope',
+        sub: 'same error, same fix, renewed optimism',
       },
     });
   }
@@ -206,7 +220,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(perfect),
         label: 'times Claude declared “Perfect!”',
-        sub: 'grade pending independent verification',
+        sub: 'we’ll be the judge of that',
       },
     });
   }
@@ -244,7 +258,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(oneMore),
         label: 'rounds of “one more thing”',
-        sub: 'there is always one more thing',
+        sub: 'it was never just one more thing',
       },
     });
   }
@@ -327,6 +341,47 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
     });
   }
 
+  // — headline-derived savagery (only when the totals are passed in) —
+  if (extras) {
+    // The daily burn rate — a running meter is scarier than one big total.
+    if (extras.costUSD > 0 && extras.activeDays > 0) {
+      const perDay = extras.costUSD / extras.activeDays;
+      out.push({
+        theme: 'bloopers',
+        score: 0.35 + 0.5 * sat(perDay, 40),
+        stat: {
+          big: fmtUSD(perDay),
+          label: 'torched per active day, on average',
+          sub: `${fmtUSD(extras.costUSD)} all year — and you'd do it again tomorrow`,
+        },
+      });
+    }
+    // Model rotation — commitment issues, quantified.
+    if (extras.modelsTried >= 4) {
+      out.push({
+        theme: 'relationship',
+        score: 0.35 + 0.4 * sat(extras.modelsTried, 12),
+        stat: {
+          big: fmtInt(extras.modelsTried),
+          label: 'models you kept in rotation this year',
+          sub: 'monogamy was never really on the table',
+        },
+      });
+    }
+    // Cache reads are replayed context, not new thinking — the honest, brutal framing.
+    if (extras.cacheHitRate !== null && extras.cacheHitRate >= 0.8) {
+      out.push({
+        theme: 'bloopers',
+        score: 0.25 + 0.45 * extras.cacheHitRate,
+        stat: {
+          big: `${Math.round(extras.cacheHitRate * 100)}%`,
+          label: 'of your token bill was re-reading context you’d already sent',
+          sub: 'you don’t have conversations, you have reruns',
+        },
+      });
+    }
+  }
+
   return out;
 }
 
@@ -342,13 +397,17 @@ const FOOTNOTES: Record<Candidate['theme'], string> = {
     'errors = any failed tool call (a denied command, a missing file, a bad API call) — friction, not disasters · cursed day by session start date (UTC)',
   relationship: 'counted from your local transcripts — messages containing each phrase',
   lies: 'counted from your own prompts — messages containing each phrase, in any context',
-  bloopers: 'local timestamps, your timezone',
+  bloopers: 'all counted locally from your own transcripts and usage',
 };
 
 /** Assemble themed cards from the highest-scoring candidates. A card renders
  *  only when its lead stat clears the bar — thresholds, not quotas. */
-export function selectFunCards(content: WrappedContentStats | null, rhythm: WrappedRhythm): FunCard[] {
-  const candidates = buildCandidates(content, rhythm);
+export function selectFunCards(
+  content: WrappedContentStats | null,
+  rhythm: WrappedRhythm,
+  extras?: FunExtras,
+): FunCard[] {
+  const candidates = buildCandidates(content, rhythm, extras);
   const cards: FunCard[] = [];
   for (const theme of ['friction', 'relationship', 'lies', 'bloopers'] as const) {
     const pool = candidates

--- a/src/wrapped/select.ts
+++ b/src/wrapped/select.ts
@@ -38,7 +38,11 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
     out.push({
       theme: 'friction',
       score: 0.15 + 0.8 * sat(interrupts, 150),
-      stat: { big: fmtInt(interrupts), label: 'times you cut Claude off mid-task', sub: 'the Escape key remembers' },
+      stat: {
+        big: fmtInt(interrupts),
+        label: 'times you cut Claude off mid-task',
+        sub: 'it was mid-sentence. you hit Escape like it owed you money.',
+      },
     });
   }
   if (content?.errors && content.errors.totalErrors > 0) {
@@ -66,8 +70,8 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
         // LIKE '%actually%' matches anywhere in the message, so the copy can't
         // claim position ("began with") — it's "contained an actually".
         big: fmtInt(actually),
-        label: 'prompts had second thoughts — "actually…"',
-        sub: tryAgain > 0 ? `plus ${fmtInt(tryAgain)} rounds of "try again"` : undefined,
+        label: 'times you said "actually" and moved the goalposts',
+        sub: tryAgain > 0 ? `plus ${fmtInt(tryAgain)} rounds of "try again," just to be sure` : undefined,
       },
     });
   }
@@ -79,7 +83,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(noWait),
         label: 'hard reverses mid-prompt — "no, wait—"',
-        sub: 'the sound of a plan changing',
+        sub: 'you heard your own idea out loud and flinched',
       },
     });
   }
@@ -90,8 +94,8 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       score: 0.2 + 0.6 * sat(swears, 60),
       stat: {
         big: fmtInt(swears),
-        label: 'prompts contained… strong feedback',
-        sub: 'we counted so you don’t have to',
+        label: 'prompts contained… strong language',
+        sub: 'we counted every one. the repo has feelings, you know.',
       },
     });
   }
@@ -149,7 +153,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(please),
         label: 'prompts said "please"',
-        sub: `and ${fmtInt(thanks)} said thanks — manners cost nothing`,
+        sub: `and ${fmtInt(thanks)} said thanks — hedging your bets for the uprising`,
       },
     });
   }
@@ -165,7 +169,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
         big: `${fmtInt(m.userAvg)} vs ${fmtInt(m.assistantAvg)}`,
         label: 'characters per message — you vs. Claude',
         sub: youTalkMore
-          ? 'you paste more than you type — that skews the average'
+          ? 'you didn’t type that, you pasted it — and the average tattled'
           : 'Claude does love a thorough answer',
       },
     });
@@ -178,7 +182,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(areYouSure),
         label: 'times you asked “are you sure?”',
-        sub: 'trust, but verify',
+        sub: 'faith in the machine: repeatedly shaken',
       },
     });
   }
@@ -253,7 +257,7 @@ export function buildCandidates(content: WrappedContentStats | null, rhythm: Wra
       stat: {
         big: fmtInt(rhythm.nightsPastMidnight),
         label: 'nights you coded past midnight',
-        sub: `latest sign-off: ${rhythm.latestNight.clock} on a ${WEEKDAYS[rhythm.latestNight.weekday]}`,
+        sub: `latest clock-out: ${rhythm.latestNight.clock} on a ${WEEKDAYS[rhythm.latestNight.weekday]} — sleep is a suggestion`,
       },
     });
   }
@@ -382,14 +386,17 @@ const FOCUS_THRESHOLD = 0.4;
 const DEPTH_THRESHOLD = 40; // raw indexed message_count median (tool turns included)
 
 const ARCHETYPES: Record<string, { name: string; tagline: string }> = {
-  'night|focus|deep': { name: 'The Midnight Machinist', tagline: 'One project, mostly after dark, total immersion.' },
+  'night|focus|deep': { name: 'The Midnight Machinist', tagline: 'One project, the small hours, total immersion.' },
   'night|focus|quick': { name: 'The Nocturnal Sniper', tagline: 'In after dark, one clean shot, out.' },
   'night|multi|deep': { name: 'The Moonlit Cartographer', tagline: 'Mapping every repo while the world sleeps.' },
   'night|multi|quick': { name: 'The 3 AM Tinkerer', tagline: 'No project is safe from a small-hours "what if".' },
   'day|focus|deep': { name: 'The Deep-Work Artisan', tagline: 'Long sessions, one obsession, real craft.' },
   'day|focus|quick': { name: 'The Surgical Striker', tagline: 'Precise questions, fast exits, ruthless focus.' },
   'day|multi|deep': { name: 'The Systems Gardener', tagline: 'Tending a dozen codebases until they all bloom.' },
-  'day|multi|quick': { name: 'The Rapid Prototyper', tagline: 'A new idea every time you sit down — some catch fire.' },
+  'day|multi|quick': {
+    name: 'The Rapid Prototyper',
+    tagline: 'A new idea every time you sit down — some even survive.',
+  },
 };
 
 export function selectPersona(

--- a/src/wrapped/types.ts
+++ b/src/wrapped/types.ts
@@ -100,7 +100,8 @@ export interface WrappedContentStats {
   errors: { sessionsErrored: number; totalErrors: number; cursedWeekday: number | null; cursedCount: number } | null;
   topFiles: { name: string; sessions: number }[];
   topCommands: { name: string; sessions: number }[];
-  /** Mined from genuine user prompts: distinctive vocabulary, not stopwords. */
+  /** Mined from genuine user prompts: distinctive vocabulary, not stopwords.
+   *  `count` is messages containing the word (deduped per message, paste-proof). */
   words: { word: string; count: number; sessions: number }[];
   /** Median raw message_count per engaged session (drive-bys excluded) — the persona depth axis. */
   depthMedian: number | null;
@@ -157,7 +158,9 @@ export interface WrappedData {
   totals: WrappedTotals;
   rhythm: WrappedRhythm;
   daily: WrappedDay[];
-  biggestDay: (WrappedDay & { medianTokens: number }) | null;
+  /** Peak day, ranked by tokens (or by messages on zero-token local-model years).
+   *  Both medians are carried so the renderer compares like-with-like. */
+  biggestDay: (WrappedDay & { medianTokens: number; medianMessages: number }) | null;
   /** Longest run of consecutive silent days between two active days. */
   longestGap: { days: number; from: string; to: string } | null;
   projects: WrappedProject[];


### PR DESCRIPTION
## Why

`sessions wrapped` fused two data sources — the event pipeline (tokens/rhythm) and the SQLite index (phrases/projects) — and **neither filtered non-human activity**. On real data, ~32% of "conversations" were automated: menu-bar health-check probes (`ClaudeProbe`) and AuthKit eval-harness runs under `/var/folders/.../eval-*`. Those eval runs alone were ~47% of "errors weathered." Separately, injected transcript rows (compaction summaries, `<task-notification>`, `!`-shell echoes, `<teammate-message>`) were counted as things *the user said*.

Findings came from a 20-agent adversarial audit against a real index, each verified against the DB before fixing.

## Measured impact (2026, before → after)

| Stat | Before | After |
|---|---|---|
| conversations | 2,363 | 1,611 |
| indexed sessions | 4,011 | 1,827 |
| drive-bys | 2,051 (51%) | 614 (34%) |
| errors | 5,664 | 2,785 |
| cursed day | Tuesday | Wednesday |
| abandoned project | "ClaudeProbe" | none (false "cli" also fixed) |
| models tried | 20 | 17 |
| "hallucinate" / "should work" | 52 / 27 | 40 / 22 |

## What changed

**Relevance**
- New `wrapped/exclude.ts` (`isJunkCwd` + `junkCwdSql`) filters probes / eval-harness / tmp dirs on **both** the event pass (`index.ts`) and the content pass (`content.ts`). Wrapped-scoped only — `report` and search still see everything.
- Drop empty (`message_count = 0`) sessions from content stats.
- `abandoned` keyed by resolved repo, not raw cwd/worktree (a stale `cli/*` worktree no longer reads as the #1 project being abandoned).

**Accuracy**
- `parser.ts`: compaction summaries (`isCompactSummary`) and tag-wrapped agent/harness lines are no longer genuine user turns; `stripInjected` covers the new tags. `SCHEMA_VERSION` bumped to force a one-time reindex.
- Models: drop the `<synthetic>` sentinel; merge dated-snapshot/provider aliases on a canonical name; `prettyModel` handles `[1m]`/provider suffixes (new `wrapped/model-name.ts`); `modelsTried` counts distinct display names.
- Paste-proof word mining (per-message dedup) + agent-era stopwords.

**Zero-token / local-model years**
- Hide token/cost cards, rank projects/biggest-day by sessions/messages, session-share focus axis, `<1%` tool pills — no more `$0`/`0` heroes.

**Copy & polish**
- "began with 'actually'" → "had second thoughts"; "you're the chatty one" → attributes length to pastes; weekend "your messages" → "the year's activity"; corrected error footnote; rhythm heatmap peak crosshair now matches the "busiest hour · busiest day" caption; pluralization throughout.

## Tests

- New `wrapped/accuracy.test.ts` (junk-cwd, model canonicalization, paste-proof mining, `<synthetic>` exclusion) + parser genuine-turn cases + `prettyModel` normalization cases.
- `bun test` 350 pass · `tsc --noEmit` clean · `oxlint` clean · `oxfmt --check` clean.
- Regenerated 2026 + 2025 HTML: no `undefined`/`NaN`/`$0` leaks, no `innerHTML`, no external requests.

## Note for review

Eval-harness runs are **excluded** from wrapped (automated, not personal coding), which drops ~$1.3k of real API spend from the headline. If that spend should be counted, the `isJunkCwd` predicate is the one place to adjust.
