### PR TITLE
fix(mcp): exit on stdin close to avoid orphaned servers busy-looping CPU

### DIFF
--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -264,3 +264,30 @@ test('get_session_messages omits tools by default (back-compat shape)', async ()
   const parsed = JSON.parse(res.content[0]!.text);
   expect(parsed.messages[0].tools).toBeUndefined();
 });
+
+// ——— stdio lifecycle ———
+
+test('server exits when the client closes stdin instead of lingering as an orphan', async () => {
+  const proc = Bun.spawn([process.execPath, 'run', join(import.meta.dir, '..', 'index.ts'), '--mcp'], {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'ignore',
+  });
+  proc.stdin.write(
+    `${j({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+    })}\n`,
+  );
+  await proc.stdin.flush();
+  // Wait for the initialize response so the transport is fully wired before we hang up.
+  const reader = proc.stdout.getReader();
+  await reader.read();
+  reader.releaseLock();
+  proc.stdin.end(); // simulate the parent client dying
+  const result = await Promise.race([proc.exited, Bun.sleep(5000).then(() => 'orphaned' as const)]);
+  if (result === 'orphaned') proc.kill();
+  expect(result).toBe(0);
+}, 15000);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -314,4 +314,9 @@ server.tool(
 export async function startMcpServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  // The SDK transport only listens for stdin 'data'/'error', so when the parent
+  // client dies the server is never told. Under Bun's compiled binary the EOF'd
+  // pipe then busy-loops the event loop at 100% CPU. Exit as soon as stdin ends.
+  process.stdin.on('end', () => process.exit(0));
+  process.stdin.on('close', () => process.exit(0));
 }


### PR DESCRIPTION
## Problem

Every Claude Code session spawns a `sessions --mcp` stdio server, but the server never noticed when its parent died. The MCP SDK's `StdioServerTransport` only subscribes to stdin `'data'`/`'error'` — never `'end'`/`'close'` — and `startMcpServer()` added no shutdown handling on top (and `index.ts` parks the process forever with `await new Promise(() => {})`).

When a Claude Code session exits uncleanly, the orphaned server (PPID 1) lives on. Under the Bun-compiled binary this is worse than a leak: the EOF'd stdin pipe keeps the event loop spinning through `kevent64` at ~100% CPU forever. Observed in the wild: two orphans with 7h+ and 12h+ of accumulated CPU time, ~97% CPU each (stack-sampled to confirm the busy loop).

## Fix

Exit the process as soon as stdin ends — the only lifecycle signal a stdio server gets:

```ts
process.stdin.on('end', () => process.exit(0));
process.stdin.on('close', () => process.exit(0));
```

Handlers attach after `server.connect()`, since connect's `start()` adds the `'data'` listener that puts stdin into flowing mode (which is what makes `'end'` fire on EOF).

## Test

New regression test spawns the real server (`bun run index.ts --mcp`), completes the MCP initialize handshake, then closes stdin to simulate the parent dying, and asserts the process exits 0. Verified red/green: without the fix the child out-waits the 5s race and the test fails; with it, the server exits in <200ms.

Note: orphans from binaries built before this fix will still spin — worth a `pkill -f 'sessions --mcp'` sweep of PPID-1 stragglers after upgrading.