### PR TITLE
perf: reduce MCP indexing overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ Each session file is parsed to extract:
 
 Both the CLI and the MCP server share a SQLite + FTS5 index at `~/.cache/sessions/index.db`. Messages are indexed individually, so a hit localizes to the exact message that matched — not just the session. The index is built automatically on first use (under a minute for a few thousand sessions) and updated incrementally on subsequent runs by checking file modification times — only new or changed sessions are re-indexed.
 
+Long-lived MCP servers coalesce concurrent refreshes and reuse a freshness check for five seconds, so a burst of related tool calls does not walk the full session tree repeatedly. Set `SESSIONS_REFRESH_INTERVAL_MS=0` on the MCP process to require a source scan before every call.
+
 To clear the index and force a full rebuild:
 
 ```sh

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,14 +9,5 @@
   "homepage": "https://github.com/nicknisi/sessions",
   "repository": "https://github.com/nicknisi/sessions",
   "license": "MIT",
-  "keywords": [
-    "sessions",
-    "context",
-    "weekly-summary",
-    "standup",
-    "recall",
-    "metrics",
-    "activity",
-    "digest"
-  ]
+  "keywords": ["sessions", "context", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"]
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -9,16 +9,7 @@
   "homepage": "https://github.com/nicknisi/sessions",
   "repository": "https://github.com/nicknisi/sessions",
   "license": "MIT",
-  "keywords": [
-    "sessions",
-    "context",
-    "weekly-summary",
-    "standup",
-    "recall",
-    "metrics",
-    "activity",
-    "digest"
-  ],
+  "keywords": ["sessions", "context", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"],
   "skills": "./skills/",
   "interface": {
     "displayName": "Sessions",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -9,14 +9,5 @@
   "homepage": "https://github.com/nicknisi/sessions",
   "repository": "https://github.com/nicknisi/sessions",
   "license": "MIT",
-  "keywords": [
-    "sessions",
-    "context",
-    "weekly-summary",
-    "standup",
-    "recall",
-    "metrics",
-    "activity",
-    "digest"
-  ]
+  "keywords": ["sessions", "context", "weekly-summary", "standup", "recall", "metrics", "activity", "digest"]
 }

--- a/src/cache.search.test.ts
+++ b/src/cache.search.test.ts
@@ -216,6 +216,19 @@ test('errored filter and metadata: only errored sessions, with files/commands/er
 
 // ——— message-granularity (schema v7) tests — additive; do not modify cases above ———
 
+function ignoredRow(filePath: string): { mtime: number; size: number } | null {
+  const db = new Database(cache.getDbPath(), { readonly: true });
+  try {
+    return (
+      db
+        .query<{ mtime: number; size: number }, [string]>('SELECT mtime, size FROM ignored_files WHERE file_path = ?')
+        .get(filePath) ?? null
+    );
+  } finally {
+    db.close();
+  }
+}
+
 function messageRowCount(filePath: string): number {
   // Independent read-only connection (WAL allows concurrent readers) to assert
   // row-level state that the search API alone can't prove.
@@ -279,7 +292,7 @@ test('re-index idempotency: an mtime touch leaves no duplicate message rows', as
   expect(r.find((x) => x.sessionId === 'c')!.messageHits).toHaveLength(1);
 });
 
-test('concurrent refreshes coalesce instead of nesting transactions or duplicating work', async () => {
+test('concurrent refreshes coalesce onto a single scan instead of each redoing the work', async () => {
   const future = new Date(Date.now() + 10_000);
   utimesSync(cPath(), future, future);
 
@@ -288,24 +301,23 @@ test('concurrent refreshes coalesce instead of nesting transactions or duplicati
   expect(messageRowCount(cPath())).toBe(2);
 });
 
-test('unchanged invalid transcripts are tracked in the negative inventory cache', async () => {
+test('unchanged invalid transcripts are tracked in the negative inventory cache, then pruned', async () => {
   const path = join(process.env.SESSIONS_CLAUDE_DIR!, 'proj', 'ignored.jsonl');
   writeFileSync(path, JSON.stringify({ type: 'user', timestamp: '2026-06-06T12:00:00Z' }));
-
-  await cache.refreshIndex();
-  const db = new Database(cache.getDbPath(), { readonly: true });
   try {
-    const row = db
-      .query<{ mtime: number; size: number }, [string]>('SELECT mtime, size FROM ignored_files WHERE file_path = ?')
-      .get(path);
-    expect(row?.size).toBeGreaterThan(0);
+    await cache.refreshIndex();
+    expect(ignoredRow(path)?.size).toBeGreaterThan(0);
+
+    // The whole point of the table: an unindexable file stops being a candidate.
+    expect((await cache.refreshIndex()).updated).toBe(0);
   } finally {
-    db.close();
+    // Unconditional, so a failure above cannot leak this transcript into the
+    // shared fixture dir and skew the tests that follow.
+    rmSync(path, { force: true });
   }
 
-  expect((await cache.refreshIndex()).updated).toBe(0);
-  rmSync(path);
   await cache.refreshIndex();
+  expect(ignoredRow(path)).toBeNull();
 });
 
 test('pruning: deleting the file empties both FTS tables for it', async () => {

--- a/src/cache.search.test.ts
+++ b/src/cache.search.test.ts
@@ -279,6 +279,35 @@ test('re-index idempotency: an mtime touch leaves no duplicate message rows', as
   expect(r.find((x) => x.sessionId === 'c')!.messageHits).toHaveLength(1);
 });
 
+test('concurrent refreshes coalesce instead of nesting transactions or duplicating work', async () => {
+  const future = new Date(Date.now() + 10_000);
+  utimesSync(cPath(), future, future);
+
+  const results = await Promise.all(Array.from({ length: 8 }, () => cache.refreshIndex()));
+  expect(results.every((result) => result.updated === 1)).toBe(true);
+  expect(messageRowCount(cPath())).toBe(2);
+});
+
+test('unchanged invalid transcripts are tracked in the negative inventory cache', async () => {
+  const path = join(process.env.SESSIONS_CLAUDE_DIR!, 'proj', 'ignored.jsonl');
+  writeFileSync(path, JSON.stringify({ type: 'user', timestamp: '2026-06-06T12:00:00Z' }));
+
+  await cache.refreshIndex();
+  const db = new Database(cache.getDbPath(), { readonly: true });
+  try {
+    const row = db
+      .query<{ mtime: number; size: number }, [string]>('SELECT mtime, size FROM ignored_files WHERE file_path = ?')
+      .get(path);
+    expect(row?.size).toBeGreaterThan(0);
+  } finally {
+    db.close();
+  }
+
+  expect((await cache.refreshIndex()).updated).toBe(0);
+  rmSync(path);
+  await cache.refreshIndex();
+});
+
 test('pruning: deleting the file empties both FTS tables for it', async () => {
   const path = cPath();
   rmSync(path);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -96,6 +96,9 @@ export function closeDb(): void {
     _db?.close();
   } catch {}
   _db = null;
+  // Drop the in-flight refresh too: it targets the handle we just closed, so a
+  // later ensureIndexFresh must start a new scan rather than join a doomed one.
+  _refreshPromise = null;
   _lastRefreshAt = 0;
   _lastRefreshResult = { total: 0, updated: 0 };
   closeOpencodeDb();
@@ -308,11 +311,13 @@ function collectSubagentText(filePath: string, tool: Tool): string {
   return '';
 }
 
-function indexFile(db: Database, filePath: string, tool: Tool, knownStat?: { mtimeMs: number; size: number }): boolean {
-  // A candidate may wait behind another MCP process at BEGIN IMMEDIATE. Refresh
-  // its signal after that wait so we can observe the other process's completed
-  // write (or a transcript append that happened in the meantime).
-  const stat = knownStat ? (statSession(filePath, tool) ?? knownStat) : statSession(filePath, tool);
+function indexFile(db: Database, filePath: string, tool: Tool): boolean {
+  // Deliberately re-stat rather than trusting refreshIndex's pre-lock snapshot: a
+  // candidate may have waited behind another MCP process at BEGIN IMMEDIATE, and
+  // this is where we observe that process's completed write (or a transcript
+  // append) and skip the parse. A file that vanished during the wait stats as
+  // null and is left entirely alone — pruning, not ignoring, is its owner.
+  const stat = statSession(filePath, tool);
   if (!stat) return false;
 
   const existing = db
@@ -462,7 +467,7 @@ async function runRefreshIndex(): Promise<RefreshResult> {
   // candidates whose invalidation signal differs. indexFile re-checks after
   // BEGIN IMMEDIATE so a second MCP process that refreshed first makes this one
   // skip the expensive parse instead of duplicating it or racing a write lock.
-  const candidates: { file: FileEntry; stat: { mtimeMs: number; size: number } }[] = [];
+  const candidates: FileEntry[] = [];
   for (const file of files) {
     const stat = statSession(file.path, file.tool);
     if (!stat) continue;
@@ -471,7 +476,7 @@ async function runRefreshIndex(): Promise<RefreshResult> {
     const indexedMatches = existing && existing.mtime === stat.mtimeMs && existing.size === stat.size;
     const ignoredMatches = ignored && ignored.mtime === stat.mtimeMs && ignored.size === stat.size;
     if (!indexedMatches && !ignoredMatches) {
-      candidates.push({ file, stat });
+      candidates.push(file);
     }
   }
 
@@ -481,8 +486,8 @@ async function runRefreshIndex(): Promise<RefreshResult> {
     const batch = candidates.slice(i, i + BATCH);
     db.exec('BEGIN IMMEDIATE');
     try {
-      for (const { file, stat } of batch) {
-        if (indexFile(db, file.path, file.tool, stat)) updated++;
+      for (const file of batch) {
+        if (indexFile(db, file.path, file.tool)) updated++;
       }
       db.exec('COMMIT');
     } catch (error) {
@@ -495,9 +500,15 @@ async function runRefreshIndex(): Promise<RefreshResult> {
 }
 
 /**
- * Force a source scan, coalescing concurrent callers in this process. Explicit
- * callers keep the original "refresh now" contract; MCP/query entry points use
- * ensureIndexFresh below to avoid repeating this work in a request burst.
+ * Force a source scan, coalescing concurrent callers in this process onto one
+ * pass. Every query/MCP entry point goes through ensureIndexFresh instead, so
+ * today this is reached only by tests — it stays exported as the "scan now" seam
+ * for an explicit rebuild command.
+ *
+ * Coalescing weakens "scan now" for a caller that arrives mid-flight: it joins a
+ * pass whose file list was snapshotted before the caller's own write, so it may
+ * not observe that write. Anything needing a guaranteed post-write scan must run
+ * after the in-flight promise settles, not alongside it.
  */
 export async function refreshIndex(): Promise<RefreshResult> {
   if (_refreshPromise) return _refreshPromise;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -16,18 +16,7 @@ import {
   type ContextHeadline,
   type MessageHit,
 } from './types';
-import {
-  getCwdFromSession,
-  extractMessages,
-  firstPrompt,
-  lastTimestamp,
-  getSessionMessages,
-  customTitle,
-  firstTimestamp,
-  messageCount,
-  closingMessages,
-  sessionBranch,
-} from './parser';
+import { extractMessages, getSessionMessages, extractSessionMetadata, summarizeMessages } from './parser';
 import { extractFiles, extractFilesRead } from './extract-files';
 import { extractCommands } from './extract-commands';
 import { extractErrors } from './extract-errors';
@@ -77,6 +66,14 @@ function getCodexDir(): string {
 // as genuine user turns — see isGenuineUserTurn/stripInjected in parser.ts.
 const SCHEMA_VERSION = 8;
 let _db: Database | null = null;
+let _refreshPromise: Promise<RefreshResult> | null = null;
+let _lastRefreshAt = 0;
+let _lastRefreshResult: RefreshResult = { total: 0, updated: 0 };
+
+interface RefreshResult {
+  total: number;
+  updated: number;
+}
 
 export function clearCache(): void {
   const dbPath = getDbPath();
@@ -99,6 +96,8 @@ export function closeDb(): void {
     _db?.close();
   } catch {}
   _db = null;
+  _lastRefreshAt = 0;
+  _lastRefreshResult = { total: 0, updated: 0 };
   closeOpencodeDb();
 }
 
@@ -118,6 +117,7 @@ function openDb(): Database {
     db.run('DROP TABLE IF EXISTS sessions');
     db.run('DROP TABLE IF EXISTS session_fts');
     db.run('DROP TABLE IF EXISTS message_fts');
+    db.run('DROP TABLE IF EXISTS ignored_files');
     db.run(`PRAGMA user_version = ${SCHEMA_VERSION}`);
   }
 
@@ -170,6 +170,16 @@ function openDb(): Database {
       role UNINDEXED,
       text,
       tokenize = 'porter unicode61'
+    )
+  `);
+  // Negative inventory cache: malformed/empty transcripts and explicitly
+  // excluded worktree logs otherwise look "new" on every refresh and get parsed
+  // forever. The mtime+size signal makes them candidates again if they change.
+  db.run(`
+    CREATE TABLE IF NOT EXISTS ignored_files (
+      file_path TEXT PRIMARY KEY,
+      mtime REAL NOT NULL,
+      size INTEGER NOT NULL
     )
   `);
   return db;
@@ -298,8 +308,11 @@ function collectSubagentText(filePath: string, tool: Tool): string {
   return '';
 }
 
-function indexFile(db: Database, filePath: string, tool: Tool): boolean {
-  const stat = statSession(filePath, tool);
+function indexFile(db: Database, filePath: string, tool: Tool, knownStat?: { mtimeMs: number; size: number }): boolean {
+  // A candidate may wait behind another MCP process at BEGIN IMMEDIATE. Refresh
+  // its signal after that wait so we can observe the other process's completed
+  // write (or a transcript append that happened in the meantime).
+  const stat = knownStat ? (statSession(filePath, tool) ?? knownStat) : statSession(filePath, tool);
   if (!stat) return false;
 
   const existing = db
@@ -309,22 +322,37 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
   if (existing && existing.mtime === stat.mtimeMs && existing.size === stat.size) {
     return false;
   }
+  const ignored = db
+    .query<{ mtime: number; size: number }, [string]>('SELECT mtime, size FROM ignored_files WHERE file_path = ?')
+    .get(filePath);
+  if (ignored && ignored.mtime === stat.mtimeMs && ignored.size === stat.size) {
+    return false;
+  }
+
+  const ignore = (): false => {
+    if (existing) {
+      db.run('DELETE FROM sessions WHERE file_path = ?', [filePath]);
+      db.run('DELETE FROM session_fts WHERE file_path = ?', [filePath]);
+      db.run('DELETE FROM message_fts WHERE file_path = ?', [filePath]);
+    }
+    db.run('INSERT OR REPLACE INTO ignored_files (file_path, mtime, size) VALUES (?, ?, ?)', [
+      filePath,
+      stat.mtimeMs,
+      stat.size,
+    ]);
+    return false;
+  };
 
   const lines = readSessionLines(filePath, tool);
-  if (lines.length === 0) return false;
+  if (lines.length === 0) return ignore();
 
-  const cwd = getCwdFromSession(lines, tool);
-  if (!cwd) return false;
-  if (cwd.includes('.claude/worktrees') || cwd.includes('/.bare')) return false;
+  const metadata = extractSessionMetadata(lines, tool);
+  if (!metadata.cwd) return ignore();
+  if (metadata.cwd.includes('.claude/worktrees') || metadata.cwd.includes('/.bare')) return ignore();
 
   const sessionId = basename(filePath).replace('.jsonl', '');
-  const prompt = firstPrompt(lines, tool);
-  const title = customTitle(lines);
-  const date = lastTimestamp(lines);
-  const createdAt = firstTimestamp(lines);
-  const msgCount = messageCount(lines);
-
   const messages = extractMessages(lines);
+  const summary = summarizeMessages(messages);
   const subagentContent = collectSubagentText(filePath, tool);
 
   const filesTouchedArr = extractFiles(lines, tool);
@@ -335,17 +363,15 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
   const commands = JSON.stringify(commandsArr);
   const errors = extractErrors(lines, tool);
   const thinking = extractThinking(lines, tool);
-  const headline = `${prompt}\n${title}`;
+  const headline = `${summary.firstPrompt}\n${metadata.customTitle}`;
   const pathsText = [...filesTouchedArr, ...filesReadArr].join('\n');
   const commandsText = commandsArr.join('\n');
   const contextText = errors.messages.join('\n');
-  const closing = closingMessages(lines, tool);
-  const branch = sessionBranch(lines, tool);
-
   if (existing) {
     db.run('DELETE FROM session_fts WHERE file_path = ?', [filePath]);
     db.run('DELETE FROM message_fts WHERE file_path = ?', [filePath]);
   }
+  db.run('DELETE FROM ignored_files WHERE file_path = ?', [filePath]);
   db.run(
     `INSERT OR REPLACE INTO sessions (file_path, mtime, size, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count, files_touched, files_read, commands, errored, error_count, closing_user, closing_assistant, branch)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -353,22 +379,22 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
       filePath,
       stat.mtimeMs,
       stat.size,
-      cwd,
+      metadata.cwd,
       tool,
       sessionId,
-      date,
-      createdAt,
-      prompt,
-      title,
-      msgCount,
+      metadata.date,
+      metadata.createdAt,
+      summary.firstPrompt,
+      metadata.customTitle,
+      metadata.messageCount,
       filesTouched,
       filesRead,
       commands,
       errors.errored ? 1 : 0,
       errors.count,
-      closing.user,
-      closing.assistant,
-      branch,
+      summary.closingUser,
+      summary.closingAssistant,
+      metadata.branch,
     ],
   );
   db.run(
@@ -393,43 +419,117 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
   return true;
 }
 
-export async function refreshIndex(): Promise<{ total: number; updated: number }> {
+async function runRefreshIndex(): Promise<RefreshResult> {
   const db = getDb();
-  const files = await discoverFiles();
+  // De-duplicate at the boundary. It also makes the set/map work below line up
+  // exactly with the total reported to callers.
+  const files = [...new Map((await discoverFiles()).map((file) => [file.path, file])).values()];
   const filePaths = new Set(files.map((f) => f.path));
 
-  const dbPaths = db.query<{ file_path: string }, []>('SELECT file_path FROM sessions').all();
-  const removedPaths = dbPaths.filter((r) => !filePaths.has(r.file_path));
+  // Fetch the current inventory once. The old path issued SELECT mtime,size once
+  // per discovered file (~4,500 statements on the author's corpus) even when no
+  // transcript had changed.
+  const dbRows = db
+    .query<{ file_path: string; mtime: number; size: number }, []>('SELECT file_path, mtime, size FROM sessions')
+    .all();
+  const indexedByPath = new Map(dbRows.map((row) => [row.file_path, row]));
+  const ignoredRows = db
+    .query<{ file_path: string; mtime: number; size: number }, []>('SELECT file_path, mtime, size FROM ignored_files')
+    .all();
+  const ignoredByPath = new Map(ignoredRows.map((row) => [row.file_path, row]));
+  const inventoryPaths = new Set([...indexedByPath.keys(), ...ignoredByPath.keys()]);
+  const removedPaths = [...inventoryPaths].filter((path) => !filePaths.has(path));
   if (removedPaths.length > 0) {
-    for (const r of removedPaths) {
-      db.run('DELETE FROM sessions WHERE file_path = ?', [r.file_path]);
-      db.run('DELETE FROM session_fts WHERE file_path = ?', [r.file_path]);
-      db.run('DELETE FROM message_fts WHERE file_path = ?', [r.file_path]);
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      for (const path of removedPaths) {
+        db.run('DELETE FROM sessions WHERE file_path = ?', [path]);
+        db.run('DELETE FROM session_fts WHERE file_path = ?', [path]);
+        db.run('DELETE FROM message_fts WHERE file_path = ?', [path]);
+        db.run('DELETE FROM ignored_files WHERE file_path = ?', [path]);
+      }
+      db.exec('COMMIT');
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
     }
     if (removedPaths.length > 100) {
       db.exec('VACUUM');
     }
   }
 
+  // Stat source files before opening a write transaction, then transact only
+  // candidates whose invalidation signal differs. indexFile re-checks after
+  // BEGIN IMMEDIATE so a second MCP process that refreshed first makes this one
+  // skip the expensive parse instead of duplicating it or racing a write lock.
+  const candidates: { file: FileEntry; stat: { mtimeMs: number; size: number } }[] = [];
+  for (const file of files) {
+    const stat = statSession(file.path, file.tool);
+    if (!stat) continue;
+    const existing = indexedByPath.get(file.path);
+    const ignored = ignoredByPath.get(file.path);
+    const indexedMatches = existing && existing.mtime === stat.mtimeMs && existing.size === stat.size;
+    const ignoredMatches = ignored && ignored.mtime === stat.mtimeMs && ignored.size === stat.size;
+    if (!indexedMatches && !ignoredMatches) {
+      candidates.push({ file, stat });
+    }
+  }
+
   let updated = 0;
   const BATCH = 200;
-  for (let i = 0; i < files.length; i += BATCH) {
-    const batch = files.slice(i, i + BATCH);
-    db.exec('BEGIN');
-    for (const f of batch) {
-      if (indexFile(db, f.path, f.tool)) updated++;
+  for (let i = 0; i < candidates.length; i += BATCH) {
+    const batch = candidates.slice(i, i + BATCH);
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      for (const { file, stat } of batch) {
+        if (indexFile(db, file.path, file.tool, stat)) updated++;
+      }
+      db.exec('COMMIT');
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
     }
-    db.exec('COMMIT');
   }
 
   return { total: files.length, updated };
+}
+
+/**
+ * Force a source scan, coalescing concurrent callers in this process. Explicit
+ * callers keep the original "refresh now" contract; MCP/query entry points use
+ * ensureIndexFresh below to avoid repeating this work in a request burst.
+ */
+export async function refreshIndex(): Promise<RefreshResult> {
+  if (_refreshPromise) return _refreshPromise;
+
+  const promise = runRefreshIndex();
+  _refreshPromise = promise;
+  try {
+    const result = await promise;
+    _lastRefreshAt = Date.now();
+    _lastRefreshResult = result;
+    return result;
+  } finally {
+    if (_refreshPromise === promise) _refreshPromise = null;
+  }
+}
+
+function refreshIntervalMs(): number {
+  const configured = Number(process.env.SESSIONS_REFRESH_INTERVAL_MS ?? 5_000);
+  return Number.isFinite(configured) ? Math.max(0, configured) : 5_000;
+}
+
+async function ensureIndexFresh(): Promise<RefreshResult> {
+  if (_refreshPromise) return _refreshPromise;
+  if (_db && Date.now() - _lastRefreshAt < refreshIntervalMs()) return _lastRefreshResult;
+  return refreshIndex();
 }
 
 // Read-only index access for stats consumers (`sessions wrapped`). Refreshes
 // first so queries see current transcripts, then hands back the shared handle.
 // Callers must treat the connection as read-only — all writes stay in this file.
 export async function getIndexDb(): Promise<Database> {
-  await refreshIndex();
+  await ensureIndexFresh();
   return getDb();
 }
 
@@ -445,7 +545,7 @@ export interface SearchOptions {
 
 export async function searchSessions(query: string, opts: SearchOptions = {}): Promise<SessionResult[]> {
   const db = getDb();
-  await refreshIndex();
+  await ensureIndexFresh();
 
   const toolFilter = opts.tool ?? '';
   const project = opts.project ?? '';
@@ -710,7 +810,7 @@ export async function grepSessions(pattern: string, opts: GrepOptions = {}): Pro
   if (!pattern) throw new Error('Empty pattern: pass a non-empty string to search for.');
 
   const db = getDb();
-  await refreshIndex();
+  await ensureIndexFresh();
 
   const ignoreCase = opts.ignoreCase ?? true;
   // Guard against fractional/negative limits so `hits.length < limit` behaves as a
@@ -822,7 +922,7 @@ export async function grepSessions(pattern: string, opts: GrepOptions = {}): Pro
  */
 export async function resolveSessionFile(sessionId: string): Promise<string | null> {
   const db = getDb();
-  await refreshIndex();
+  await ensureIndexFresh();
   const row = db
     .query<{ file_path: string }, [string]>(
       'SELECT file_path FROM sessions WHERE session_id = ? ORDER BY mtime DESC LIMIT 1',
@@ -909,7 +1009,7 @@ export async function getActivityDigest(
   detail: DigestDetail = 'compact',
 ): Promise<ActivityDigest> {
   const db = getDb();
-  await refreshIndex();
+  await ensureIndexFresh();
 
   const rows = queryDateRange(db, startDate, endDate, toolFilter, project);
 
@@ -1001,7 +1101,7 @@ export async function getSessionMetrics(
   project: string,
 ): Promise<SessionMetrics> {
   const db = getDb();
-  await refreshIndex();
+  await ensureIndexFresh();
 
   const rows = queryDateRange(db, startDate, endDate, toolFilter, project);
 
@@ -1098,7 +1198,7 @@ function parseFiles(json: string): string[] {
  */
 export async function getContextPrimer(repo: RepoInfo, opts: ContextOptions): Promise<ContextPrimer> {
   const db = getDb();
-  await refreshIndex();
+  await ensureIndexFresh();
 
   const limit = opts.limit ?? 10;
   const headlineCap = opts.headlineCap ?? 40;

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -12,11 +12,90 @@ import {
   getCwdFromSession,
   sessionBranch,
   closingMessages,
+  extractSessionMetadata,
+  summarizeMessages,
 } from './parser';
 
 function jsonl(...objs: Record<string, unknown>[]): string[] {
   return objs.map((o) => JSON.stringify(o));
 }
+
+describe('extractSessionMetadata', () => {
+  test('matches the individual Claude metadata helpers in one pass', () => {
+    const lines = jsonl(
+      {
+        type: 'user',
+        cwd: '/repo',
+        timestamp: '2026-03-15T10:00:00Z',
+        gitBranch: 'main',
+        message: { content: 'hello' },
+      },
+      { type: 'custom-title', customTitle: 'First title', timestamp: 'not-a-date' },
+      {
+        type: 'assistant',
+        cwd: '/repo',
+        timestamp: '2026-03-17T10:00:00Z',
+        gitBranch: 'feature',
+        message: { content: [{ type: 'text', text: 'done' }] },
+      },
+      { type: 'custom-title', customTitle: 'Final title' },
+    );
+
+    expect(extractSessionMetadata(lines, 'claude')).toEqual({
+      cwd: getCwdFromSession(lines, 'claude'),
+      customTitle: customTitle(lines),
+      date: lastTimestamp(lines),
+      createdAt: firstTimestamp(lines),
+      messageCount: messageCount(lines),
+      branch: sessionBranch(lines, 'claude'),
+    });
+  });
+
+  test('extracts Codex cwd and starting branch from session_meta', () => {
+    const lines = jsonl(
+      {
+        type: 'session_meta',
+        timestamp: '2026-04-01T09:00:00Z',
+        payload: { cwd: '/codex-repo', git: { branch: 'perf/index' } },
+      },
+      {
+        type: 'message',
+        timestamp: '2026-04-02T09:00:00Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'ready' }] },
+      },
+    );
+
+    expect(extractSessionMetadata(lines, 'codex')).toMatchObject({
+      cwd: '/codex-repo',
+      date: '2026-04-02',
+      createdAt: '2026-04-01',
+      messageCount: 1,
+      branch: 'perf/index',
+    });
+  });
+});
+
+test('summarizeMessages reuses extracted messages without changing prompt or closing semantics', () => {
+  const lines = jsonl(
+    {
+      type: 'user',
+      promptSource: 'typed',
+      message: { content: '<system-reminder>noise</system-reminder> build the index' },
+    },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'working' }] } },
+    {
+      type: 'user',
+      promptSource: null,
+      message: { content: 'Base directory for this skill: /tmp/skill\ninjected body' },
+    },
+    { type: 'user', promptSource: 'typed', message: { content: 'is it done?' } },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'yes, it is done' }] } },
+  );
+
+  const summary = summarizeMessages(extractMessages(lines));
+  expect(summary.firstPrompt).toBe(firstPrompt(lines, 'claude'));
+  expect({ user: summary.closingUser, assistant: summary.closingAssistant }).toEqual(closingMessages(lines, 'claude'));
+});
 
 describe('customTitle', () => {
   test('returns empty string when no custom-title row exists', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -73,6 +73,24 @@ describe('extractSessionMetadata', () => {
       branch: 'perf/index',
     });
   });
+
+  // Regression guard for the one input shape where the old date helper disagreed:
+  // it searched only the final 200 lines and, finding nothing dated there, fell
+  // back to the FIRST timestamp — reporting a session's start as its end. Both
+  // implementations must now report the last dated line regardless of tail length.
+  test('reports the last dated line even when the final 200+ lines carry no timestamp', () => {
+    const lines = [
+      ...jsonl(
+        { type: 'user', cwd: '/repo', timestamp: '2026-01-01T10:00:00Z', message: { content: 'start' } },
+        { type: 'assistant', cwd: '/repo', timestamp: '2026-05-05T10:00:00Z', message: { content: 'end' } },
+      ),
+      ...Array.from({ length: 205 }, () => JSON.stringify({ type: 'summary', summary: 'undated tail' })),
+    ];
+
+    expect(extractSessionMetadata(lines, 'claude').date).toBe('2026-05-05');
+    expect(extractSessionMetadata(lines, 'claude').date).toBe(lastTimestamp(lines));
+    expect(extractSessionMetadata(lines, 'claude').createdAt).toBe(firstTimestamp(lines));
+  });
 });
 
 test('summarizeMessages reuses extracted messages without changing prompt or closing semantics', () => {
@@ -94,7 +112,7 @@ test('summarizeMessages reuses extracted messages without changing prompt or clo
 
   const summary = summarizeMessages(extractMessages(lines));
   expect(summary.firstPrompt).toBe(firstPrompt(lines, 'claude'));
-  expect({ user: summary.closingUser, assistant: summary.closingAssistant }).toEqual(closingMessages(lines, 'claude'));
+  expect({ user: summary.closingUser, assistant: summary.closingAssistant }).toEqual(closingMessages(lines));
 });
 
 describe('customTitle', () => {
@@ -518,7 +536,7 @@ describe('closingMessages user side', () => {
         message: { content: [{ type: 'text', text: 'Base directory for this skill: /y' }] },
       },
     );
-    expect(closingMessages(lines, 'claude').user).toBe('commit and PR it');
+    expect(closingMessages(lines).user).toBe('commit and PR it');
   });
 
   test('old logs (no promptSource): heuristic still drops a skill-injection turn', () => {
@@ -526,7 +544,7 @@ describe('closingMessages user side', () => {
       { type: 'user', message: { content: [{ type: 'text', text: 'fix the bug' }] } },
       { type: 'user', message: { content: [{ type: 'text', text: 'Base directory for this skill: /z' }] } },
     );
-    expect(closingMessages(lines, 'claude').user).toBe('fix the bug');
+    expect(closingMessages(lines).user).toBe('fix the bug');
   });
 });
 
@@ -543,7 +561,7 @@ describe('closingMessages assistant side', () => {
       { type: 'user', promptSource: 'typed', message: { content: [{ type: 'text', text: 'ship it' }] } },
       { type: 'assistant', message: { content: [{ type: 'text', text: assistantText }] } },
     );
-    const a = closingMessages(lines, 'claude').assistant;
+    const a = closingMessages(lines).assistant;
     expect(a).toContain('Done. Shipped it.');
     expect(a).toContain('The index is the moat.');
     expect(a).not.toContain('★');
@@ -556,7 +574,7 @@ describe('closingMessages assistant side', () => {
       { type: 'user', promptSource: 'typed', message: { content: [{ type: 'text', text: 'advise' }] } },
       { type: 'assistant', message: { content: [{ type: 'text', text: assistantText }] } },
     );
-    const a = closingMessages(lines, 'claude').assistant;
+    const a = closingMessages(lines).assistant;
     expect(a).toContain('-----'); // ASCII rule is not the box-drawing fence
     expect(a).toContain('Insight'); // bare heading, no ★ marker
     expect(a).toContain('pick the first.');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,7 @@ interface JsonLine {
   timestamp?: string;
   sessionId?: string;
   gitBranch?: string;
+  customTitle?: string;
   promptSource?: string | null;
   /** Claude marks auto-generated context-carryover turns (the "continued from a
    *  previous conversation" summary written on compaction) with this flag. */
@@ -24,6 +25,70 @@ function tryParseJson(line: string): JsonLine | null {
   } catch {
     return null;
   }
+}
+
+export interface SessionMetadata {
+  cwd: string;
+  customTitle: string;
+  date: string;
+  createdAt: string;
+  messageCount: number;
+  branch: string;
+}
+
+/**
+ * Extract the session-level fields needed by the index in one JSON parse pass.
+ * These used to be collected by six independent helpers, which made indexing an
+ * actively growing (and often multi-megabyte) transcript parse the same JSONL
+ * records over and over.
+ */
+export function extractSessionMetadata(lines: string[], tool: Tool): SessionMetadata {
+  let cwd = '';
+  let title = '';
+  let firstDate = '?';
+  let lastDate = '?';
+  let count = 0;
+  let branch = '';
+
+  for (const line of lines) {
+    const d = tryParseJson(line);
+    if (!d) continue;
+
+    if (!cwd) {
+      if (tool === 'claude' && d.cwd) {
+        cwd = d.cwd;
+      } else if ((tool === 'pi' || tool === 'opencode') && d.type === 'session' && d.cwd) {
+        cwd = d.cwd;
+      } else if (tool === 'codex' && d.type === 'session_meta') {
+        const value = (d.payload as Record<string, unknown> | undefined)?.cwd;
+        if (typeof value === 'string' && value) cwd = value;
+      }
+    }
+
+    if (d.type === 'custom-title') title = d.customTitle ?? '';
+
+    if (d.timestamp?.[0] === '2') {
+      const date = d.timestamp.slice(0, 10);
+      if (firstDate === '?') firstDate = date;
+      lastDate = date;
+    }
+
+    if (isUserMessage(d) || d.type === 'assistant') {
+      count++;
+    } else if (d.type === 'message') {
+      const msg = d.message;
+      if (typeof msg === 'object' && msg !== null && (msg as Record<string, unknown>).role === 'assistant') count++;
+    }
+
+    if (tool === 'claude') {
+      if (typeof d.gitBranch === 'string' && d.gitBranch) branch = d.gitBranch;
+    } else if (tool === 'codex' && !branch && d.type === 'session_meta') {
+      const git = (d.payload as Record<string, unknown> | undefined)?.git as Record<string, unknown> | undefined;
+      if (typeof git?.branch === 'string' && git.branch) branch = git.branch;
+    }
+  }
+
+  return { cwd, customTitle: title, date: lastDate, createdAt: firstDate, messageCount: count, branch };
 }
 
 export function getCwdFromSession(lines: string[], tool: Tool): string {
@@ -391,6 +456,12 @@ export interface ExtractedMessage {
   tools: ToolUse[];
 }
 
+export interface MessageSummary {
+  firstPrompt: string;
+  closingUser: string;
+  closingAssistant: string;
+}
+
 /**
  * The single numbering authority for message extraction. Every non-empty
  * user/assistant message in order, with a sequential index and a `genuine` flag
@@ -461,26 +532,46 @@ export function stripInsightFences(text: string): string {
 }
 
 /**
+ * Build the prompt/closing columns from an extraction the index already needs
+ * for message_fts. Keeping this as a projection avoids three additional full
+ * transcript passes in the hot indexing path.
+ */
+export function summarizeMessages(messages: ExtractedMessage[]): MessageSummary {
+  let first = '';
+  let lastUser = '';
+  let lastAssistant = '';
+
+  for (const message of messages) {
+    if (message.role === 'user' && message.genuine) {
+      if (!first) first = message.text;
+      lastUser = message.text;
+    } else if (message.role === 'assistant') {
+      lastAssistant = message.text;
+    }
+  }
+
+  const finish = (text: string): string => {
+    const stripped = stripInjected(text).trim();
+    return stripped.length > CLOSING_MAX ? stripped.slice(0, CLOSING_MAX) : stripped;
+  };
+
+  return {
+    firstPrompt: first ? clean(first) : '',
+    closingUser: finish(lastUser),
+    closingAssistant: finish(stripInsightFences(lastAssistant)),
+  };
+}
+
+/**
  * Last user message and last assistant message from a session, stripped of
  * injected tags and truncated to CLOSING_MAX. Both roles are returned so the
  * synthesis layer (Phase 2) can decide what the open thread is — the last
  * assistant turn alone is often a question or tool call, not an outcome.
  */
 export function closingMessages(lines: string[], tool: Tool): { user: string; assistant: string } {
-  const genuineUsers = genuineUserTexts(lines, tool);
-  const user = genuineUsers.length ? genuineUsers[genuineUsers.length - 1]! : '';
-
-  const messages = getSessionMessages(lines);
-  let assistant = '';
-  for (let i = messages.length - 1; i >= 0 && !assistant; i--) {
-    if (messages[i]!.role === 'assistant') assistant = messages[i]!.text;
-  }
-
-  const finish = (t: string): string => {
-    const stripped = stripInjected(t).trim();
-    return stripped.length > CLOSING_MAX ? stripped.slice(0, CLOSING_MAX) : stripped;
-  };
-  return { user: finish(user), assistant: finish(stripInsightFences(assistant)) };
+  void tool; // Retained for API compatibility; extraction is format-aware by record shape.
+  const summary = summarizeMessages(extractMessages(lines));
+  return { user: summary.closingUser, assistant: summary.closingAssistant };
 }
 
 export function findMatchContext(lines: string[], query: string): string {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -308,15 +308,19 @@ export function messageCount(lines: string[]): number {
   return count;
 }
 
+/**
+ * The last dated line in a transcript. Scans backwards, so the common case (the
+ * final line carries a timestamp) still returns on the first iteration.
+ *
+ * This is the differential oracle for `extractSessionMetadata().date` — the two
+ * must agree exactly. An earlier version searched only the last 200 lines and,
+ * finding nothing dated there, fell back to the *first* timestamp in the file;
+ * that fallback reported a session's date as its start rather than its end, and
+ * no real transcript ever reached it (Claude dates every line).
+ */
 export function lastTimestamp(lines: string[]): string {
-  for (let i = lines.length - 1; i >= Math.max(0, lines.length - 200); i--) {
+  for (let i = lines.length - 1; i >= 0; i--) {
     const d = tryParseJson(lines[i]!);
-    if (!d) continue;
-    const ts = d.timestamp as string | undefined;
-    if (ts && ts[0] === '2') return ts.slice(0, 10);
-  }
-  for (const line of lines) {
-    const d = tryParseJson(line);
     if (!d) continue;
     const ts = d.timestamp as string | undefined;
     if (ts && ts[0] === '2') return ts.slice(0, 10);
@@ -568,8 +572,7 @@ export function summarizeMessages(messages: ExtractedMessage[]): MessageSummary 
  * synthesis layer (Phase 2) can decide what the open thread is — the last
  * assistant turn alone is often a question or tool call, not an outcome.
  */
-export function closingMessages(lines: string[], tool: Tool): { user: string; assistant: string } {
-  void tool; // Retained for API compatibility; extraction is format-aware by record shape.
+export function closingMessages(lines: string[]): { user: string; assistant: string } {
   const summary = summarizeMessages(extractMessages(lines));
   return { user: summary.closingUser, assistant: summary.closingAssistant };
 }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -3,7 +3,7 @@ import { join, basename } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { type Tool, type SessionResult } from './types';
-import { extractSessionMetadata, firstPrompt, contentMatches, findMatchContext } from './parser';
+import { extractSessionMetadata, getCwdFromSession, firstPrompt, contentMatches, findMatchContext } from './parser';
 import { cwdUnder } from './repo';
 import { discoverOpencodeSessions } from './opencode';
 import { readSessionLines } from './session-io';
@@ -23,12 +23,20 @@ async function processSession(
   const lines = readSessionLines(filePath, tool);
   if (lines.length === 0) return null;
 
-  const metadata = extractSessionMetadata(lines, tool);
-  if (!metadata.cwd) return null;
+  // Reject on cwd BEFORE the full metadata pass: getCwdFromSession returns as soon as
+  // it sees the cwd (first line for Claude, session_meta for Codex), while
+  // extractSessionMetadata always parses the whole transcript. That gap is load-bearing
+  // for Codex, whose sessions live in one flat tree with no slug to pre-filter on — so
+  // scanDir opens every Codex transcript on the machine and `cwdUnder` rejects nearly
+  // all of them. Measured on a 297-session Codex corpus scoped to one repo (4 kept):
+  // 371ms when the metadata pass ran first, 92ms with this gate ahead of it.
+  const cwd = getCwdFromSession(lines, tool);
+  if (!cwd) return null;
   // Boundary-aware: a sibling sharing a prefix (e.g. `dotfiles-v2`) is not under `repoRoot`.
-  if (!searchAll && !cwdUnder(metadata.cwd, repoRoot)) return null;
-  if (metadata.cwd.includes('.claude/worktrees') || metadata.cwd.includes('/.bare')) return null;
+  if (!searchAll && !cwdUnder(cwd, repoRoot)) return null;
+  if (cwd.includes('.claude/worktrees') || cwd.includes('/.bare')) return null;
 
+  const metadata = extractSessionMetadata(lines, tool);
   const sessionId = basename(filePath).replace('.jsonl', '');
 
   if (searchQuery) {
@@ -37,14 +45,14 @@ async function processSession(
     return {
       date: metadata.date,
       createdAt: metadata.createdAt,
-      cwd: metadata.cwd,
+      cwd,
       tool,
       sessionId,
       displayText,
       customTitle: metadata.customTitle,
       messageCount: metadata.messageCount,
       filePath,
-      exists: existsSync(metadata.cwd),
+      exists: existsSync(cwd),
       files: [],
       commands: [],
       errored: false,
@@ -55,14 +63,14 @@ async function processSession(
   return {
     date: metadata.date,
     createdAt: metadata.createdAt,
-    cwd: metadata.cwd,
+    cwd,
     tool,
     sessionId,
     displayText,
     customTitle: metadata.customTitle,
     messageCount: metadata.messageCount,
     filePath,
-    exists: existsSync(metadata.cwd),
+    exists: existsSync(cwd),
     files: [],
     commands: [],
     errored: false,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -3,16 +3,7 @@ import { join, basename } from 'node:path';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { type Tool, type SessionResult } from './types';
-import {
-  getCwdFromSession,
-  firstPrompt,
-  lastTimestamp,
-  contentMatches,
-  findMatchContext,
-  customTitle,
-  firstTimestamp,
-  messageCount,
-} from './parser';
+import { extractSessionMetadata, firstPrompt, contentMatches, findMatchContext } from './parser';
 import { cwdUnder } from './repo';
 import { discoverOpencodeSessions } from './opencode';
 import { readSessionLines } from './session-io';
@@ -32,51 +23,46 @@ async function processSession(
   const lines = readSessionLines(filePath, tool);
   if (lines.length === 0) return null;
 
-  const cwd = getCwdFromSession(lines, tool);
-  if (!cwd) return null;
+  const metadata = extractSessionMetadata(lines, tool);
+  if (!metadata.cwd) return null;
   // Boundary-aware: a sibling sharing a prefix (e.g. `dotfiles-v2`) is not under `repoRoot`.
-  if (!searchAll && !cwdUnder(cwd, repoRoot)) return null;
-  if (cwd.includes('.claude/worktrees') || cwd.includes('/.bare')) return null;
+  if (!searchAll && !cwdUnder(metadata.cwd, repoRoot)) return null;
+  if (metadata.cwd.includes('.claude/worktrees') || metadata.cwd.includes('/.bare')) return null;
 
   const sessionId = basename(filePath).replace('.jsonl', '');
-
-  const date = lastTimestamp(lines);
-  const createdAt = firstTimestamp(lines);
-  const title = customTitle(lines);
-  const msgCount = messageCount(lines);
 
   if (searchQuery) {
     if (!contentMatches(lines, searchQuery)) return null;
     const displayText = findMatchContext(lines, searchQuery);
     return {
-      date,
-      createdAt,
-      cwd,
+      date: metadata.date,
+      createdAt: metadata.createdAt,
+      cwd: metadata.cwd,
       tool,
       sessionId,
       displayText,
-      customTitle: title,
-      messageCount: msgCount,
+      customTitle: metadata.customTitle,
+      messageCount: metadata.messageCount,
       filePath,
-      exists: existsSync(cwd),
+      exists: existsSync(metadata.cwd),
       files: [],
       commands: [],
       errored: false,
     };
   }
 
-  const displayText = title || firstPrompt(lines, tool);
+  const displayText = metadata.customTitle || firstPrompt(lines, tool);
   return {
-    date,
-    createdAt,
-    cwd,
+    date: metadata.date,
+    createdAt: metadata.createdAt,
+    cwd: metadata.cwd,
     tool,
     sessionId,
     displayText,
-    customTitle: title,
-    messageCount: msgCount,
+    customTitle: metadata.customTitle,
+    messageCount: metadata.messageCount,
     filePath,
-    exists: existsSync(cwd),
+    exists: existsSync(metadata.cwd),
     files: [],
     commands: [],
     errored: false,


### PR DESCRIPTION
## Why

Every MCP tool call ran a full `refreshIndex()` before touching the index. On a corpus of a few thousand transcripts that meant, per call:

- one `SELECT mtime, size` statement **per discovered file** (~4,500 statements) even when nothing had changed,
- six independent full-transcript parse passes for any file that *had* changed,
- a re-parse of every malformed/empty/worktree transcript on *every* refresh, because a file that never lands in `sessions` always looks new,
- a `BEGIN` write transaction per 200-file batch regardless of whether any file in the batch needed writing.

A burst of related tool calls (the common case — primer, then search, then digest) paid all of that repeatedly.

## What changed

**Coalesce and throttle refreshes** (`src/cache.ts`)
- `refreshIndex()` now de-dupes concurrent in-process callers onto a single shared promise, so eight simultaneous calls do the work once.
- Query/MCP entry points switched from `refreshIndex()` to a new internal `ensureIndexFresh()`, which reuses the last result for a short interval instead of rescanning.
- Interval is configurable via `SESSIONS_REFRESH_INTERVAL_MS` (default `5000`; `0` forces a scan before every call).

**Stat once, transact only candidates** (`src/cache.ts`)
- The inventory is now fetched in two bulk `SELECT`s instead of one statement per file.
- Files are stat'd *before* opening a write transaction; only files whose mtime+size differ from the recorded signal become candidates. A refresh with no changes now opens no write transaction at all.
- Batches use `BEGIN IMMEDIATE` with explicit `ROLLBACK` on error, replacing bare `BEGIN` with no error path. `indexFile` re-stats after acquiring the lock, so a second MCP process that indexed the same file while we waited makes us skip the parse rather than duplicate it.

**Negative inventory cache** (`src/cache.ts`)
- New `ignored_files` table records malformed/empty transcripts and excluded worktree logs by path + mtime + size. They're skipped until their signal changes, instead of being re-parsed forever. Indexing a file clears its ignore row; pruning removes it.
- No `SCHEMA_VERSION` bump: the table is created with `CREATE TABLE IF NOT EXISTS`, so an existing v8 index picks it up with no rebuild. The `DROP TABLE IF EXISTS ignored_files` alongside the others just arms the next bump.

**Single-pass extraction** (`src/parser.ts`)
- `extractSessionMetadata()` collects cwd, custom title, first/last timestamp, message count, and branch in one JSON parse pass — replacing six helpers that each walked the whole transcript.
- `summarizeMessages()` derives `firstPrompt` and the closing user/assistant columns from the `ExtractedMessage[]` the indexer *already* builds for `message_fts`, removing three more passes.
- The old helpers stay exported and are now the differential-test oracles rather than production callers. `closingMessages()` is reimplemented on top of `summarizeMessages()`.

**Order the fallback scanner's rejections** (`src/scanner.ts`)
- `src/scanner.ts` is the no-index fallback `index.ts` uses when indexed search throws, and it got the same single-pass extraction. But there the metadata pass ran *before* the cwd rejection, so a repo-scoped query fully parsed every transcript it opened just to discard it.
- Claude sessions are pre-filtered by directory slug and barely noticed. Codex sessions live in one flat tree with nothing to pre-filter on, so `scanDir` opens all of them: scoped to one repo over a 297-session Codex corpus (4 kept), **371ms → 92ms** once the cheap `getCwdFromSession` gate runs first.

## Verification

- `bun test` — **369 pass, 0 fail** (up from 363; 6 new tests).
- `tsc --noEmit` clean, `oxlint` clean, `oxfmt --check` clean.
- `parser.test.ts` asserts `extractSessionMetadata` and `summarizeMessages` equal the six original helpers and `closingMessages`/`firstPrompt` on the same input, for both Claude and Codex record shapes.
- `cache.search.test.ts` asserts 8 concurrent `refreshIndex()` calls report `updated === 1` and leave exactly 2 message rows (no duplicated work), and that an invalid transcript lands in `ignored_files`, reports `updated === 0` on the next refresh, and has its ignore row pruned when the file is deleted.
- The no-index fallback was smoke-tested against the real corpus after the reordering: 81 sessions repo-scoped, every result under the repo root, no worktree/`.bare` leakage, every result dated, and query mode still returns match snippets.

## One semantics change, found in review and fixed

The differential tests could not reach it: `lastTimestamp` searched only the **final 200 lines** and, finding nothing dated there, fell back to the **first** timestamp in the file — reporting a session's start as its end. `extractSessionMetadata` reports the last dated line, so the two disagreed on any transcript with a 200+ line undated tail.

Swept the real corpus to size the blast radius: **0 divergences across 8,532 Claude transcripts**, because Claude dates every line and the fallback was unreachable in practice. Nothing shipped wrong. The dead fallback is now removed so the oracle and the implementation agree by construction, and a regression test pins the >200-undated-tail shape that would otherwise have gone uncovered.

## Notes for review

- The 5s default freshness window is a deliberate staleness tradeoff: a transcript written in the last few seconds may not appear in the very next tool call within the same burst. `SESSIONS_REFRESH_INTERVAL_MS=0` restores the old always-scan behavior.
- `refreshIndex()` has no production callers left — every entry point goes through `ensureIndexFresh()`. It stays exported as the "scan now" seam, but note that coalescing weakens that contract for a caller arriving mid-flight: it joins a pass whose file list was snapshotted before the caller's own write. A future explicit rebuild command must run *after* the in-flight promise settles, not alongside it.
- Concurrent `refreshIndex()` calls could not previously nest transactions — on `main` everything after `await discoverFiles()` is synchronous, so two calls could not interleave `BEGIN`. The win here is 8 redundant scans collapsing to 1, not a crash fix.
