### PR TITLE
fix: Codex message extraction, setup config paths, metrics timezone, and a CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,16 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
       - run: bun install --frozen-lockfile
       - run: bun run build
+
+  # Runs deliberately on a runner with no agent CLI installed. Several suites used to
+  # pass only because `claude` happened to be on the developer's PATH; keeping the
+  # runner bare is what stops that class of test from regressing silently.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun install --frozen-lockfile
+      - run: bun run test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "oxlint",
     "format": "oxfmt . '!plugin/**/plugin.json'",
     "format:check": "oxfmt --check . '!plugin/**/plugin.json'",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/cache.metrics.test.ts
+++ b/src/cache.metrics.test.ts
@@ -1,0 +1,121 @@
+/**
+ * getSessionMetrics: the active-hours histogram.
+ *
+ * Transcript timestamps are Z-normalized, and the old implementation read the hour by
+ * slicing characters 11-13 out of the ISO string — the UTC hour, labelled as the user's.
+ * A US-Central user's 9am work showed up in the 14:00 or 15:00 bucket. The fixture below
+ * is chosen to cross a day boundary so a UTC/local mixup cannot pass by coincidence.
+ */
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const j = (o: unknown): string => JSON.stringify(o);
+
+let tmp: string;
+let cache: typeof import('./cache');
+
+function setEnv(): void {
+  process.env.SESSIONS_CACHE_DIR = join(tmp, 'cache');
+  process.env.SESSIONS_CLAUDE_DIR = join(tmp, 'claude');
+  process.env.SESSIONS_PI_DIR = join(tmp, 'pi');
+  process.env.SESSIONS_CODEX_DIR = join(tmp, 'codex');
+  process.env.SESSIONS_OPENCODE_DB = join(tmp, 'opencode.db'); // absent → nothing leaks in
+  // Re-index on every call. The default 5s freshness window would hide a fixture written
+  // partway through this file, making the assertion pass against a stale index.
+  process.env.SESSIONS_REFRESH_INTERVAL_MS = '0';
+}
+
+/** 02:30 UTC on June 1. In Chicago that is 21:30 on May 31 — a different hour AND day. */
+const INSTANT = '2026-06-01T02:30:00Z';
+
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'sessions-metrics-'));
+  setEnv();
+  const dir = join(tmp, 'claude', 'proj');
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(join(tmp, 'pi'), { recursive: true });
+  mkdirSync(join(tmp, 'codex'), { recursive: true });
+  writeFileSync(
+    join(dir, 'a.jsonl'),
+    [
+      j({
+        type: 'user',
+        cwd: '/repoA',
+        timestamp: INSTANT,
+        promptSource: 'typed',
+        message: { role: 'user', content: [{ type: 'text', text: 'late night refactor' }] },
+      }),
+      j({
+        type: 'assistant',
+        cwd: '/repoA',
+        timestamp: '2026-06-01T02:35:00Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'on it' }] },
+      }),
+    ].join('\n'),
+  );
+});
+
+beforeEach(async () => {
+  setEnv();
+  cache = await import('./cache');
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('buckets active hours in the given zone, not UTC', async () => {
+  const m = await cache.getSessionMetrics('2026-05-30', '2026-06-02', '', '', 'America/Chicago');
+  expect(m.totalSessions).toBe(1);
+  // 21 on May 31 locally. Slicing the ISO string would have given '02'.
+  expect(m.activeHours).toEqual({ '21': 1 });
+});
+
+test('the same instant lands in a different bucket in a different zone', async () => {
+  // Proves the bucket tracks the zone rather than happening to match one fixture. The
+  // zone is a parameter precisely because V8 caches the process default on first clock
+  // read, which made the old getHours()-based conversion untestable in-process.
+  const m = await cache.getSessionMetrics('2026-05-30', '2026-06-02', '', '', 'Asia/Tokyo');
+  expect(m.activeHours).toEqual({ '11': 1 });
+});
+
+test('UTC is just another zone, and returns the hour the old code guessed', async () => {
+  const m = await cache.getSessionMetrics('2026-05-30', '2026-06-02', '', '', 'UTC');
+  expect(m.activeHours).toEqual({ '02': 1 });
+});
+
+test('midnight is bucketed as 00, never 24', async () => {
+  // Pins the contract: buckets are 00-23. It does NOT prove the `% 24` guard in hourIn
+  // fires — this machine's ICU already renders midnight as '00', so the test passes with
+  // the guard removed. The guard follows the vendored localHour in
+  // src/report/parsers/util.ts, which carries the same modulo for ICU builds that emit
+  // '24'. Treat it as precedent-driven, not as covered here.
+  const dir = join(tmp, 'claude', 'proj');
+  writeFileSync(
+    join(dir, 'midnight.jsonl'),
+    j({
+      type: 'user',
+      cwd: '/repoB',
+      timestamp: '2026-06-02T00:15:00Z',
+      promptSource: 'typed',
+      message: { role: 'user', content: [{ type: 'text', text: 'midnight' }] },
+    }),
+  );
+  try {
+    const m = await cache.getSessionMetrics('2026-06-02', '2026-06-02', '', '', 'UTC');
+    expect(m.activeHours).toEqual({ '00': 1 });
+  } finally {
+    rmSync(join(dir, 'midnight.jsonl'));
+  }
+});
+
+test('every matched session contributes exactly one hour', async () => {
+  // The histogram total must equal the session count. The old implementation built it in
+  // a second pass that reopened each transcript and swallowed every failure, so a
+  // read error silently dropped sessions out of the histogram but not the totals.
+  const m = await cache.getSessionMetrics('2026-05-30', '2026-06-02', '', '', 'America/Chicago');
+  const bucketed = Object.values(m.activeHours).reduce((a, b) => a + b, 0);
+  expect(bucketed).toBe(m.totalSessions);
+});

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -71,7 +71,11 @@ function getCodexDir(): string {
 // v8: message_fts no longer stores compaction summaries or tag-wrapped agent/
 // harness injections (task-notifications, `!`-mode shell echoes, teammate relays)
 // as genuine user turns — see isGenuineUserTurn/stripInjected in parser.ts.
-const SCHEMA_VERSION = 8;
+// v9: adds sessions.started_at (the full first timestamp, for the active-hours
+// histogram), and Codex transcripts index their messages for the first time —
+// every Codex row held metadata only until parser.ts learned the response_item
+// envelope, so a rebuild is what actually populates them.
+const SCHEMA_VERSION = 9;
 let _db: Database | null = null;
 let _refreshPromise: Promise<RefreshResult> | null = null;
 let _lastRefreshAt = 0;
@@ -141,6 +145,10 @@ function openDb(): Database {
       session_id TEXT NOT NULL,
       date TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT '?',
+      -- The full first timestamp. created_at is the same instant truncated to a day;
+      -- the active-hours histogram needs the clock, and reading it from here is what
+      -- lets getSessionMetrics skip a second pass over every transcript on disk.
+      started_at TEXT NOT NULL DEFAULT '',
       first_prompt TEXT NOT NULL,
       custom_title TEXT NOT NULL DEFAULT '',
       message_count INTEGER NOT NULL DEFAULT 0,
@@ -385,8 +393,8 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
   }
   db.run('DELETE FROM ignored_files WHERE file_path = ?', [filePath]);
   db.run(
-    `INSERT OR REPLACE INTO sessions (file_path, mtime, size, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count, files_touched, files_read, commands, errored, error_count, closing_user, closing_assistant, branch)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT OR REPLACE INTO sessions (file_path, mtime, size, cwd, tool, session_id, date, created_at, started_at, first_prompt, custom_title, message_count, files_touched, files_read, commands, errored, error_count, closing_user, closing_assistant, branch)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       filePath,
       stat.mtimeMs,
@@ -396,6 +404,7 @@ function indexFile(db: Database, filePath: string, tool: Tool): boolean {
       sessionId,
       metadata.date,
       metadata.createdAt,
+      metadata.startedAt,
       summary.firstPrompt,
       metadata.customTitle,
       metadata.messageCount,
@@ -972,9 +981,42 @@ interface DateRangeRow {
   session_id: string;
   date: string;
   created_at: string;
+  started_at: string;
   first_prompt: string;
   custom_title: string;
   message_count: number;
+}
+
+/** The machine's IANA zone. Resolved per call: `Date#getHours` reads a zone V8 caches on
+ *  first use, which makes the process default untestable once anything has read a clock. */
+function systemTz(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+const hourFmtCache = new Map<string, Intl.DateTimeFormat>();
+
+/**
+ * The two-digit hour of an ISO timestamp in `tz`, or null when there is nothing to read.
+ *
+ * Formats against an explicit zone rather than calling `getHours()`, so the conversion
+ * depends on an argument instead of ambient process state. Deliberately not
+ * src/report/parsers/util.ts's localHour: that file is vendored verbatim from upstream
+ * and the report subtree stays self-contained. This one keys the activeHours histogram,
+ * so it returns the zero-padded string that map is indexed by.
+ */
+function hourIn(iso: string, tz: string): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  let fmt = hourFmtCache.get(tz);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-US', { timeZone: tz, hour: '2-digit', hour12: false });
+    hourFmtCache.set(tz, fmt);
+  }
+  const h = fmt.formatToParts(d).find((p) => p.type === 'hour')?.value;
+  if (h === undefined) return null;
+  // en-US renders midnight as '24' in some ICU builds; the histogram is 00-23.
+  return String(Number(h) % 24).padStart(2, '0');
 }
 
 function queryDateRange(
@@ -999,7 +1041,7 @@ function queryDateRange(
   const where = 'WHERE ' + conditions.join(' AND ');
   return db
     .query<DateRangeRow, any[]>(
-      `SELECT file_path, cwd, tool, session_id, date, created_at, first_prompt, custom_title, message_count
+      `SELECT file_path, cwd, tool, session_id, date, created_at, started_at, first_prompt, custom_title, message_count
        FROM sessions ${where}
        ORDER BY created_at ASC, date ASC`,
     )
@@ -1133,6 +1175,8 @@ export async function getSessionMetrics(
   endDate: string,
   toolFilter: Tool | '',
   project: string,
+  /** IANA zone for the active-hours histogram. Defaults to the machine's. */
+  tz: string = systemTz(),
 ): Promise<SessionMetrics> {
   const db = getDb();
   await ensureIndexFresh();
@@ -1159,18 +1203,12 @@ export async function getSessionMetrics(
     dm.sessions++;
     dm.messages += r.message_count;
     dailyMap.set(day, dm);
-  }
 
-  for (const r of rows) {
-    try {
-      const lines = readSessionLines(r.file_path, r.tool as Tool);
-      const d = JSON.parse(lines[0] ?? '{}');
-      const ts = d.timestamp as string | undefined;
-      if (ts && ts.includes('T')) {
-        const hour = ts.slice(11, 13);
-        activeHours[hour] = (activeHours[hour] ?? 0) + 1;
-      }
-    } catch {}
+    // Local, not UTC. Transcript timestamps are Z-normalized, and slicing the hour out
+    // of the ISO string read it as wall-clock — shifting the whole histogram by the
+    // machine's offset, so a US-Central user's 9am showed up as 2pm or 3pm.
+    const hour = hourIn(r.started_at, tz);
+    if (hour !== null) activeHours[hour] = (activeHours[hour] ?? 0) + 1;
   }
 
   const projectBreakdown = [...projectMap.entries()]

--- a/src/mcp-config.test.ts
+++ b/src/mcp-config.test.ts
@@ -1,0 +1,351 @@
+import { describe, test, expect, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Sandboxed home, set BEFORE import: nothing here may touch the real ~/.codex,
+// ~/.cursor, or ~/.pi — the whole point of these tests is a merge into a live
+// user-owned config, and the live one is the user's.
+const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), 'sessions-mcpcfg-')));
+process.env.SESSIONS_HOME = fixtureRoot;
+
+const {
+  detectClients,
+  wireJsonClient,
+  unwireJsonClient,
+  wireCodex,
+  unwireCodex,
+  mergeCodexConfig,
+  removeCodexConfig,
+  cleanDeadConfigs,
+} = await import('./mcp-config');
+
+const codexPath = join(fixtureRoot, '.codex', 'config.toml');
+const cursorPath = join(fixtureRoot, '.cursor', 'mcp.json');
+const piPath = join(fixtureRoot, '.pi', 'agent', 'mcp.json');
+const CMD = '/opt/homebrew/bin/sessions';
+
+afterAll(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const dir of ['.codex', '.cursor', '.pi', '.claude']) {
+    rmSync(join(fixtureRoot, dir), { recursive: true, force: true });
+  }
+});
+
+function writeFixture(path: string, content: string): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+}
+
+/** A config.toml shaped like the real one: settings, project tables, other servers. */
+const REAL_CONFIG = `approval_policy = "never"
+model = "gpt-5.6-sol"
+
+[projects."/Users/someone/Developer/thing"]
+trust_level = "trusted"
+
+[mcp_servers.node_repl]
+command = "/Applications/Codex.app/Contents/Resources/node_repl"
+startup_timeout_sec = 120.0
+
+[mcp_servers.node_repl.env]
+CODEX_HOME = "/Users/someone/.codex"
+
+[mcp_servers.workos]
+url = "https://mcp.workos.com/mcp"
+`;
+
+describe('detectClients', () => {
+  test('finds each client by the directory it actually owns', () => {
+    mkdirSync(join(fixtureRoot, '.codex'), { recursive: true });
+    mkdirSync(join(fixtureRoot, '.pi', 'agent'), { recursive: true });
+
+    const byId = Object.fromEntries(detectClients().map((c) => [c.id, c]));
+    expect(byId.codex!.detected).toBe(true);
+    expect(byId.pi!.detected).toBe(true);
+    expect(byId.cursor!.detected).toBe(false);
+
+    // The paths the clients read — not the `.mcp.json` dotfiles setup used to write.
+    expect(byId.codex!.configPath).toBe(codexPath);
+    expect(byId.cursor!.configPath).toBe(cursorPath);
+    expect(byId.pi!.configPath).toBe(piPath);
+    expect(byId.claude!.configPath).toBe(''); // wired through the plugin instead
+  });
+
+  test('no client is wired through a `<config-dir>/.mcp.json` dotfile', () => {
+    // The original bug stated as an invariant. Every write target was
+    // `<config-dir>/.mcp.json`, a filename no client in this list opens, and setup
+    // printed a checkmark for each one. A future client added with the same guess
+    // fails here rather than shipping a silent no-op.
+    for (const client of detectClients()) {
+      expect(client.configPath.endsWith('/.mcp.json')).toBe(false);
+    }
+  });
+});
+
+describe('codex config.toml merge', () => {
+  test('merges into an existing config with prior entries, preserving all of them', () => {
+    writeFixture(codexPath, REAL_CONFIG);
+    expect(wireCodex(codexPath, CMD).status).toBe('added');
+
+    const after = readFileSync(codexPath, 'utf-8');
+    expect(after).toContain('[mcp_servers.sessions]');
+    expect(after).toContain(`command = "${CMD}"`);
+    expect(after).toContain('args = ["--mcp"]');
+
+    // Every pre-existing line survives byte for byte.
+    for (const line of REAL_CONFIG.trimEnd().split('\n')) {
+      expect(after).toContain(line);
+    }
+  });
+
+  test('backs the file up before the first edit', () => {
+    writeFixture(codexPath, REAL_CONFIG);
+    wireCodex(codexPath, CMD);
+    expect(readFileSync(codexPath + '.sessions-bak', 'utf-8')).toBe(REAL_CONFIG);
+  });
+
+  test('is idempotent: a second run changes nothing', () => {
+    writeFixture(codexPath, REAL_CONFIG);
+    wireCodex(codexPath, CMD);
+    const first = readFileSync(codexPath, 'utf-8');
+
+    expect(wireCodex(codexPath, CMD).status).toBe('unchanged');
+    expect(readFileSync(codexPath, 'utf-8')).toBe(first);
+  });
+
+  test('updates a stale command in place without touching the user keys beside it', () => {
+    writeFixture(
+      codexPath,
+      `${REAL_CONFIG}
+[mcp_servers.sessions]
+command = "/old/path/sessions"
+args = ["--mcp"]
+startup_timeout_sec = 30.0
+
+[mcp_servers.sessions.env]
+SESSIONS_DEBUG = "1"
+`,
+    );
+    expect(wireCodex(codexPath, CMD).status).toBe('added');
+
+    const after = readFileSync(codexPath, 'utf-8');
+    expect(after).toContain(`command = "${CMD}"`);
+    expect(after).not.toContain('/old/path/sessions');
+    expect(after).toContain('startup_timeout_sec = 30.0'); // the user's, kept
+    expect(after).toContain('SESSIONS_DEBUG = "1"');
+  });
+
+  test('adds a missing args key to a half-written table', () => {
+    writeFixture(codexPath, `[mcp_servers.sessions]\ncommand = "${CMD}"\n`);
+    expect(wireCodex(codexPath, CMD).status).toBe('added');
+    expect(readFileSync(codexPath, 'utf-8')).toContain('args = ["--mcp"]');
+  });
+
+  test('creates the file when Codex has no config yet', () => {
+    mkdirSync(join(fixtureRoot, '.codex'), { recursive: true });
+    expect(wireCodex(codexPath, CMD).status).toBe('added');
+    expect(readFileSync(codexPath, 'utf-8')).toBe(`[mcp_servers.sessions]\ncommand = "${CMD}"\nargs = ["--mcp"]\n`);
+  });
+
+  test('quotes a command containing spaces and quotes', () => {
+    const odd = '/Applications/My "Tools"/sessions';
+    expect(mergeCodexConfig('', odd)).toMatchObject({
+      text: `[mcp_servers.sessions]\ncommand = "/Applications/My \\"Tools\\"/sessions"\nargs = ["--mcp"]\n`,
+    });
+  });
+
+  test('keeps a table whose name merely starts the same', () => {
+    writeFixture(codexPath, '[mcp_servers.sessions_other]\ncommand = "/bin/other"\n');
+    wireCodex(codexPath, CMD);
+
+    const after = readFileSync(codexPath, 'utf-8');
+    expect(after).toContain('[mcp_servers.sessions_other]');
+    expect(after).toContain('command = "/bin/other"');
+    expect(after).toContain('[mcp_servers.sessions]');
+  });
+});
+
+describe('codex config.toml refusals', () => {
+  // Each of these is a file we cannot edit by hand without risking corruption.
+  // The contract is that the file comes back untouched and the caller is told.
+  const malformed: [string, string][] = [
+    ['a multi-line string', 'notice = """\nhello\n[mcp_servers.sessions]\n"""\n'],
+    ['a multi-line array', 'notify = [\n  "one",\n  "two",\n]\n'],
+    ['mcp_servers as a dotted key', 'mcp_servers.sessions = { command = "/bin/x" }\n'],
+    ['mcp_servers as an inline table', 'mcp_servers = { sessions = { command = "/bin/x" } }\n'],
+    ['an unterminated table header', '[mcp_servers.sessions\ncommand = "/bin/x"\n'],
+    ['our table as an array of tables', '[[mcp_servers.sessions]]\ncommand = "/bin/x"\n'],
+  ];
+
+  for (const [label, content] of malformed) {
+    test(`refuses ${label} rather than corrupting it`, () => {
+      writeFixture(codexPath, content);
+      const result = wireCodex(codexPath, CMD);
+
+      expect(result.status).toBe('refused');
+      expect(result.reason).toBeTruthy();
+      expect(readFileSync(codexPath, 'utf-8')).toBe(content); // untouched
+      expect(existsSync(codexPath + '.sessions-bak')).toBe(false); // never even opened for writing
+    });
+  }
+
+  test('a refusal never writes a partial table', () => {
+    writeFixture(codexPath, 'notify = [\n  "one",\n]\n');
+    wireCodex(codexPath, CMD);
+    expect(readFileSync(codexPath, 'utf-8')).not.toContain('sessions');
+  });
+});
+
+describe('codex removal', () => {
+  test('removes our table and its sub-tables, keeping every other server', () => {
+    writeFixture(
+      codexPath,
+      `${REAL_CONFIG}
+[mcp_servers.sessions]
+command = "${CMD}"
+args = ["--mcp"]
+
+[mcp_servers.sessions.env]
+SESSIONS_DEBUG = "1"
+`,
+    );
+    expect(unwireCodex(codexPath).status).toBe('added');
+
+    const after = readFileSync(codexPath, 'utf-8');
+    expect(after).not.toContain('sessions');
+    expect(after).toContain('[mcp_servers.node_repl]');
+    expect(after).toContain('[mcp_servers.workos]');
+    expect(after).toContain('url = "https://mcp.workos.com/mcp"');
+  });
+
+  test('is a no-op when our table was never there', () => {
+    writeFixture(codexPath, REAL_CONFIG);
+    expect(unwireCodex(codexPath).status).toBe('unchanged');
+    expect(readFileSync(codexPath, 'utf-8')).toBe(REAL_CONFIG);
+  });
+
+  test('round-trips: merge then remove restores the original byte for byte', () => {
+    const merged = mergeCodexConfig(REAL_CONFIG, CMD);
+    const removed = removeCodexConfig((merged as { text: string }).text);
+    expect((removed as { text: string }).text).toBe(REAL_CONFIG);
+  });
+
+  test('leaves blank runs the user wrote elsewhere in the file alone', () => {
+    // Two blank lines before a later table: the user's formatting, not our seam.
+    const spaced = `model = "gpt-5.6-sol"\n\n\n[plugins."github"]\nenabled = true\n`;
+    const merged = mergeCodexConfig(spaced, CMD);
+    const removed = removeCodexConfig((merged as { text: string }).text);
+    expect((removed as { text: string }).text).toBe(spaced);
+  });
+});
+
+describe('json clients', () => {
+  test('merges into Cursor mcp.json, preserving the servers already there', () => {
+    writeFixture(
+      cursorPath,
+      JSON.stringify({ mcpServers: { workos: { url: 'https://mcp.workos.com/mcp' } } }, null, 2),
+    );
+    expect(wireJsonClient(cursorPath, 'cursor', CMD).status).toBe('added');
+
+    const after = JSON.parse(readFileSync(cursorPath, 'utf-8'));
+    expect(after.mcpServers.workos).toEqual({ url: 'https://mcp.workos.com/mcp' });
+    expect(after.mcpServers.sessions).toEqual({ command: CMD, args: ['--mcp'] });
+  });
+
+  test('gives Pi the stdio type its schema expects, and keeps its other keys', () => {
+    writeFixture(piPath, JSON.stringify({ discoveryMode: 'auto', importConfigs: ['~/.claude.json'], mcpServers: {} }));
+    expect(wireJsonClient(piPath, 'pi', CMD).status).toBe('added');
+
+    const after = JSON.parse(readFileSync(piPath, 'utf-8'));
+    expect(after.mcpServers.sessions).toEqual({ type: 'stdio', command: CMD, args: ['--mcp'] });
+    expect(after.discoveryMode).toBe('auto');
+    expect(after.importConfigs).toEqual(['~/.claude.json']);
+  });
+
+  test('is idempotent', () => {
+    writeFixture(cursorPath, '{}\n');
+    wireJsonClient(cursorPath, 'cursor', CMD);
+    const first = readFileSync(cursorPath, 'utf-8');
+
+    expect(wireJsonClient(cursorPath, 'cursor', CMD).status).toBe('unchanged');
+    expect(readFileSync(cursorPath, 'utf-8')).toBe(first);
+  });
+
+  test('refuses malformed JSON rather than replacing it', () => {
+    const broken = '{ "mcpServers": { oops\n';
+    writeFixture(cursorPath, broken);
+
+    const result = wireJsonClient(cursorPath, 'cursor', CMD);
+    expect(result.status).toBe('refused');
+    expect(readFileSync(cursorPath, 'utf-8')).toBe(broken);
+  });
+
+  test('refuses a config whose mcpServers is the wrong shape', () => {
+    writeFixture(cursorPath, JSON.stringify({ mcpServers: [] }));
+    expect(wireJsonClient(cursorPath, 'cursor', CMD).status).toBe('refused');
+  });
+
+  test('a re-run keeps keys the user added to our entry', () => {
+    writeFixture(
+      piPath,
+      JSON.stringify({
+        mcpServers: { sessions: { type: 'stdio', command: '/old/dev/build', args: ['--mcp'], cwd: '/work/sessions' } },
+      }),
+    );
+    expect(wireJsonClient(piPath, 'pi', CMD).status).toBe('added');
+
+    const after = JSON.parse(readFileSync(piPath, 'utf-8'));
+    expect(after.mcpServers.sessions.command).toBe(CMD); // stale path updated
+    expect(after.mcpServers.sessions.cwd).toBe('/work/sessions'); // the user's, kept
+  });
+
+  test('removal takes only our server', () => {
+    writeFixture(cursorPath, JSON.stringify({ mcpServers: { workos: { url: 'x' }, sessions: { command: CMD } } }));
+    expect(unwireJsonClient(cursorPath).status).toBe('added');
+
+    const after = JSON.parse(readFileSync(cursorPath, 'utf-8'));
+    expect(after.mcpServers.sessions).toBeUndefined();
+    expect(after.mcpServers.workos).toEqual({ url: 'x' });
+  });
+});
+
+describe('cleanDeadConfigs', () => {
+  const ours = JSON.stringify({ mcpServers: { sessions: { command: CMD, args: ['--mcp'] } } }, null, 2) + '\n';
+
+  test('removes the dotfiles older setups wrote that no client reads', () => {
+    writeFixture(join(fixtureRoot, '.codex', '.mcp.json'), ours);
+    writeFixture(join(fixtureRoot, '.cursor', '.mcp.json'), ours);
+    writeFixture(join(fixtureRoot, '.claude', '.mcp.json'), ours);
+
+    const removed = cleanDeadConfigs();
+    expect(removed).toHaveLength(3);
+    expect(existsSync(join(fixtureRoot, '.codex', '.mcp.json'))).toBe(false);
+    expect(existsSync(join(fixtureRoot, '.cursor', '.mcp.json'))).toBe(false);
+  });
+
+  test('leaves a file the user made their own, even at our path', () => {
+    const theirs = JSON.stringify({ mcpServers: { sessions: { command: CMD }, other: { command: '/bin/x' } } });
+    writeFixture(join(fixtureRoot, '.cursor', '.mcp.json'), theirs);
+
+    expect(cleanDeadConfigs()).toEqual([]);
+    expect(readFileSync(join(fixtureRoot, '.cursor', '.mcp.json'), 'utf-8')).toBe(theirs);
+  });
+
+  test('leaves a file with keys beyond mcpServers alone', () => {
+    const theirs = JSON.stringify({ mcpServers: { sessions: { command: CMD } }, inputs: [] });
+    writeFixture(join(fixtureRoot, '.codex', '.mcp.json'), theirs);
+    expect(cleanDeadConfigs()).toEqual([]);
+  });
+
+  test('never touches the real config files', () => {
+    // The paths cleaned are resolved from SESSIONS_HOME, not the real home.
+    writeFixture(join(fixtureRoot, '.codex', '.mcp.json'), ours);
+    for (const path of cleanDeadConfigs()) {
+      expect(path.startsWith(fixtureRoot)).toBe(true);
+    }
+  });
+});

--- a/src/mcp-config.ts
+++ b/src/mcp-config.ts
@@ -1,0 +1,451 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getHome } from './paths';
+
+// Where each client actually reads its MCP server list. Earlier versions of setup
+// guessed `<config-dir>/.mcp.json` for all of them and reported success either
+// way; every one of those guesses but Claude Code's plugin was a file no client
+// ever opens. Paths here are the ones confirmed against a real install.
+
+export type ClientId = 'claude' | 'cursor' | 'codex' | 'pi';
+
+export interface McpClient {
+  id: ClientId;
+  name: string;
+  detected: boolean;
+  /**
+   * The file the client reads. Empty for Claude Code: its MCP server arrives with
+   * the plugin, so setup has no config file of its own to own there.
+   */
+  configPath: string;
+}
+
+/** What a wiring attempt actually did. Setup reports these rather than assuming. */
+export type WireStatus = 'added' | 'unchanged' | 'refused' | 'failed';
+
+export interface WireResult {
+  status: WireStatus;
+  /** Why it was refused or failed. Always shown — a refusal the user can't see is a lie. */
+  reason?: string;
+}
+
+const ARGS = ['--mcp'];
+
+export function detectClients(): McpClient[] {
+  const home = getHome();
+  return [
+    {
+      id: 'claude',
+      name: 'Claude Code',
+      detected: existsSync(join(home, '.claude')),
+      configPath: '',
+    },
+    {
+      id: 'cursor',
+      name: 'Cursor',
+      detected: existsSync(join(home, '.cursor')),
+      configPath: join(home, '.cursor', 'mcp.json'),
+    },
+    {
+      id: 'codex',
+      name: 'Codex',
+      detected: existsSync(join(home, '.codex')),
+      configPath: join(home, '.codex', 'config.toml'),
+    },
+    {
+      id: 'pi',
+      name: 'Pi',
+      detected: existsSync(join(home, '.pi', 'agent')),
+      configPath: join(home, '.pi', 'agent', 'mcp.json'),
+    },
+  ];
+}
+
+/** The server entry each client expects. Pi's schema wants an explicit transport. */
+function serverEntry(id: ClientId, command: string): Record<string, unknown> {
+  if (id === 'pi') return { type: 'stdio', command, args: ARGS };
+  return { command, args: ARGS };
+}
+
+// ---- JSON clients (Cursor, Pi) ----
+
+/**
+ * Merge our server into a client's JSON config, preserving every other server.
+ * Refuses on anything it can't merge without guessing, so a hand-edited config is
+ * never replaced by ours.
+ */
+export function wireJsonClient(path: string, id: ClientId, command: string): WireResult {
+  let config: Record<string, unknown> = {};
+
+  if (existsSync(path)) {
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf-8');
+    } catch (err) {
+      return { status: 'failed', reason: `could not read it: ${String(err)}` };
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return { status: 'refused', reason: 'it is not a JSON object' };
+      }
+      config = parsed as Record<string, unknown>;
+    } catch {
+      return { status: 'refused', reason: 'it is not valid JSON' };
+    }
+  }
+
+  const existing = config.mcpServers;
+  if (existing !== undefined && (typeof existing !== 'object' || existing === null || Array.isArray(existing))) {
+    return { status: 'refused', reason: 'its `mcpServers` is not an object' };
+  }
+
+  const servers = (existing ?? {}) as Record<string, unknown>;
+  const current = servers.sessions;
+  // Update the keys we own and keep the rest, the same way the Codex merge does:
+  // a `cwd` or `env` the user added is theirs, and a re-run must not eat it.
+  const previous = typeof current === 'object' && current !== null && !Array.isArray(current) ? current : {};
+  const entry = { ...previous, ...serverEntry(id, command) };
+  if (JSON.stringify(current) === JSON.stringify(entry)) return { status: 'unchanged' };
+
+  servers.sessions = entry;
+  config.mcpServers = servers;
+
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+  } catch (err) {
+    return { status: 'failed', reason: `could not write it: ${String(err)}` };
+  }
+  return { status: 'added' };
+}
+
+/** Drop our server from a JSON config, leaving the user's other servers alone. */
+export function unwireJsonClient(path: string): WireResult {
+  if (!existsSync(path)) return { status: 'unchanged' };
+  let config: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { status: 'refused', reason: 'it is not a JSON object' };
+    }
+    config = parsed as Record<string, unknown>;
+  } catch {
+    return { status: 'refused', reason: 'it is not valid JSON' };
+  }
+
+  const servers = config.mcpServers;
+  if (typeof servers !== 'object' || servers === null || Array.isArray(servers)) return { status: 'unchanged' };
+  const map = servers as Record<string, unknown>;
+  if (!('sessions' in map)) return { status: 'unchanged' };
+
+  delete map.sessions;
+  try {
+    writeFileSync(path, JSON.stringify(config, null, 2) + '\n');
+  } catch (err) {
+    return { status: 'failed', reason: `could not write it: ${String(err)}` };
+  }
+  return { status: 'added' };
+}
+
+// ---- Codex (TOML) ----
+
+// Codex reads `[mcp_servers.<name>]` tables out of ~/.codex/config.toml, a file
+// the user owns and that already holds their model, sandbox, and per-project
+// trust settings. Runtime deps stay at two, so there is no TOML library here:
+// the merge below edits only its own table, line by line, and refuses outright
+// on any shape it cannot edit safely. A wrong merge corrupts real user config,
+// so every ambiguity resolves to a refusal plus copy-paste instructions.
+
+const CODEX_TABLE = 'mcp_servers.sessions';
+const BACKUP_SUFFIX = '.sessions-bak';
+
+interface TomlHeader {
+  line: number;
+  parts: string[];
+  array: boolean;
+}
+
+/** Serialize a TOML basic string. Paths can hold spaces, quotes, or backslashes. */
+function tomlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Parse a table header into its dotted key parts. Returns null when the line is
+ * not a header, or is one we can't read — callers treat null on a `[`-leading
+ * line as a reason to refuse rather than to guess.
+ */
+function parseHeader(line: string): TomlHeader | null {
+  const s = line.trim();
+  if (!s.startsWith('[')) return null;
+  const array = s.startsWith('[[');
+  const parts: string[] = [];
+  let cur = '';
+  let quoted = false;
+  let quote: string | null = null;
+
+  for (let i = array ? 2 : 1; i < s.length; i++) {
+    const ch = s[i]!;
+    if (quote) {
+      if (ch === '\\' && quote === '"') {
+        cur += s[++i] ?? '';
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      cur += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      quoted = true;
+      continue;
+    }
+    if (ch === '.') {
+      parts.push(quoted ? cur : cur.trim());
+      cur = '';
+      quoted = false;
+      continue;
+    }
+    if (ch === ']') {
+      parts.push(quoted ? cur : cur.trim());
+      return { line: 0, parts, array };
+    }
+    cur += ch;
+  }
+  return null; // unterminated header
+}
+
+/**
+ * Shapes that defeat line-by-line editing. Refusing on these is what keeps the
+ * merge honest: inside a multi-line string or array, a line starting with `[`
+ * is content, not a table header, and mistaking the two rewrites the wrong span.
+ */
+function unsupportedShape(source: string, lines: string[]): string | null {
+  if (/"""|'''/.test(source)) return 'it contains a multi-line string';
+  for (const line of lines) {
+    // An assignment whose array opens but does not close on the same line.
+    if (/=\s*\[[^\]]*$/.test(line.split('#')[0] ?? '')) return 'it contains a multi-line array';
+    // `mcp_servers` as a dotted key or inline table, which our table would duplicate.
+    if (/^\s*mcp_servers\s*[.=]/.test(line)) return 'it defines `mcp_servers` as a key rather than a table';
+  }
+  return null;
+}
+
+/** Collect every table header, or the line number of one we could not parse. */
+function collectHeaders(lines: string[]): { headers: TomlHeader[] } | { badLine: number } {
+  const headers: TomlHeader[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!line.trim().startsWith('[')) continue;
+    const parsed = parseHeader(line);
+    if (!parsed) return { badLine: i + 1 };
+    headers.push({ ...parsed, line: i });
+  }
+  return { headers };
+}
+
+function isOurTable(h: TomlHeader): boolean {
+  return h.parts.length === 2 && h.parts[0] === 'mcp_servers' && h.parts[1] === 'sessions';
+}
+
+/** True for `[mcp_servers.sessions.env]` and friends — part of our table's block. */
+function isOurChild(h: TomlHeader): boolean {
+  return h.parts.length > 2 && h.parts[0] === 'mcp_servers' && h.parts[1] === 'sessions';
+}
+
+export type TomlMerge = { text: string; changed: boolean } | { refused: string };
+
+/**
+ * Add or update `[mcp_servers.sessions]` in a Codex config, preserving the rest
+ * of the file byte for byte. Only `command` and `args` are written: any other key
+ * in the table (a tuned `startup_timeout_sec`, an `env` sub-table, a comment) is
+ * the user's and survives a re-run.
+ */
+export function mergeCodexConfig(source: string, command: string): TomlMerge {
+  const lines = source.split('\n');
+
+  const unsupported = unsupportedShape(source, lines);
+  if (unsupported) return { refused: unsupported };
+
+  const collected = collectHeaders(lines);
+  if ('badLine' in collected) return { refused: `line ${collected.badLine} is not a table header we can read` };
+  const { headers } = collected;
+
+  const ours = headers.find(isOurTable);
+  if (headers.some((h) => h.array && (isOurTable(h) || isOurChild(h)))) {
+    return { refused: '`mcp_servers.sessions` is an array of tables' };
+  }
+
+  const desiredCommand = `command = ${tomlString(command)}`;
+  const desiredArgs = `args = [${ARGS.map(tomlString).join(', ')}]`;
+
+  if (!ours) {
+    // A new table at end of file is always valid: nothing can swallow it.
+    const body = source.replace(/\s*$/, '');
+    const text = `${body ? body + '\n\n' : ''}[${CODEX_TABLE}]\n${desiredCommand}\n${desiredArgs}\n`;
+    return { text, changed: true };
+  }
+
+  // The table's own keys run to the next header of any kind; child tables keep theirs.
+  const start = ours.line + 1;
+  const end = headers.find((h) => h.line > ours.line)?.line ?? lines.length;
+  const block = lines.slice(start, end);
+
+  const isCommand = (l: string) => /^\s*command\s*=/.test(l);
+  const isArgs = (l: string) => /^\s*args\s*=/.test(l);
+  let changed = false;
+
+  const cmdAt = block.findIndex(isCommand);
+  if (cmdAt >= 0) {
+    if (block[cmdAt]!.trim() !== desiredCommand) {
+      block[cmdAt] = desiredCommand;
+      changed = true;
+    }
+  } else {
+    block.unshift(desiredCommand);
+    changed = true;
+  }
+
+  const argsAt = block.findIndex(isArgs);
+  if (argsAt >= 0) {
+    if (block[argsAt]!.trim() !== desiredArgs) {
+      block[argsAt] = desiredArgs;
+      changed = true;
+    }
+  } else {
+    block.splice(block.findIndex(isCommand) + 1, 0, desiredArgs);
+    changed = true;
+  }
+
+  if (!changed) return { text: source, changed: false };
+  return { text: [...lines.slice(0, start), ...block, ...lines.slice(end)].join('\n'), changed: true };
+}
+
+/** Remove our table and its sub-tables, leaving every other table untouched. */
+export function removeCodexConfig(source: string): TomlMerge {
+  const lines = source.split('\n');
+
+  const unsupported = unsupportedShape(source, lines);
+  if (unsupported) return { refused: unsupported };
+
+  const collected = collectHeaders(lines);
+  if ('badLine' in collected) return { refused: `line ${collected.badLine} is not a table header we can read` };
+  const { headers } = collected;
+
+  const ours = headers.find(isOurTable);
+  if (!ours) return { text: source, changed: false };
+
+  const next = headers.find((h) => h.line > ours.line && !isOurChild(h));
+  const end = next?.line ?? lines.length;
+  const kept = [...lines.slice(0, ours.line), ...lines.slice(end)];
+
+  // Close the gap only at the seam. A blank run anywhere else in the file is the
+  // user's formatting, and collapsing it would edit lines we never owned.
+  const seam = ours.line;
+  while (seam > 0 && kept[seam - 1] === '' && kept[seam] === '') kept.splice(seam, 1);
+  while (kept.length > 1 && kept.at(-1) === '' && kept.at(-2) === '') kept.pop();
+
+  return { text: kept.join('\n'), changed: true };
+}
+
+/** Copy the file aside once, before the first edit we ever make to it. */
+function backupOnce(path: string): void {
+  const backup = path + BACKUP_SUFFIX;
+  if (existsSync(path) && !existsSync(backup)) copyFileSync(path, backup);
+}
+
+export function wireCodex(path: string, command: string): WireResult {
+  let source = '';
+  if (existsSync(path)) {
+    try {
+      source = readFileSync(path, 'utf-8');
+    } catch (err) {
+      return { status: 'failed', reason: `could not read it: ${String(err)}` };
+    }
+  }
+
+  const merged = mergeCodexConfig(source, command);
+  if ('refused' in merged) return { status: 'refused', reason: merged.refused };
+  if (!merged.changed) return { status: 'unchanged' };
+
+  try {
+    backupOnce(path);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, merged.text);
+  } catch (err) {
+    return { status: 'failed', reason: `could not write it: ${String(err)}` };
+  }
+  return { status: 'added' };
+}
+
+export function unwireCodex(path: string): WireResult {
+  if (!existsSync(path)) return { status: 'unchanged' };
+  let source: string;
+  try {
+    source = readFileSync(path, 'utf-8');
+  } catch (err) {
+    return { status: 'failed', reason: `could not read it: ${String(err)}` };
+  }
+
+  const removed = removeCodexConfig(source);
+  if ('refused' in removed) return { status: 'refused', reason: removed.refused };
+  if (!removed.changed) return { status: 'unchanged' };
+
+  try {
+    backupOnce(path);
+    writeFileSync(path, removed.text);
+  } catch (err) {
+    return { status: 'failed', reason: `could not write it: ${String(err)}` };
+  }
+  return { status: 'added' };
+}
+
+/** The block to paste when we refuse to edit the file ourselves. */
+export function codexManualBlock(command: string): string {
+  return `[${CODEX_TABLE}]\ncommand = ${tomlString(command)}\nargs = [${ARGS.map(tomlString).join(', ')}]`;
+}
+
+// ---- dead files from earlier setups ----
+
+/**
+ * `<config-dir>/.mcp.json` files older versions of setup wrote and no client
+ * reads. Removed only when the content is exactly what we generated — a lone
+ * `sessions` server and nothing else — so a file the user made their own stays.
+ */
+function deadConfigPaths(): string[] {
+  const home = getHome();
+  return [join(home, '.claude', '.mcp.json'), join(home, '.cursor', '.mcp.json'), join(home, '.codex', '.mcp.json')];
+}
+
+function isOurDeadFile(raw: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return false;
+    const keys = Object.keys(parsed);
+    if (keys.length !== 1 || keys[0] !== 'mcpServers') return false;
+    const servers = (parsed as { mcpServers: unknown }).mcpServers;
+    if (typeof servers !== 'object' || servers === null || Array.isArray(servers)) return false;
+    const names = Object.keys(servers);
+    return names.length === 1 && names[0] === 'sessions';
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the paths actually removed, for setup to report. */
+export function cleanDeadConfigs(): string[] {
+  const removed: string[] = [];
+  for (const path of deadConfigPaths()) {
+    try {
+      if (!existsSync(path)) continue;
+      if (!isOurDeadFile(readFileSync(path, 'utf-8'))) continue;
+      rmSync(path);
+      removed.push(path);
+    } catch {}
+  }
+  return removed;
+}

--- a/src/parser.corpus.test.ts
+++ b/src/parser.corpus.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Invariants asserted against the real transcripts on THIS machine.
+ *
+ * Env-gated because it reads ~/.codex/sessions and ~/.claude/projects, which CI does not
+ * have and which differ per developer. Run it with:
+ *
+ *     SESSIONS_LIVE_CORPUS=1 bun test src/parser.corpus.test.ts
+ *
+ * Why this exists rather than fixture tests alone: the Codex extraction bug was invisible
+ * to fixtures for two years because parser.test.ts asserted a hand-written shape that
+ * occurs zero times in real Codex logs, while the sibling extract-files/extract-commands
+ * dispatchers DID understand the real envelope and kept populating files and commands.
+ * Every unit test passed and every rollout still extracted to zero messages. Only reading
+ * the actual corpus catches that class, so this asserts against it directly.
+ *
+ * The one-time main-vs-branch differential is deliberately NOT here: it compared two
+ * checkouts of the same function and stops being expressible once the fix is merged. It
+ * was run out-of-band over 9,112 Claude and 166 pi transcripts (108,545 and 1,542
+ * messages) and found byte-identical output; what remains checkable in-repo is that the
+ * non-Codex paths still produce messages at all, which `no harness extracts to zero`
+ * below covers.
+ */
+import { describe, test, expect } from 'bun:test';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { Glob } from 'bun';
+import { extractMessages } from './parser';
+
+const ENABLED = process.env.SESSIONS_LIVE_CORPUS === '1';
+const describeCorpus = ENABLED ? describe : describe.skip;
+
+/** Real roots, not the SESSIONS_* test redirections — the point is the actual corpus. */
+const CODEX_ROOT = join(homedir(), '.codex', 'sessions');
+const CLAUDE_ROOT = join(homedir(), '.claude', 'projects');
+
+// Kept in sync with the copy in parser.ts by the assertion below, which fails if a
+// non-genuine turn appears that this pattern cannot explain.
+const CODEX_INJECTED =
+  /^(<environment_context|<user_action|<turn_aborted|<recommended_plugins|<image\b|<skill\b|<user_shell_command|# AGENTS\.md instructions for |Warning: )/;
+
+async function* transcripts(root: string, pattern: string, cap: number): AsyncGenerator<string[]> {
+  if (!existsSync(root)) return;
+  let n = 0;
+  for await (const p of new Glob(pattern).scan({ cwd: root, absolute: true })) {
+    if (n++ >= cap) return;
+    yield (await Bun.file(p).text()).split('\n').filter((l) => l.trim());
+  }
+}
+
+describeCorpus('live corpus', () => {
+  test('every substantive Codex rollout extracts messages', async () => {
+    let files = 0;
+    let substantive = 0;
+    let extracted = 0;
+    for await (const lines of transcripts(CODEX_ROOT, '**/rollout-*.jsonl', 5000)) {
+      files++;
+      // "Substantive" = carries at least one model-facing message record. A rollout that
+      // was opened and abandoned holds only session_meta and legitimately yields nothing.
+      const hasMessage = lines.some((l) => {
+        try {
+          const d = JSON.parse(l);
+          return d?.type === 'response_item' && d?.payload?.type === 'message';
+        } catch {
+          return false;
+        }
+      });
+      if (!hasMessage) continue;
+      substantive++;
+      if (extractMessages(lines).length > 0) extracted++;
+    }
+    if (files === 0) return; // no Codex corpus on this machine
+    expect(substantive).toBeGreaterThan(0);
+    expect(extracted).toBe(substantive);
+  });
+
+  test('Codex non-genuine turns are all explained by the injection prefixes', async () => {
+    // The event_msg join and the prefix regex are independent signals. On the corpus they
+    // agree exactly; a turn marked non-genuine that no prefix explains means the join has
+    // started mis-firing (a whitespace-normalization drift between the two streams would
+    // look like this), which is the failure mode that silently blanks first_prompt.
+    const unexplained: string[] = [];
+    for await (const lines of transcripts(CODEX_ROOT, '**/rollout-*.jsonl', 5000)) {
+      for (const m of extractMessages(lines)) {
+        if (m.role !== 'user' || m.genuine) continue;
+        if (!CODEX_INJECTED.test(m.text.trim())) unexplained.push(m.text.slice(0, 80));
+      }
+    }
+    expect(unexplained).toEqual([]);
+  });
+
+  test('numbering stays dense on every real transcript', async () => {
+    // array[i].index === i is what get_session_messages pagination and message_fts hit
+    // offsets both rely on. A harness-specific branch that emits out of order breaks
+    // search-result deep-linking without breaking any single-message assertion.
+    const roots: [string, string][] = [
+      [CODEX_ROOT, '**/rollout-*.jsonl'],
+      [CLAUDE_ROOT, '**/*.jsonl'],
+    ];
+    for (const [root, pattern] of roots) {
+      for await (const lines of transcripts(root, pattern, 1500)) {
+        const msgs = extractMessages(lines);
+        expect(msgs.map((m) => m.index)).toEqual(msgs.map((_, i) => i));
+      }
+    }
+  });
+
+  test('no harness extracts to zero across its whole corpus', async () => {
+    // The bug this file exists for, stated generally: a harness whose every transcript
+    // yields nothing is a dispatch gap, never real data.
+    for (const [label, root, pattern] of [
+      ['codex', CODEX_ROOT, '**/rollout-*.jsonl'],
+      ['claude', CLAUDE_ROOT, '**/*.jsonl'],
+    ] as const) {
+      let files = 0;
+      let total = 0;
+      for await (const lines of transcripts(root, pattern, 800)) {
+        files++;
+        total += extractMessages(lines).length;
+      }
+      if (files === 0) continue;
+      expect({ label, zero: total === 0 }).toEqual({ label, zero: false });
+    }
+  });
+});

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -46,9 +46,27 @@ describe('extractSessionMetadata', () => {
       customTitle: customTitle(lines),
       date: lastTimestamp(lines),
       createdAt: firstTimestamp(lines),
+      // No standalone helper to compare against: startedAt is the same instant as
+      // createdAt with the time kept, and only this one-pass extractor produces it.
+      startedAt: '2026-03-15T10:00:00Z',
       messageCount: messageCount(lines),
       branch: sessionBranch(lines, 'claude'),
     });
+  });
+
+  test('startedAt keeps the clock createdAt truncates away', () => {
+    const lines = jsonl(
+      { type: 'user', cwd: '/repo', timestamp: '2026-06-02T21:47:13.500Z', message: { content: 'late night' } },
+      { type: 'assistant', cwd: '/repo', timestamp: '2026-06-03T01:02:03Z', message: { content: 'yes' } },
+    );
+    const meta = extractSessionMetadata(lines, 'claude');
+    expect(meta.createdAt).toBe('2026-06-02');
+    expect(meta.startedAt).toBe('2026-06-02T21:47:13.500Z');
+  });
+
+  test('startedAt is empty when no line carries a timestamp', () => {
+    const lines = jsonl({ type: 'user', cwd: '/repo', message: { content: 'undated' } });
+    expect(extractSessionMetadata(lines, 'claude').startedAt).toBe('');
   });
 
   test('extracts Codex cwd and starting branch from session_meta', () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -673,3 +673,133 @@ describe('tool-call extraction (include_tools support)', () => {
     expect(t.summary.length).toBe(121); // 120 chars + ellipsis
   });
 });
+
+// Every shape below is copied from real ~/.codex/sessions rollouts. The dispatch these
+// exercise did not exist before: Codex nests messages under a `response_item` envelope,
+// so all 305 rollouts on a real machine extracted to zero messages. The pre-existing
+// `{type:'message', message:{…}}` tests elsewhere in this file are the PI shape, which
+// occurs zero times in real Codex logs — hence the duplicate coverage rather than edits
+// to those.
+describe('extractMessages: Codex', () => {
+  /** A Codex rollout head. Present on line 1 of all 305 real rollouts. */
+  const meta = { type: 'session_meta', payload: { cwd: '/repo', git: { branch: 'main' } } };
+  const userItem = (text: string) => ({
+    type: 'response_item',
+    payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] },
+  });
+  const assistantItem = (text: string) => ({
+    type: 'response_item',
+    payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] },
+  });
+  /** The UI-log echo of what the human actually typed — Codex's genuineness oracle. */
+  const typedEvent = (message: string) => ({ type: 'event_msg', payload: { type: 'user_message', message } });
+
+  test('extracts user and assistant turns from the response_item envelope', () => {
+    const lines = jsonl(meta, typedEvent('add a test'), userItem('add a test'), assistantItem('Done.'));
+    const msgs = extractMessages(lines);
+    expect(msgs.map((m) => [m.role, m.text])).toEqual([
+      ['user', 'add a test'],
+      ['assistant', 'Done.'],
+    ]);
+    expect(msgs.map((m) => m.index)).toEqual([0, 1]);
+  });
+
+  test('a user turn with a user_message twin is genuine; one without is not', () => {
+    const lines = jsonl(meta, typedEvent('the real ask'), userItem('the real ask'), userItem('<user_action> tabbed'));
+    expect(extractMessages(lines).map((m) => [m.text, m.genuine])).toEqual([
+      ['the real ask', true],
+      ['<user_action> tabbed', false],
+    ]);
+  });
+
+  test('the user_message event may arrive after its twin (the join needs two passes)', () => {
+    // Ordering observed in the real corpus: the UI event usually trails the model-facing
+    // record, so a single forward pass would classify the turn before its oracle exists.
+    const lines = jsonl(meta, userItem('ship it'), typedEvent('ship it'), assistantItem('ok'));
+    expect(extractMessages(lines)[0]).toMatchObject({ text: 'ship it', genuine: true });
+  });
+
+  test('falls back to injection prefixes when the two streams never join', () => {
+    // No user_message events at all — 26 of 305 real rollouts look like this. Without the
+    // guard every turn would flip to genuine:false and first_prompt would go blank again.
+    const lines = jsonl(meta, userItem('<environment_context> cwd=/repo'), userItem('what changed?'));
+    expect(extractMessages(lines).map((m) => [m.text, m.genuine])).toEqual([
+      ['<environment_context> cwd=/repo', false],
+      ['what changed?', true],
+    ]);
+  });
+
+  test('developer-role messages are injected framing, not turns', () => {
+    const lines = jsonl(meta, {
+      type: 'response_item',
+      payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text: '# AGENTS.md' }] },
+    });
+    expect(extractMessages(lines)).toEqual([]);
+  });
+
+  test('assistant text is read once, not doubled by its event_msg twin', () => {
+    // response_item and event_msg overlap: every assistant text is duplicated in the UI
+    // log. Reading both would double every Codex turn in message_fts.
+    const lines = jsonl(meta, assistantItem('the answer'), {
+      type: 'event_msg',
+      payload: { type: 'agent_message', message: 'the answer' },
+    });
+    expect(extractMessages(lines).map((m) => m.text)).toEqual(['the answer']);
+  });
+
+  test('tool calls fold into the turn head and keep numbering dense', () => {
+    const lines = jsonl(
+      meta,
+      typedEvent('fix it'),
+      userItem('fix it'),
+      assistantItem('Looking.'),
+      {
+        type: 'response_item',
+        payload: { type: 'function_call', name: 'shell', call_id: 'c1', arguments: '{"command":"bun test"}' },
+      },
+      { type: 'response_item', payload: { type: 'custom_tool_call', name: 'apply_patch', input: '*** Begin Patch' } },
+    );
+    const msgs = extractMessages(lines);
+    expect(msgs.map((m) => m.index)).toEqual([0, 1]);
+    expect(msgs[1]!.tools).toEqual([
+      { name: 'shell', summary: 'bun test' },
+      { name: 'apply_patch', summary: '*** Begin Patch' },
+    ]);
+  });
+
+  test('a tool call before any message buffers onto the first turn emitted', () => {
+    const lines = jsonl(
+      meta,
+      { type: 'response_item', payload: { type: 'function_call', name: 'shell', arguments: '{"command":"ls"}' } },
+      typedEvent('what is here?'),
+      userItem('what is here?'),
+    );
+    const msgs = extractMessages(lines);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.tools).toEqual([{ name: 'shell', summary: 'ls' }]);
+  });
+
+  test('getSessionMessages numbering agrees with extractMessages on Codex', () => {
+    const lines = jsonl(meta, typedEvent('a'), userItem('a'), assistantItem('b'), assistantItem('c'));
+    expect(getSessionMessages(lines).map((m) => m.index)).toEqual(extractMessages(lines).map((m) => m.index));
+  });
+
+  test('an abandoned rollout (session_meta only) yields no messages', () => {
+    // 14 of 305 real rollouts are exactly this: opened, never used.
+    expect(extractMessages(jsonl(meta))).toEqual([]);
+  });
+
+  test('the sniff reads parsed types, so Claude prose about response_item is unaffected', () => {
+    // This repo's own transcripts discuss the Codex envelope. Detecting on a raw substring
+    // would reroute them into the Codex path and silently blank them.
+    const lines = jsonl(
+      {
+        type: 'user',
+        promptSource: 'typed',
+        message: { content: [{ type: 'text', text: 'why does {"type":"response_item"} parse to nothing?' }] },
+      },
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'session_meta is the tell.' }] } },
+    );
+    expect(extractMessages(lines).map((m) => m.role)).toEqual(['user', 'assistant']);
+  });
+});

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -69,6 +69,53 @@ describe('extractSessionMetadata', () => {
     expect(extractSessionMetadata(lines, 'claude').startedAt).toBe('');
   });
 
+  test('counts Codex response_item messages, excluding developer framing', () => {
+    // The counting loop had the same envelope gap extractMessages did, so every Codex
+    // row indexed with message_count 0 even after its messages became extractable.
+    const lines = jsonl(
+      { type: 'session_meta', timestamp: '2026-04-01T09:00:00Z', payload: { cwd: '/repo' } },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text: '# AGENTS.md' }] },
+      },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] },
+      },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] },
+      },
+      { type: 'response_item', payload: { type: 'function_call', name: 'shell', arguments: '{}' } },
+      { type: 'event_msg', payload: { type: 'agent_message', message: 'done' } },
+    );
+    // Two: the user turn and the assistant turn. Not the developer line, not the tool
+    // call, and not the event_msg echo of the assistant text.
+    expect(extractSessionMetadata(lines, 'codex').messageCount).toBe(2);
+  });
+
+  test('Codex message_count agrees with the number of extracted messages', () => {
+    // These are separate loops over the same lines and they drifted apart before. For
+    // Codex they should now report the same figure on the same input.
+    const lines = jsonl(
+      { type: 'session_meta', timestamp: '2026-04-01T09:00:00Z', payload: { cwd: '/repo' } },
+      { type: 'event_msg', payload: { type: 'user_message', message: 'first' } },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'first' }] },
+      },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'a' }] },
+      },
+      {
+        type: 'response_item',
+        payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'b' }] },
+      },
+    );
+    expect(extractSessionMetadata(lines, 'codex').messageCount).toBe(extractMessages(lines).length);
+  });
+
   test('extracts Codex cwd and starting branch from session_meta', () => {
     const lines = jsonl(
       {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -90,6 +90,13 @@ export function extractSessionMetadata(lines: string[], tool: Tool): SessionMeta
     } else if (d.type === 'message') {
       const msg = d.message;
       if (typeof msg === 'object' && msg !== null && (msg as Record<string, unknown>).role === 'assistant') count++;
+    } else if (d.type === 'response_item') {
+      // The same envelope gap extractMessages had, in the counting loop. Left unfixed,
+      // every Codex row indexed with message_count 0 even once its messages parsed —
+      // `developer` is excluded here for the same reason it is there: injected framing.
+      const p = d.payload;
+      const role = p?.['type'] === 'message' ? p['role'] : undefined;
+      if (role === 'user' || role === 'assistant') count++;
     }
 
     if (tool === 'claude') {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -32,6 +32,14 @@ export interface SessionMetadata {
   customTitle: string;
   date: string;
   createdAt: string;
+  /**
+   * The first timestamp in full, not truncated to a day like `createdAt`.
+   *
+   * The index needs the time of day for the active-hours histogram. Without this
+   * column get_session_metrics made a second pass over every matched row, reopening
+   * each transcript from disk purely to read line 1's clock.
+   */
+  startedAt: string;
   messageCount: number;
   branch: string;
 }
@@ -46,6 +54,7 @@ export function extractSessionMetadata(lines: string[], tool: Tool): SessionMeta
   let cwd = '';
   let title = '';
   let firstDate = '?';
+  let firstTs = '';
   let lastDate = '?';
   let count = 0;
   let branch = '';
@@ -69,7 +78,10 @@ export function extractSessionMetadata(lines: string[], tool: Tool): SessionMeta
 
     if (d.timestamp?.[0] === '2') {
       const date = d.timestamp.slice(0, 10);
-      if (firstDate === '?') firstDate = date;
+      if (firstDate === '?') {
+        firstDate = date;
+        firstTs = d.timestamp;
+      }
       lastDate = date;
     }
 
@@ -88,7 +100,15 @@ export function extractSessionMetadata(lines: string[], tool: Tool): SessionMeta
     }
   }
 
-  return { cwd, customTitle: title, date: lastDate, createdAt: firstDate, messageCount: count, branch };
+  return {
+    cwd,
+    customTitle: title,
+    date: lastDate,
+    createdAt: firstDate,
+    startedAt: firstTs,
+    messageCount: count,
+    branch,
+  };
 }
 
 export function getCwdFromSession(lines: string[], tool: Tool): string {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -466,6 +466,156 @@ export interface MessageSummary {
   closingAssistant: string;
 }
 
+// ——— Codex ———
+
+/**
+ * Text that arrives on a user-role line but is not the human speaking. Codex writes no
+ * `promptSource`, so these prefixes are the shape of every injection observed across the
+ * real corpus (305 rollouts, 1,022 user records, 417 of them injections).
+ *
+ * `Warning: ` is the harness scolding itself — "Warning: apply_patch was requested via
+ * exec_command…" — and it is the one prefix that could plausibly open a human turn. It is
+ * still tested before the event_msg join rather than after, because the sessions carrying
+ * it are exactly the ones with no `user_message` events to join against.
+ */
+const CODEX_INJECTED =
+  /^(<environment_context|<user_action|<turn_aborted|<recommended_plugins|<image\b|<skill\b|<user_shell_command|# AGENTS\.md instructions for |Warning: )/;
+
+/** How far in to look for the Codex envelope. Every real rollout opens with `session_meta`
+ *  on line 1; the slack absorbs a truncated or blank-padded head. */
+const CODEX_SNIFF_LINES = 20;
+
+/**
+ * Whether these lines are a Codex rollout.
+ *
+ * Sniffed rather than passed in: getSessionMessages runs from mcp.ts and cache.ts with
+ * nothing but a file's lines, so a `tool` parameter would have to be threaded through
+ * every caller. The check reads the PARSED top-level `type` and never a substring of the
+ * raw line — a transcript that merely discusses Codex has `response_item` in its prose.
+ */
+function isCodexTranscript(lines: string[]): boolean {
+  const n = Math.min(lines.length, CODEX_SNIFF_LINES);
+  for (let i = 0; i < n; i++) {
+    const t = tryParseJson(lines[i] ?? '')?.type;
+    if (t === 'session_meta' || t === 'response_item') return true;
+  }
+  return false;
+}
+
+/** The text of a Codex payload's content blocks of `kind`, joined. */
+function codexText(payload: Record<string, unknown>, kind: 'input_text' | 'output_text'): string {
+  const content = payload['content'];
+  if (!Array.isArray(content)) return '';
+  const texts: string[] = [];
+  for (const c of content) {
+    if (c && typeof c === 'object' && (c as Record<string, unknown>)['type'] === kind) {
+      texts.push((c as Record<string, string>)['text'] ?? '');
+    }
+  }
+  return texts.join(' ');
+}
+
+/** A Codex tool call, whatever envelope it arrived in. */
+function codexToolUse(p: Record<string, unknown>): ToolUse {
+  const name = typeof p['name'] === 'string' ? p['name'] : String(p['type'] ?? '?');
+  // Codex ships arguments three ways: a JSON string (`function_call.arguments`), the raw
+  // payload itself (`custom_tool_call.input` — a patch or a script), and an object.
+  const raw = p['arguments'] ?? p['input'] ?? p['action'];
+  if (typeof raw === 'string') {
+    try {
+      const o = JSON.parse(raw);
+      if (o && typeof o === 'object') return { name, summary: summarizeToolInput(o) };
+    } catch {
+      // Not JSON — it is the patch or script text itself, so summarize it directly.
+    }
+    const s = raw.replace(/\s+/g, ' ').trim();
+    return { name, summary: s.length > 120 ? s.slice(0, 120) + '…' : s };
+  }
+  return { name, summary: summarizeToolInput(raw) };
+}
+
+/**
+ * Codex, both streams reconciled.
+ *
+ * Codex writes two parallel logs. `response_item` is the model-facing history and
+ * `event_msg` is the UI event log, and they overlap: every assistant text is duplicated
+ * by an `event_msg` `agent_message`. Messages therefore come from `response_item` only —
+ * reading both would double every Codex turn in message_fts.
+ *
+ * What `event_msg` alone has is `user_message`: the harness echo of what the human
+ * actually typed, and nothing it injected. That makes genuineness a JOIN rather than a
+ * heuristic. Measured over the 305-rollout corpus, 604 of 1,022 user records have a
+ * text-identical twin in that stream, and every one of the 417 that do not is matched by
+ * CODEX_INJECTED — the two signals agree completely, with nothing left unexplained.
+ */
+function extractCodexMessages(lines: string[]): ExtractedMessage[] {
+  const parsed = lines.map(tryParseJson);
+
+  // Pass 1: the genuineness oracle. The `user_message` event usually lands AFTER its
+  // `response_item` twin, so this cannot fold into the emit pass below.
+  const typed = new Set<string>();
+  const userTexts: string[] = [];
+  for (const d of parsed) {
+    if (!d?.payload) continue;
+    if (d.type === 'event_msg' && d.payload['type'] === 'user_message') {
+      const m = d.payload['message'];
+      if (typeof m === 'string' && m.trim()) typed.add(m.trim());
+    } else if (d.type === 'response_item' && d.payload['type'] === 'message' && d.payload['role'] === 'user') {
+      const t = stripInjected(codexText(d.payload, 'input_text')).trim();
+      if (t) userTexts.push(t);
+    }
+  }
+  // Trust the join only where it demonstrably joins. If Codex ever normalized whitespace
+  // differently between the two streams, every turn would silently flip to genuine:false
+  // and first_prompt would go blank again — indistinguishable from the bug this fixes. A
+  // session whose streams do not meet falls back to the injection prefixes alone.
+  const joins = typed.size > 0 && userTexts.some((t) => typed.has(t));
+
+  const messages: ExtractedMessage[] = [];
+  let idx = 0;
+  // The turn's head message — where a following pure-tool-call line's calls attach.
+  let current: ExtractedMessage | null = null;
+  let pending: ToolUse[] = [];
+
+  for (const d of parsed) {
+    if (!d || d.type !== 'response_item' || !d.payload) continue;
+    const p = d.payload;
+    switch (p['type']) {
+      case 'message': {
+        if (p['role'] === 'user') {
+          const text = stripInjected(codexText(p, 'input_text'));
+          const trimmed = text.trim();
+          if (!trimmed) break;
+          const genuine = !CODEX_INJECTED.test(trimmed) && (!joins || typed.has(trimmed));
+          current = { role: 'user', text, index: idx++, genuine, tools: pending };
+          pending = [];
+          messages.push(current);
+        } else if (p['role'] === 'assistant') {
+          const text = codexText(p, 'output_text');
+          if (!text.trim()) break;
+          current = { role: 'assistant', text, index: idx++, genuine: true, tools: pending };
+          pending = [];
+          messages.push(current);
+        }
+        // Any other role (`developer`, `system`) is injected framing, not a turn.
+        break;
+      }
+      case 'function_call':
+      case 'custom_tool_call':
+      case 'web_search_call':
+      case 'tool_search_call': {
+        // A pure tool-call line carries no text and so gets no index of its own; its
+        // call folds into the head of the current turn, exactly as the Claude path does.
+        const call = codexToolUse(p);
+        if (current) current.tools.push(call);
+        else pending.push(call);
+        break;
+      }
+    }
+  }
+  return messages;
+}
+
 /**
  * The single numbering authority for message extraction. Every non-empty
  * user/assistant message in order, with a sequential index and a `genuine` flag
@@ -475,6 +625,10 @@ export interface MessageSummary {
  * exactly, so both derive from this function.
  */
 export function extractMessages(lines: string[]): ExtractedMessage[] {
+  // Codex nests its messages under a `response_item` envelope the dispatch below does
+  // not model, which is why every Codex transcript extracted to zero messages.
+  if (isCodexTranscript(lines)) return extractCodexMessages(lines);
+
   const messages: ExtractedMessage[] = [];
   let idx = 0;
   // The turn's head message — where a following pure-tool-use line's calls attach.

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -11,13 +11,22 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 
 /**
+ * Home root. `SESSIONS_HOME` exists so the installer can be exercised against a temp
+ * dir: src/mcp-config.ts edits real client config files (~/.codex/config.toml among
+ * them), and a test that writes those for real is not a test anyone can run twice.
+ */
+export function getHome(): string {
+  return process.env.SESSIONS_HOME || homedir();
+}
+
+/**
  * The durable data directory. Honors SESSIONS_DATA_DIR and is resolved lazily —
  * never frozen at import — for the same reason as src/cache.ts:41-45: the module
  * instance is shared across a `bun test` run, so a test that mutates the env on an
  * already-imported module must still be honored.
  */
 export function getDataDir(): string {
-  return process.env.SESSIONS_DATA_DIR || join(homedir(), '.local', 'share', 'sessions');
+  return process.env.SESSIONS_DATA_DIR || join(getHome(), '.local', 'share', 'sessions');
 }
 
 /** The memory store. Deliberately outside the cache dir — see src/memory/store.ts. */

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,12 +1,21 @@
-import { existsSync, mkdirSync, writeFileSync, readFileSync, cpSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, cpSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { homedir } from 'node:os';
 import { C } from './colors';
 import { PLUGIN_FILES } from './plugin-files';
 import { enableSessionHook, disableSessionHook } from './hooks';
 import { getDataDir } from './paths';
+import {
+  cleanDeadConfigs,
+  codexManualBlock,
+  detectClients,
+  unwireCodex,
+  unwireJsonClient,
+  wireCodex,
+  wireJsonClient,
+  type McpClient,
+  type WireResult,
+} from './mcp-config';
 
-const home = homedir();
 /** The sessions data dir. Single source of truth is getDataDir() — the memory store
  *  lives in the same directory, and the two must never disagree about where it is. */
 function sessionsDir(): string {
@@ -31,32 +40,6 @@ function ownedInstallPaths(): string[] {
 const PLUGIN_VERSION = '1.19.0'; // x-release-please-version
 const MARKETPLACE_NAME = 'sessions';
 const PLUGIN_NAME = 'sessions';
-
-interface ToolConfig {
-  name: string;
-  detected: boolean;
-  mcpConfigPath: string;
-}
-
-function detectTools(): ToolConfig[] {
-  return [
-    {
-      name: 'Claude Code',
-      detected: existsSync(join(home, '.claude')),
-      mcpConfigPath: join(home, '.claude', '.mcp.json'),
-    },
-    {
-      name: 'Cursor',
-      detected: existsSync(join(home, '.cursor')),
-      mcpConfigPath: join(home, '.cursor', '.mcp.json'),
-    },
-    {
-      name: 'Codex',
-      detected: existsSync(join(home, '.codex')),
-      mcpConfigPath: join(home, '.codex', '.mcp.json'),
-    },
-  ];
-}
 
 function findPluginSource(): string {
   const candidates = [
@@ -128,30 +111,22 @@ function sessionsCommand(): string {
   return 'sessions';
 }
 
-function configureMcp(tool: ToolConfig): boolean {
-  try {
-    const cmd = sessionsCommand();
-    let config: Record<string, unknown> = {};
+/**
+ * Write the MCP entry into the file this client actually reads.
+ *
+ * Claude Code has no config of its own here: its server arrives with the plugin, which
+ * is also the reason the old dotfile bug went unnoticed for so long — the one client
+ * most likely to be tested worked through a path setup never touched.
+ */
+function wire(client: McpClient): WireResult {
+  if (!client.configPath) return { status: 'unchanged' };
+  const cmd = sessionsCommand();
+  return client.id === 'codex' ? wireCodex(client.configPath, cmd) : wireJsonClient(client.configPath, client.id, cmd);
+}
 
-    if (existsSync(tool.mcpConfigPath)) {
-      try {
-        config = JSON.parse(readFileSync(tool.mcpConfigPath, 'utf-8'));
-      } catch {}
-    }
-
-    const servers = (config.mcpServers ?? {}) as Record<string, unknown>;
-    servers.sessions = {
-      command: cmd,
-      args: ['--mcp'],
-    };
-    config.mcpServers = servers;
-
-    mkdirSync(dirname(tool.mcpConfigPath), { recursive: true });
-    writeFileSync(tool.mcpConfigPath, JSON.stringify(config, null, 2) + '\n');
-    return true;
-  } catch {
-    return false;
-  }
+function unwire(client: McpClient): WireResult {
+  if (!client.configPath) return { status: 'unchanged' };
+  return client.id === 'codex' ? unwireCodex(client.configPath) : unwireJsonClient(client.configPath);
 }
 
 function runClaude(...args: string[]): boolean {
@@ -212,22 +187,38 @@ export function runSetup(opts: SetupOptions = {}): void {
     process.exit(1);
   }
 
-  const tools = detectTools();
-  const detected = tools.filter((t) => t.detected);
+  for (const path of cleanDeadConfigs()) {
+    w(`  ${C.green}✓${C.reset} Removed dead config ${C.dim}${path}${C.reset}\n`);
+  }
+
+  const detected = detectClients().filter((t) => t.detected);
 
   if (detected.length === 0) {
-    w(`\n  ${C.dim}No AI tools detected. Install Claude Code, Cursor, or Codex first.${C.reset}\n\n`);
+    w(`\n  ${C.dim}No AI tools detected. Install Claude Code, Cursor, Codex, or Pi first.${C.reset}\n\n`);
     process.exit(0);
   }
 
   for (const tool of detected) {
-    if (configureMcp(tool)) {
-      w(`  ${C.green}✓${C.reset} MCP server added to ${C.dim}${tool.name}${C.reset}\n`);
-    } else {
-      w(`  ${C.red}✗${C.reset} Failed to configure MCP for ${tool.name}\n`);
+    // Report what the write actually did. The previous version printed a checkmark for
+    // every client whose file it managed to create, including three no client reads.
+    const res = wire(tool);
+    if (res.status === 'added') {
+      w(
+        `  ${C.green}✓${C.reset} MCP server added to ${C.dim}${tool.name}${C.reset} ${C.dim}(${tool.configPath})${C.reset}\n`,
+      );
+    } else if (res.status === 'unchanged' && tool.configPath) {
+      w(`  ${C.dim}ℹ${C.reset} MCP server already configured for ${C.dim}${tool.name}${C.reset}\n`);
+    } else if (res.status === 'refused') {
+      w(`  ${C.yellow}!${C.reset} Left ${C.dim}${tool.configPath}${C.reset} alone — ${res.reason}\n`);
+      if (tool.id === 'codex') {
+        w(`  ${C.dim}  Add this yourself:${C.reset}\n`);
+        for (const line of codexManualBlock(sessionsCommand()).split('\n')) w(`  ${C.dim}    ${line}${C.reset}\n`);
+      }
+    } else if (res.status === 'failed') {
+      w(`  ${C.red}✗${C.reset} Failed to configure MCP for ${tool.name} — ${res.reason}\n`);
     }
 
-    if (tool.name === 'Claude Code') {
+    if (tool.id === 'claude') {
       const result = registerClaudePlugin();
       if (result.marketplace) {
         w(`  ${C.green}✓${C.reset} Marketplace added to ${C.dim}${tool.name}${C.reset}\n`);
@@ -243,7 +234,7 @@ export function runSetup(opts: SetupOptions = {}): void {
   }
 
   // SessionStart auto-injection hook — opt-in, Claude Code only for now.
-  const claudeDetected = detected.some((t) => t.name === 'Claude Code');
+  const claudeDetected = detected.some((t) => t.id === 'claude');
   if (claudeDetected && shouldEnableHook(opts)) {
     const res = enableSessionHook('claude');
     if (res.changed) {
@@ -269,20 +260,19 @@ export function runUninstall(): void {
 
   w(`\n${C.bold}sessions uninstall${C.reset}\n\n`);
 
-  const tools = detectTools();
-  for (const tool of tools.filter((t) => t.detected)) {
-    try {
-      if (existsSync(tool.mcpConfigPath)) {
-        const config = JSON.parse(readFileSync(tool.mcpConfigPath, 'utf-8'));
-        if (config.mcpServers?.sessions) {
-          delete config.mcpServers.sessions;
-          writeFileSync(tool.mcpConfigPath, JSON.stringify(config, null, 2) + '\n');
-          w(`  ${C.green}✓${C.reset} Removed MCP config from ${C.dim}${tool.name}${C.reset}\n`);
-        }
-      }
-    } catch {}
+  for (const path of cleanDeadConfigs()) {
+    w(`  ${C.green}✓${C.reset} Removed dead config ${C.dim}${path}${C.reset}\n`);
+  }
 
-    if (tool.name === 'Claude Code') {
+  for (const tool of detectClients().filter((t) => t.detected)) {
+    const res = unwire(tool);
+    if (res.status === 'added') {
+      w(`  ${C.green}✓${C.reset} Removed MCP config from ${C.dim}${tool.name}${C.reset}\n`);
+    } else if (res.status === 'refused' || res.status === 'failed') {
+      w(`  ${C.yellow}!${C.reset} Left ${C.dim}${tool.configPath}${C.reset} alone — ${res.reason}\n`);
+    }
+
+    if (tool.id === 'claude') {
       unregisterClaudePlugin();
       w(`  ${C.green}✓${C.reset} Removed plugin from ${C.dim}${tool.name}${C.reset}\n`);
 

--- a/src/wrapped/index.test.ts
+++ b/src/wrapped/index.test.ts
@@ -277,7 +277,10 @@ describe('runWrapped', () => {
         '-e',
         "require('./src/wrapped/index.ts').runWrapped({tz:'UTC',stdout:true,offline:true,extras:'/nope/missing.json',noContent:true,roots:{claudeCode:'/nope',pi:'/nope',codex:'/nope'}})",
       ],
-      { cwd: '/Users/nicknisi/Developer/sessions' },
+      // Repo root derived from this file, never hardcoded: the absolute path that used
+      // to live here existed on one machine, so the spawn failed for the wrong reason
+      // everywhere else and the assertion below could not be reached.
+      { cwd: join(import.meta.dir, '..', '..') },
     );
     expect(r.exitCode).toBe(1);
     expect(r.stderr.toString()).toContain('--extras: cannot read');

--- a/src/wrapped/roast.ts
+++ b/src/wrapped/roast.ts
@@ -27,6 +27,11 @@ const ROAST_TOOLS: RoastTool[] = [
   { id: 'pi', label: 'Pi', bin: 'pi', args: (p) => ['-p', p] },
 ];
 
+/** The table entry for `id`, without asking PATH whether it is installed. */
+function namedRoastTool(id?: RoastToolId): RoastTool {
+  return ROAST_TOOLS.find((t) => t.id === id) ?? ROAST_TOOLS[0]!;
+}
+
 /** First installed roast tool (honoring `preferred`), or null if none on PATH. */
 export function detectRoastTool(preferred?: RoastToolId): RoastTool | null {
   const ordered = preferred ? [...ROAST_TOOLS].sort((a) => (a.id === preferred ? -1 : 1)) : ROAST_TOOLS;
@@ -125,7 +130,10 @@ export interface RoastOptions {
  *  output). Never throws — the roast is sugar, the page must survive without it. */
 export async function runRoast(d: WrappedData, opts: RoastOptions = {}): Promise<WrappedExtra[]> {
   const log = opts.log ?? ((m: string) => process.stderr.write(m + '\n'));
-  const tool = detectRoastTool(opts.preferred);
+  // An injected runner supplies the execution mechanism, so looking for an
+  // executable on PATH is meaningless — and doing it anyway made these paths
+  // testable only on a machine that happened to have an agent CLI installed.
+  const tool = opts.runner ? namedRoastTool(opts.preferred) : detectRoastTool(opts.preferred);
   if (!tool) {
     log(
       opts.preferred


### PR DESCRIPTION
Four defects extracted from the stale #48/#49 branches and rebuilt on current `main`, plus the CI job that would have caught two of them. Each was reproduced on real data before being fixed and re-measured after.

#48 and #49 should be closed once this lands: #48 is a strict subset of #49 (every commit is an ancestor), and #49's centrepiece — the `distill` lesson miner — lost to `src/memory/mine.ts`, which shipped in #50 and was repaired in #53. Both branches conflict in 21 files, including a `memory.db` collision where two schemas claim the same `PRAGMA user_version`. What remains worth taking from them is the eval harness (`src/eval/`) and trajectory export, each its own PR.

## Measured

| | before | after |
| --- | --- | --- |
| Codex rollouts extracting messages | **0 / 305** | **291 / 305** |
| Codex messages indexed | 0 | 3,378 |
| Codex tool calls visible | 0 | 12,906 |
| `sessions setup` writes a client reads | 0 / 3 | 3 / 3 |
| `get_session_metrics` disk reads per call | one per matched row | **0** |
| active-hours histogram | UTC | local |
| Codex `message_count` | 0 | 3,378 |
| Codex rows in `message_fts` | 0 | 2,900 |
| tests run by CI | **0** of 817 | 869 |

The 14 Codex rollouts that still extract nothing hold a lone `session_meta` line: opened and abandoned.

## Codex was indexed metadata-only

`extractMessages` dispatched on the top-level `type` and knew `user`, `assistant`, `message`. Codex nests everything one level down under `{type:"response_item", payload:{type:"message", role, content}}`. No branch matched, so 305 rollouts and 55,422 lines produced zero messages.

It stayed hidden because `extract-files.ts` and `extract-commands.ts` *do* model the real envelope — files, commands, and branch populated normally, so the sessions looked indexed. `parser.test.ts` asserted `{type:"message", message:{…}}`, which is the **pi** shape and occurs zero times in real Codex logs.

Codex writes two overlapping logs. `response_item` is the model-facing history, `event_msg` is the UI log, and every assistant text appears in both, so messages come from `response_item` alone — reading both would double every turn in `message_fts`. What `event_msg` uniquely has is `user_message`, the harness echo of what the human actually typed. **Genuineness is a join, not a heuristic:** 604 of 1,022 user records have a text-identical twin, and every one of the 417 that don't is matched by the injection-prefix pattern. Two independent signals, complete agreement, nothing unexplained.

The join is trusted only where it demonstrably joins — 26 of 305 rollouts carry no `user_message` events at all, and without the guard every turn there would flip to `genuine:false` and blank `first_prompt` again, indistinguishable from the bug being fixed.

Format is **sniffed** from the parsed top-level type rather than passed in, because `getSessionMessages` runs from `mcp.ts` and `cache.ts` with nothing but a file's lines. The sniff reads parsed types and never a raw substring, since this repo's own transcripts discuss `response_item` in prose — there's a test for exactly that.

One gap only an end-to-end index build exposed: `extractSessionMetadata` has its own counting loop, which had the same envelope blindness. Codex messages became searchable while every Codex row still indexed with `message_count` 0 — invisible to both the unit tests and the corpus assertions, since both go through `extractMessages`. Fixed in the same place, and Codex's count now equals the extracted total exactly. (Claude's `message_count` remains a line count, ~3x the extracted figure. That predates this branch and is left alone.)

**No regression:** `extractMessages` output compared between `origin/main` and this branch across all 9,112 Claude transcripts (108,545 messages) and 166 pi transcripts (1,542). Byte-identical, zero differing files.

## `sessions setup` configured nothing

All three writes were dead, and it printed a checkmark for each:

| written | actually read |
| --- | --- |
| `~/.codex/.mcp.json` | `[mcp_servers]` in `~/.codex/config.toml` |
| `~/.cursor/.mcp.json` | `~/.cursor/mcp.json` (no dot) |
| `~/.claude/.mcp.json` | `~/.claude.json` |

Claude Code worked anyway because its server ships with the bundled plugin. The one client most likely to be checked was the one setup never had to configure correctly.

Codex gets a hand-rolled TOML merge rather than a new dependency (runtime deps stay at two). `config.toml` is a user-owned file holding their model, sandbox, and per-project trust settings, so the merge touches only `[mcp_servers.sessions]`, preserves every other key across re-runs, backs up before its first write, and **refuses rather than guesses** on shapes it can't edit line-by-line: multi-line strings, multi-line arrays, `mcp_servers` as a dotted key, arrays of tables. On refusal it prints the block to paste. pi is now supported via `~/.pi/agent/mcp.json`.

Exercised end-to-end against a temp `HOME` with a realistic `config.toml` (model, `sandbox_workspace_write`, an existing `mcp_servers.linear`, a projects table) and a Cursor config with an existing `figma` server: every pre-existing key survived, a re-run reported unchanged and left the file byte-identical, uninstall restored `config.toml` byte-for-byte, and a config with `[mcp_servers.sessions]` inside a multi-line string was refused and left untouched.

## The metrics histogram was UTC, and paid for it twice

`activeHours` sliced characters 11-13 out of the ISO timestamp — the UTC hour presented as the user's. A US-Central 9am landed in the 14:00 bucket; late-evening sessions landed on the wrong day.

It also got that timestamp by walking the matched rows a *second* time and reopening every transcript from disk to `JSON.parse` line 1. Full file reads for one field, on a path that already had the rows.

Both come from `created_at` being truncated to a day. `sessions` gains `started_at`, captured in the pass `extractSessionMetadata` was already making. The second loop is gone.

Conversion formats against an explicit IANA zone instead of `Date#getHours`. That matters beyond correctness: `getHours` reads a zone V8 caches on first clock read, so setting `process.env.TZ` between two assertions in one file does nothing and a test written that way silently measures the process default. `getSessionMetrics` takes an optional `tz` defaulting to the machine's; the tests pass it explicitly.

## CI ran no tests

`ci.yml` ran lint, format, typecheck, build. 55 test files, 817 tests, gating nothing.

The job runs on a bare runner with no agent CLI, and immediately earned itself: **four roast tests passed only because `claude` was on the developer's PATH.** `runRoast()` called `detectRoastTool()` even when the caller injected a runner, so tests supplying their own runner still went to PATH for a binary they were never going to execute. Verified by mirroring every PATH binary except `claude`/`codex`/`pi`/`opencode` into a temp dir: 813 pass / 4 fail before, 817 / 0 after.

Then it found two more once it was actually running, both of the same shape — tests that only ever passed on one machine:

- **`package.json` had no `test` script.** `bun run test` fell through to `/usr/bin/test`, which exits 1 on no arguments. A red check that ran nothing. My local verification used `bun test`, the built-in runner, so it could not reproduce this.
- **A spawn test hardcoded `cwd: '/Users/nicknisi/Developer/sessions'`.** That path exists on one laptop; anywhere else the child failed to start for an unrelated reason and the assertion was never reached. Now derived from `import.meta.dir`.

`release.yml` still doesn't wait for tests. `ci.yml` runs on pushes to `main` so they do execute, but the release build doesn't gate on them — deliberately left alone here.

## Upgrade notes

- **`SCHEMA_VERSION` 8 → 9.** The index rebuilds once on first use. That rebuild is what actually populates Codex message content, since every existing row predates the parser fix.
- **Re-run `sessions setup`.** It cleans up the three dead dotfiles and reports each one. Removal only happens when a file's content is exactly what we generated — a lone `sessions` server and nothing else — so a file you made your own stays.

## Verification

867 pass / 4 skip / 0 fail, run on a simulated bare CI runner. Lint, format, typecheck clean.

The 4 skips are `src/parser.corpus.test.ts`, which asserts invariants against the real transcripts on the machine behind `SESSIONS_LIVE_CORPUS=1` — that every substantive rollout extracts messages, that no harness extracts to zero across its corpus, that numbering stays dense, and that no non-genuine Codex turn goes unexplained by the injection prefixes.

Both new suites are mutation-tested rather than assumed: disabling the Codex dispatch fails 2 corpus assertions, removing the join guard fails 1, and restoring the UTC string-slice fails 2 metrics assertions. One honest gap is recorded in place — the midnight test pins the 00-23 contract but does not discriminate the `% 24` guard on this ICU build, and the comment says so instead of implying coverage it lacks.
