### PR TITLE
fix: restore changelog coverage for #61 and guard against unparseable commit messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,28 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run build
 
+  # release-please drops any commit whose body has a line-initial nested-paren token,
+  # then exits 0 — so a release silently goes missing while every check is green. This
+  # has cost two releases here, most recently 89f15bd. See the script for the mechanism.
+  commit-messages:
+    runs-on: ubuntu-latest
+    # This workflow also runs on pushes to main, where there is no pull_request payload
+    # to read a base and head from. By then the squash commit is already written, so the
+    # check has nothing left to prevent.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: ./scripts/check-commit-messages.sh --selftest
+      - name: Check this branch's commits
+        # Via env, not inline interpolation: these are SHAs today, but a `run:` block
+        # that expands PR-controlled fields directly is the shape injections arrive in.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/check-commit-messages.sh "$BASE_SHA" "$HEAD_SHA"
+
   # Runs deliberately on a runner with no agent CLI installed. Several suites used to
   # pass only because `claude` happened to be on the developer's PATH; keeping the
   # runner bare is what stops that class of test from regressing silently.

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Reject commit messages release-please cannot parse.
+#
+# release-please (action v4) parses each commit with @conventional-commits/parser,
+# whose PEG grammar treats the start of every body line as a possible footer token
+# `token(scope):`. So a LINE-INITIAL token containing NESTED parens makes the first
+# `(` open a scope and the parser demand `)`; the inner `(` throws
+#
+#     unexpected token '(' at L:C, valid tokens [)]
+#
+# The failure is silent. release-please logs the error, DROPS the commit, and still
+# exits 0 — the run is green, `Considering: 0 commits`, and no release PR is created.
+# The commit's work is then absent from the changelog permanently, because that
+# message will never parse on any later run.
+#
+# This has cost two releases in this repo:
+#   c216a1d (#50)  L165  `fingerprint(normalizeText(text))`. …
+#   89f15bd (#61)  L65   summarizeMessages(extractMessages(...)).
+#
+# Note both are ordinary prose. Backticks do not shield the pattern, and a single
+# paren group at line start is fine — only nesting breaks. Neither author chose to
+# start a line that way; the paragraph simply wrapped there. That is why this is a
+# check and not a guideline.
+#
+# Squash merges compose the body from every commit message in the PR, so one bad
+# line anywhere in the branch sinks the release.
+#
+# Usage:
+#   scripts/check-commit-messages.sh <base-ref> <head-ref>
+#   scripts/check-commit-messages.sh --selftest
+set -euo pipefail
+
+# Prints offending lines as "L<line>:<col>  <text>". Exit 1 if any were found.
+# RSTART+RLENGTH-1 is the position of the inner `(` — the column release-please reports.
+scan() {
+  awk 'match($0, /^[^ \t]*\([^)]*\(/) { printf "  L%d:%d  %s\n", NR, RSTART + RLENGTH - 1, $0; f = 1 }
+       END { exit f ? 1 : 0 }'
+}
+
+selftest() {
+  local failures=0
+
+  expect_bad() {
+    if printf '%s\n' "$1" | scan >/dev/null; then
+      echo "selftest FAIL: should have been rejected: $1" >&2
+      failures=$((failures + 1))
+    fi
+  }
+  expect_ok() {
+    if ! printf '%s\n' "$1" | scan >/dev/null; then
+      echo "selftest FAIL: should have been accepted: $1" >&2
+      failures=$((failures + 1))
+    fi
+  }
+
+  # The two real regressions.
+  expect_bad 'summarizeMessages(extractMessages(...)).'
+  expect_bad '`fingerprint(normalizeText(text))`. Import is also the one unbounded path'
+  # Nesting at line start, in other shapes.
+  expect_bad 'foo(bar(baz))'
+  expect_bad 'localHour(new Date(iso)) is the conversion'
+
+  # A single paren group at line start parses fine.
+  expect_ok 'summarizeMessages(messages) builds the columns'
+  expect_ok 'getDataDir() resolves lazily'
+  # Nesting is fine once anything precedes it — this is the documented fix.
+  expect_ok 'It is built from summarizeMessages(extractMessages(lines)).'
+  expect_ok 'Uses fingerprint(normalizeText(text)) to dedupe.'
+  # Ordinary prose and conventional-commit syntax.
+  expect_ok 'fix(parser): extract messages from Codex rollouts'
+  expect_ok 'A sentence (with a parenthetical) that starts plainly.'
+  expect_ok ''
+
+  if [ "$failures" -ne 0 ]; then
+    echo "selftest: $failures case(s) failed" >&2
+    return 1
+  fi
+  echo "selftest: all cases pass"
+}
+
+if [ "${1:-}" = "--selftest" ]; then
+  selftest
+  exit 0
+fi
+
+base=${1:?usage: check-commit-messages.sh <base-ref> <head-ref>}
+head=${2:?usage: check-commit-messages.sh <base-ref> <head-ref>}
+
+bad=0
+while read -r sha; do
+  [ -n "$sha" ] || continue
+  if ! output=$(git log -1 --format=%B "$sha" | scan); then
+    echo "✗ $(git log -1 --format='%h %s' "$sha")"
+    echo "$output"
+    bad=$((bad + 1))
+  fi
+done <<EOF
+$(git rev-list "$base..$head")
+EOF
+
+if [ "$bad" -ne 0 ]; then
+  cat >&2 <<'MSG'
+
+release-please would silently drop the commit(s) above and skip the release PR,
+while every check stayed green.
+
+Fix: reflow so a word precedes the token, or unnest it.
+
+    summarizeMessages(extractMessages(...)).          <- dropped
+    It is built from summarizeMessages(extractMessages(...)).   <- fine
+
+Then amend or rebase. Squash merges concatenate every commit message in the
+branch, so one bad line anywhere sinks the release.
+MSG
+  exit 1
+fi
+
+echo "commit messages are parseable by release-please"


### PR DESCRIPTION
Two things: get [#61](https://github.com/nicknisi/sessions/pull/61)'s work into a changelog, and stop this from happening a third time.

## What went wrong

`89f15bd` merged clean and its four fixes work. But release-please never saw it:

```
❯ error message: Error: unexpected token '(' at 65:34, valid tokens [)]
✔ Considering: 0 commits
✔ No commits for path: ., skipping
```

Line 65 column 34 of the squash body is the inner paren in `summarizeMessages(extractMessages(...)).`

release-please parses commits with `@conventional-commits/parser`, whose PEG grammar treats the start of every body line as a possible footer token `token(scope):`. A **line-initial** token with **nested** parens opens a scope on the first paren and throws on the second. It logs the error, drops the commit, and **exits 0** — green run, no release PR, nothing to notice.

Because that message will never parse, no later run recovers it. The work would have been absent from the changelog permanently.

This is the second time:

| | | |
|---|---|---|
| `c216a1d` (#50) | L165 | a backticked `fingerprint(normalizeText(text))` call |
| `89f15bd` (#61) | L65 | a `summarizeMessages(extractMessages(...))` call |

Neither author chose to start a line that way. In both cases a paragraph wrapped and put the token in column 1. Backticks don't shield it; a single paren group at line start is fine, only nesting breaks. The second one was written by someone who had the rule written down, which is the whole argument for a check instead of a guideline.

## The recovery

An empty commit describing what `89f15bd` contained, so the release notes are accurate. Nothing about the code changes.

## The guard

`scripts/check-commit-messages.sh`, run by a new `commit-messages` CI job on pull requests.

- **Reads each commit in the branch, not just the tip.** Squash merges concatenate every commit message, so one bad line anywhere sinks the release.
- **Pull requests only.** A push to `main` has no base/head to compare, and by then the squash commit is already written.
- **Self-testing.** CI runs `--selftest` before the branch scan, so a broken checker fails loudly instead of passing everything. It covers both real regressions, three synthetic nestings, and seven shapes that must keep passing — including `summarizeMessages(messages)` and the reflowed `It is built from summarizeMessages(extractMessages(lines)).`

Reports the same coordinates release-please does:

```
✗ 89f15bd fix: Codex message extraction, setup config paths, metrics timezone…
  L65:34  summarizeMessages(extractMessages(...)).
```

`L65:34` matches the parser's reported `65:34` exactly, so the detector models the real rule rather than approximating it.

## Verification

- Selftest passes; run against `099f05a..89f15bd` it reproduces the real failure at the exact position.
- Run against the last 25 commits on `main` it flags exactly the two known-bad ones and nothing else.
- A temporary poisoned commit on this branch was rejected with exit 1, then removed; the branch now passes.
- This PR's own commit messages were gated through the checker before being written.
- 869 pass / 4 skip / 0 fail. Lint, format, typecheck clean.

## One limit worth stating

The check reads commit messages. If someone squash-merges and hand-edits the body in the GitHub UI to introduce the pattern, nothing catches it — the text never existed in a commit. That path is rare and deliberate, and closing it would mean a check on `main` after the fact, which can report the loss but not prevent it.
