### PR TITLE
fix: stop --stdout hanging forever when piped

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,14 +9,5 @@
   "homepage": "https://github.com/nicknisi/sessions",
   "repository": "https://github.com/nicknisi/sessions",
   "license": "MIT",
-  "keywords": [
-    "sessions",
-    "context",
-    "weekly-summary",
-    "standup",
-    "recall",
-    "metrics",
-    "activity",
-    "digest"
-  ]
+  "keywords": ["sessions", "context", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"]
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -9,16 +9,7 @@
   "homepage": "https://github.com/nicknisi/sessions",
   "repository": "https://github.com/nicknisi/sessions",
   "license": "MIT",
-  "keywords": [
-    "sessions",
-    "context",
-    "weekly-summary",
-    "standup",
-    "recall",
-    "metrics",
-    "activity",
-    "digest"
-  ],
+  "keywords": ["sessions", "context", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Sessions",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -9,14 +9,5 @@
   "homepage": "https://github.com/nicknisi/sessions",
   "repository": "https://github.com/nicknisi/sessions",
   "license": "MIT",
-  "keywords": [
-    "sessions",
-    "context",
-    "weekly-summary",
-    "standup",
-    "recall",
-    "metrics",
-    "activity",
-    "digest"
-  ]
+  "keywords": ["sessions", "context", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"]
 }

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -11,6 +11,7 @@ import { loadRuntimePricing } from './pricing-cache.ts';
 import { resolvePeriod, type PeriodPreset } from './period.ts';
 import { resolveProject } from './project.ts';
 import { localDate } from './parsers/util.ts';
+import { writeStdoutFully } from '../stdout.ts';
 
 export type ReportFormat = 'json' | 'html' | 'both';
 
@@ -194,9 +195,7 @@ export async function runReport(opts: ReportOptions): Promise<ReportResult> {
   const outBase = opts.out ?? (needsFile ? await mkdtemp(join(tmpdir(), 'sessions-report-')) : undefined);
 
   if (opts.stdout) {
-    // Bun.write awaits the flush; process.stdout.write + the caller's
-    // process.exit(0) truncates piped output at the 64KB pipe buffer.
-    await Bun.write(Bun.stdout, json + '\n');
+    await writeStdoutFully(json + '\n');
   } else if (wantJson) {
     const p = opts.format === 'both' || !opts.out ? join(outBase!, 'usage-report.json') : opts.out;
     await writeFile(p, json, 'utf8');

--- a/src/stdout.ts
+++ b/src/stdout.ts
@@ -1,0 +1,18 @@
+// Write a large payload to stdout, resolving only once it is fully flushed.
+//
+// Two constraints shape this helper:
+//   - A bare process.stdout.write followed by the CLI's process.exit(0)
+//     truncates piped output at the 64KB pipe buffer.
+//   - Bun.write(Bun.stdout, …) — the previous fix for that truncation —
+//     busy-loops forever (bun 1.3.x) when stdout is a pipe and the payload
+//     exceeds the pipe buffer, hanging every programmatic consumer
+//     (`sessions report --stdout | …`, Bun.spawn with stdout: 'pipe').
+//
+// Awaiting the write callback satisfies both: the callback fires only after
+// the data is handed to the OS, and the node-compat write path drains pipes
+// correctly.
+export function writeStdoutFully(text: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    process.stdout.write(text, (err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/src/wrapped/index.ts
+++ b/src/wrapped/index.ts
@@ -13,6 +13,7 @@ import { aggregate } from '../report/aggregate.ts';
 import { drainPricingWarnings, resetPricingWarnings, mergeRuntimePricing } from '../report/pricing.ts';
 import { loadRuntimePricing } from '../report/pricing-cache.ts';
 import { localDate } from '../report/parsers/util.ts';
+import { writeStdoutFully } from '../stdout.ts';
 import { computeEventStats, computeLoops, longestGapRange, longestStreakRange } from './compute.ts';
 import { collectClaudeUserTurns } from './loops.ts';
 import { computeContentStats } from './content.ts';
@@ -422,9 +423,7 @@ export async function runWrapped(opts: WrappedOptions): Promise<WrappedResult> {
   const result: WrappedResult = { json };
 
   if (opts.stdout) {
-    // Bun.write awaits the flush; process.stdout.write + the caller's
-    // process.exit(0) truncates piped output at the 64KB pipe buffer.
-    await Bun.write(Bun.stdout, json + '\n');
+    await writeStdoutFully(json + '\n');
     return result;
   }
 


### PR DESCRIPTION
## Problem

`sessions report --format json --stdout | anything` spins at ~100% CPU forever when the report exceeds the 64KB pipe buffer — even with an actively draining reader. Same latent bug in `wrapped --stdout`. Every programmatic consumer hits it (shell pipes, `Bun.spawn` with `stdout: 'pipe'`); file redirection and tty output are unaffected, which is why manual runs look fine. Found because tokenmaxing's `bun run publish` blocked silently for 20+ minutes on the piped report.

## Root cause

`await Bun.write(Bun.stdout, json)` — introduced in 4c92b02 to fix the opposite bug (bare `process.stdout.write` + the CLI's `process.exit(0)` truncating piped output at 64KB) — busy-loops in bun 1.3.x when stdout is a pipe and the payload exceeds the pipe buffer. `sample` shows one Bun Pool thread pinned at a single PC while the main thread idles in `kevent64`.

Note for anyone reducing this for an upstream bun report: a minimal compiled `Bun.write(Bun.stdout, 700KB)` repro does **not** hang. The trigger needs the payload size *plus* the heavy thread-pool fs activity of a real report run beforehand.

## Fix

New `writeStdoutFully()` helper (`src/stdout.ts`): an awaited `process.stdout.write` callback. It satisfies both constraints at once — the promise resolves only after the payload is fully handed to the OS (no truncation before `process.exit`), and the node-compat write path drains pipes correctly (no spin). Both `Bun.write(Bun.stdout, …)` call sites replaced.

## Verification

- Previously hanging invocation on the compiled binary, 3 consecutive runs: full 643,170-byte report through `| wc -c` in ~25s each (was: infinite hang, killed after 30+ min)
- No truncation: 643KB ≫ 64KB arrives intact ahead of `process.exit(0)`
- `wrapped --stdout | wc -c` passes
- `tsc --noEmit` clean, 363/363 tests pass