### PR TITLE
fix: correct Pi usage tracking (dedup forks, compactions, subagents, pricing fallbacks)

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -18,6 +18,7 @@ import {
   type PrimerMemory,
 } from './types';
 import { activeMemoryFor } from './memory/retrieve';
+import { getPiSessionsDir } from './paths';
 import type { MemoryRecord } from './memory/types';
 import { extractMessages, getSessionMessages, extractSessionMetadata, summarizeMessages } from './parser';
 import { extractFiles, extractFilesRead } from './extract-files';
@@ -57,7 +58,10 @@ function getClaudeDir(): string {
   return process.env.SESSIONS_CLAUDE_DIR || join(home, '.claude/projects');
 }
 function getPiDir(): string {
-  return process.env.SESSIONS_PI_DIR || join(home, '.pi/agent/sessions');
+  // Shared resolver (src/paths.ts): honors SESSIONS_PI_DIR and Pi's own
+  // PI_CODING_AGENT_SESSION_DIR / PI_CODING_AGENT_DIR overrides, and keeps the
+  // index, scanner, and report pointed at the same tree.
+  return getPiSessionsDir();
 }
 function getCodexDir(): string {
   return process.env.SESSIONS_CODEX_DIR || join(home, '.codex/sessions');

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { getPiSessionsDir } from './paths.ts';
+
+// One resolver for every Pi consumer (index, scanner, report). These pin the
+// precedence order so the three can never silently disagree again.
+const saved = {
+  sessionsPi: process.env.SESSIONS_PI_DIR,
+  piSession: process.env.PI_CODING_AGENT_SESSION_DIR,
+  piDir: process.env.PI_CODING_AGENT_DIR,
+};
+
+beforeEach(() => {
+  delete process.env.SESSIONS_PI_DIR;
+  delete process.env.PI_CODING_AGENT_SESSION_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
+});
+
+afterAll(() => {
+  for (const [env, val] of [
+    ['SESSIONS_PI_DIR', saved.sessionsPi],
+    ['PI_CODING_AGENT_SESSION_DIR', saved.piSession],
+    ['PI_CODING_AGENT_DIR', saved.piDir],
+  ] as const) {
+    if (val === undefined) delete process.env[env];
+    else process.env[env] = val;
+  }
+});
+
+describe('getPiSessionsDir', () => {
+  test('defaults to ~/.pi/agent/sessions', () => {
+    expect(getPiSessionsDir()).toBe(join(homedir(), '.pi', 'agent', 'sessions'));
+  });
+
+  test('honors PI_CODING_AGENT_DIR (sessions live under the config dir)', () => {
+    process.env.PI_CODING_AGENT_DIR = '/custom/pi-config';
+    expect(getPiSessionsDir()).toBe('/custom/pi-config/sessions');
+  });
+
+  test('PI_CODING_AGENT_SESSION_DIR beats PI_CODING_AGENT_DIR', () => {
+    process.env.PI_CODING_AGENT_DIR = '/custom/pi-config';
+    process.env.PI_CODING_AGENT_SESSION_DIR = '/custom/session-store';
+    expect(getPiSessionsDir()).toBe('/custom/session-store');
+  });
+
+  test('SESSIONS_PI_DIR beats every Pi override', () => {
+    process.env.PI_CODING_AGENT_DIR = '/custom/pi-config';
+    process.env.PI_CODING_AGENT_SESSION_DIR = '/custom/session-store';
+    process.env.SESSIONS_PI_DIR = '/ours';
+    expect(getPiSessionsDir()).toBe('/ours');
+  });
+});

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -33,3 +33,23 @@ export function getDataDir(): string {
 export function getMemoryDbPath(): string {
   return join(getDataDir(), 'memory.db');
 }
+
+/**
+ * Where Pi keeps its session transcripts. One resolver shared by the index
+ * (src/cache.ts), the no-index scanner (src/scanner.ts), and the usage report
+ * (src/report/extract.ts) so all three always look at the same tree.
+ *
+ * Order:
+ *   1. SESSIONS_PI_DIR — this project's own override (tests, unusual setups);
+ *   2. PI_CODING_AGENT_SESSION_DIR — Pi's documented session-storage override;
+ *   3. PI_CODING_AGENT_DIR — Pi's config-dir override (sessions live under it);
+ *   4. ~/.pi/agent/sessions — Pi's default.
+ * Resolved lazily (never frozen at import) for the same test-hermeticity reason
+ * as getDataDir above.
+ */
+export function getPiSessionsDir(): string {
+  if (process.env.SESSIONS_PI_DIR) return process.env.SESSIONS_PI_DIR;
+  if (process.env.PI_CODING_AGENT_SESSION_DIR) return process.env.PI_CODING_AGENT_SESSION_DIR;
+  if (process.env.PI_CODING_AGENT_DIR) return join(process.env.PI_CODING_AGENT_DIR, 'sessions');
+  return join(homedir(), '.pi', 'agent', 'sessions');
+}

--- a/src/report/aggregate.ts
+++ b/src/report/aggregate.ts
@@ -34,6 +34,10 @@ const PROVIDER_LABEL: Record<string, string> = {
   anthropic: 'Anthropic',
   openai: 'OpenAI',
   baseten: 'Baseten',
+  // sessions-local extensions — providers Pi emits that upstream does not label
+  // (see the opencode note in the header). Preserve when re-syncing.
+  'openai-codex': 'OpenAI (Codex)',
+  openrouter: 'OpenRouter',
 };
 
 export interface AggregateInput {

--- a/src/report/event-cache.ts
+++ b/src/report/event-cache.ts
@@ -23,7 +23,10 @@ import type { AgentName } from './parsers/claude-code.ts';
 
 // Bump when the stored shape changes, so an old cache is discarded rather than
 // misread. v1: per-file events blob + agent-name map.
-const SCHEMA_VERSION = 1;
+// v2: the Pi parser changed what it emits per file (dedupKeys, subagent-run
+// attribution, compaction usage, zero-usage skips) — a v1 pi parse served from
+// cache would silently miss all of it, so old caches are rebuilt.
+const SCHEMA_VERSION = 2;
 
 export function getEventCachePath(): string {
   return join(getCacheDir(), 'usage.db');

--- a/src/report/extract.ts
+++ b/src/report/extract.ts
@@ -15,6 +15,7 @@ import { parseCodex, parseCodexFile } from './parsers/codex.ts';
 import { parseOpencode } from './parsers/opencode.ts';
 import { walkJsonl, pruneThreshold } from './parsers/walk.ts';
 import { getOpencodeDbPath } from '../opencode.ts';
+import { getPiSessionsDir } from '../paths.ts';
 import {
   openEventCache,
   statAll,
@@ -39,7 +40,9 @@ export function defaultRoots(): ReportRoots {
   const home = homedir();
   return {
     claudeCode: join(home, '.claude', 'projects'),
-    pi: join(home, '.pi', 'agent', 'sessions'),
+    // Same resolution (SESSIONS_PI_DIR / PI_CODING_AGENT_* overrides included) as
+    // the search index and scanner — one source of truth.
+    pi: getPiSessionsDir(),
     codex: join(home, '.codex', 'sessions'),
     // Same resolution (env override included) as the search index — one source of truth.
     opencode: getOpencodeDbPath(),
@@ -65,7 +68,18 @@ function fileSources(roots: ReportRoots, want: (t: ToolId) => boolean): FileSour
   const out: FileSource[] = [];
   if (want('claude-code')) out.push({ root: roots.claudeCode, parseFile: parseClaudeCodeFile });
   if (want('pi'))
-    out.push({ root: roots.pi, parseFile: async (p) => ({ events: await parsePiFile(p), agentTypes: {} }) });
+    out.push({
+      root: roots.pi,
+      parseFile: async (p) => {
+        const events = await parsePiFile(p);
+        // Register each Pi dispatch under its own (already final) type, so the
+        // cross-file resolveAgentTypes pass confirms it instead of renaming it
+        // to 'unknown' — Pi has no parent-record naming step to wait for.
+        const agentTypes: Record<string, AgentName> = {};
+        for (const e of events) if (e.agent) agentTypes[e.agent.id] = { type: e.agent.type, strong: true };
+        return { events, agentTypes };
+      },
+    });
   if (want('codex'))
     out.push({ root: roots.codex, parseFile: async (p) => ({ events: await parseCodexFile(p), agentTypes: {} }) });
   return out;

--- a/src/report/facets.ts
+++ b/src/report/facets.ts
@@ -15,7 +15,7 @@
 //   - burn:        pace against the period, and against the period before it.
 import type { UsageEvent } from './parsers/types.ts';
 import type { ToolId } from './types.ts';
-import { computeCost, find } from './pricing.ts';
+import { computeCost, find, findFamily } from './pricing.ts';
 import { localDate, weekEnding } from './parsers/util.ts';
 import { resolveProject } from './project.ts';
 
@@ -152,8 +152,10 @@ function cacheStats(events: UsageEvent[]): CacheStats {
     write += e.tokens.cacheWrite;
     read += e.tokens.cacheRead;
     // Gated on a pricing hit so an unpriced model doesn't push two more warnings
-    // per event into the collector for a number we'd end up reporting as 0.
-    if (e.tokens.cacheRead > 0 && find(e.model)) {
+    // per event into the collector for a number we'd end up reporting as 0. A
+    // family estimate counts as a hit: computeCost prices it (at the family rate),
+    // so gating it out would understate savings for models like Pi's kimi-k3.
+    if (e.tokens.cacheRead > 0 && (find(e.model) || findFamily(e.model))) {
       // Price the same tokens twice — once as cache reads, once as fresh input —
       // through the real pricing path, so tiering and per-model rates apply.
       const zero = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };

--- a/src/report/parsers.test.ts
+++ b/src/report/parsers.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parseClaudeCode } from './parsers/claude-code.ts';
 import { parseCodex } from './parsers/codex.ts';
+import { parsePi } from './parsers/pi.ts';
 
 const tmp = mkdtempSync(join(tmpdir(), 'sessions-parsers-'));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));
@@ -238,5 +239,244 @@ describe('parseCodex accounting', () => {
     );
     const events = await parseCodex(root);
     expect(events[0]!.tokens.output).toBe(100); // not 130
+  });
+});
+
+// A Pi session file: `{type:'session'}` header plus entries. Assistant messages
+// nest provider/model/usage (and responseId) inside `message`, current format.
+function piSession(id: string, entries: string[], cwd = '/Users/x/Developer/sessions'): string {
+  const header = JSON.stringify({ type: 'session', version: 3, id, timestamp: '2026-06-01T10:00:00Z', cwd });
+  return [header, ...entries].join('\n') + '\n';
+}
+
+function piAssistant(opts: {
+  responseId?: string;
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  cacheWrite1h?: number;
+  cost?: number;
+  stopReason?: string;
+  model?: string;
+  provider?: string;
+  timestamp?: string;
+}): string {
+  const usage: Record<string, unknown> = {
+    input: opts.input ?? 100,
+    output: opts.output ?? 50,
+    cacheRead: opts.cacheRead ?? 0,
+    cacheWrite: opts.cacheWrite ?? 0,
+  };
+  if (opts.cacheWrite1h !== undefined) usage.cacheWrite1h = opts.cacheWrite1h;
+  if (opts.cost !== undefined) usage.cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: opts.cost };
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    provider: opts.provider ?? 'anthropic',
+    model: opts.model ?? 'claude-opus-4-8',
+    usage,
+    stopReason: opts.stopReason ?? 'stop',
+  };
+  if (opts.responseId !== undefined) message.responseId = opts.responseId;
+  return JSON.stringify({
+    type: 'message',
+    id: Math.random().toString(36).slice(2, 10),
+    timestamp: opts.timestamp ?? '2026-06-01T10:00:05Z',
+    message,
+  });
+}
+
+describe('parsePi dedup', () => {
+  test('dedupes the same responseId across files (fork/clone copies)', async () => {
+    const root = join(tmp, 'pi-dup');
+    mkdirSync(join(root, '--proj--'), { recursive: true });
+    const turn = piAssistant({ responseId: 'resp_1', cost: 0.5 });
+    // fork/clone rewrites the same response into a new file with a NEW session id.
+    writeFileSync(join(root, '--proj--', 'a.jsonl'), piSession('s-parent', [turn]));
+    writeFileSync(join(root, '--proj--', 'b.jsonl'), piSession('s-fork', [turn]));
+    const events = await parsePi(root);
+    expect(events.length).toBe(1);
+  });
+
+  test('keeps distinct responseIds', async () => {
+    const root = join(tmp, 'pi-distinct');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'a.jsonl'),
+      piSession('s1', [
+        piAssistant({ responseId: 'resp_1', cost: 0.1 }),
+        piAssistant({ responseId: 'resp_2', cost: 0.2 }),
+      ]),
+    );
+    const events = await parsePi(root);
+    expect(events.length).toBe(2);
+  });
+
+  test('counts messages missing responseId (cannot dedupe)', async () => {
+    const root = join(tmp, 'pi-norid');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), piSession('s1', [piAssistant({ cost: 0.1 }), piAssistant({ cost: 0.1 })]));
+    const events = await parsePi(root);
+    expect(events.length).toBe(2);
+    expect(events[0]!.dedupKey).toBeUndefined();
+  });
+
+  test('pi dedup keys are tool-prefixed so they can never collide with claude-code keys', async () => {
+    const root = join(tmp, 'pi-prefix');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), piSession('s1', [piAssistant({ responseId: 'resp_9', cost: 0.1 })]));
+    const events = await parsePi(root);
+    expect(events[0]!.dedupKey).toBe('pi|resp_9');
+  });
+});
+
+describe('parsePi cost handling', () => {
+  test('trusts a positive recorded cost', async () => {
+    const root = join(tmp, 'pi-cost-pos');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), piSession('s1', [piAssistant({ responseId: 'r1', cost: 0.42 })]));
+    const events = await parsePi(root);
+    expect(events[0]!.costUSD).toBe(0.42);
+  });
+
+  test('a recorded $0 cost with real tokens falls through to the pricing engine', async () => {
+    // Pi logs cost.total = 0 when it has no rate for a model; trusting it would
+    // silently bill the tokens at $0 and mute the unpriced-model warning.
+    const root = join(tmp, 'pi-cost-zero');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), piSession('s1', [piAssistant({ responseId: 'r1', cost: 0, input: 500 })]));
+    const events = await parsePi(root);
+    expect(events.length).toBe(1);
+    expect(events[0]!.costUSD).toBeUndefined();
+  });
+
+  test('a missing cost leaves costUSD unset for downstream pricing', async () => {
+    const root = join(tmp, 'pi-cost-missing');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), piSession('s1', [piAssistant({ responseId: 'r1' })]));
+    const events = await parsePi(root);
+    expect(events[0]!.costUSD).toBeUndefined();
+  });
+
+  test('carries cacheWrite1h so the 1h premium can be priced downstream', async () => {
+    const root = join(tmp, 'pi-1h');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'a.jsonl'),
+      piSession('s1', [piAssistant({ responseId: 'r1', cacheWrite: 1000, cacheWrite1h: 700, cost: 0.2 })]),
+    );
+    const events = await parsePi(root);
+    expect(events[0]!.tokens.cacheWrite).toBe(1000);
+    expect(events[0]!.tokens.cacheWrite1h).toBe(700);
+  });
+});
+
+describe('parsePi zero-usage turns', () => {
+  test('skips aborted/error turns with all-zero usage and $0 cost', async () => {
+    const root = join(tmp, 'pi-zero');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'a.jsonl'),
+      piSession('s1', [
+        piAssistant({ responseId: 'r1', input: 0, output: 0, cost: 0, stopReason: 'aborted' }),
+        piAssistant({ responseId: 'r2', cost: 0.1 }),
+      ]),
+    );
+    const events = await parsePi(root);
+    expect(events.length).toBe(1);
+    expect(events[0]!.dedupKey).toBe('pi|r2');
+  });
+});
+
+describe('parsePi compaction and branch_summary usage', () => {
+  const compaction = (usage?: Record<string, unknown>): string =>
+    JSON.stringify({
+      type: 'compaction',
+      id: 'c1',
+      parentId: 'p1',
+      timestamp: '2026-06-01T10:10:00Z',
+      summary: 'earlier work…',
+      tokensBefore: 50000,
+      ...(usage ? { usage } : {}),
+    });
+
+  test('counts summary usage, attributed to the current provider/model', async () => {
+    const root = join(tmp, 'pi-compaction');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'a.jsonl'),
+      piSession('s1', [
+        piAssistant({ responseId: 'r1', cost: 0.1, model: 'claude-opus-4-8' }),
+        compaction({ input: 120000, output: 900, cacheRead: 0, cacheWrite: 0, cost: { total: 0.75 } }),
+      ]),
+    );
+    const events = await parsePi(root);
+    expect(events.length).toBe(2);
+    const summary = events[1]!;
+    expect(summary.model).toBe('claude-opus-4-8');
+    expect(summary.provider).toBe('anthropic');
+    expect(summary.tokens.input).toBe(120000);
+    expect(summary.costUSD).toBe(0.75);
+  });
+
+  test('a model_change entry retargets summary attribution', async () => {
+    const root = join(tmp, 'pi-compaction-model-change');
+    mkdirSync(root, { recursive: true });
+    const modelChange = JSON.stringify({
+      type: 'model_change',
+      id: 'mc1',
+      parentId: null,
+      timestamp: '2026-06-01T10:09:00Z',
+      provider: 'openrouter',
+      modelId: 'moonshotai/kimi-k3',
+    });
+    writeFileSync(
+      join(root, 'a.jsonl'),
+      piSession('s1', [
+        modelChange,
+        compaction({ input: 1000, output: 10, cacheRead: 0, cacheWrite: 0, cost: { total: 0.02 } }),
+      ]),
+    );
+    const events = await parsePi(root);
+    expect(events.length).toBe(1);
+    expect(events[0]!.provider).toBe('openrouter');
+    expect(events[0]!.model).toBe('moonshotai/kimi-k3');
+  });
+
+  test('legacy compactions without usage still emit nothing', async () => {
+    const root = join(tmp, 'pi-compaction-legacy');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'a.jsonl'), piSession('s1', [compaction()]));
+    expect(await parsePi(root)).toEqual([]);
+  });
+});
+
+describe('parsePi subagent runs', () => {
+  const PARENT = '019fbd40-44c8-7e38-8dab-28f8f12801ee';
+
+  test('attributes a nested run-N transcript to the parent session and tags it', async () => {
+    const root = join(tmp, 'pi-subagent');
+    const runDir = join(root, '--proj--', `2026-06-01T10-00-00-000Z_${PARENT}`, '5c46dd16', 'run-0');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(
+      join(runDir, 'session.jsonl'),
+      piSession('inner-session-id', [piAssistant({ responseId: 'r1', cost: 0.3 })]),
+    );
+    const events = await parsePi(root);
+    expect(events.length).toBe(1);
+    expect(events[0]!.sessionId).toBe(PARENT);
+    expect(events[0]!.agent).toEqual({ id: '5c46dd16/run-0', type: 'subagent' });
+  });
+
+  test('a top-level session is not tagged', async () => {
+    const root = join(tmp, 'pi-toplevel');
+    mkdirSync(join(root, '--proj--'), { recursive: true });
+    writeFileSync(
+      join(root, '--proj--', `2026-06-01T10-00-00-000Z_${PARENT}.jsonl`),
+      piSession(PARENT, [piAssistant({ responseId: 'r1', cost: 0.3 })]),
+    );
+    const events = await parsePi(root);
+    expect(events[0]!.sessionId).toBe(PARENT);
+    expect(events[0]!.agent).toBeUndefined();
   });
 });

--- a/src/report/parsers/pi.ts
+++ b/src/report/parsers/pi.ts
@@ -1,7 +1,24 @@
-// VENDORED VERBATIM from tokenmaxing/src/parsers/pi.ts — do not edit logic here; keep in sync. Public contract: schemaVersion 2.
+// Sessions-owned (forked from tokenmaxing's parser — no longer byte-comparable with upstream).
+// Local divergences from the vendored original, in emit order below:
+//   - nested subagent transcripts (`<project>/<ts>_<parentSession>/<dispatch>/run-N/*.jsonl`)
+//     are attributed to the PARENT session and tagged as subagent dispatches, mirroring
+//     how claude-code.ts treats `<session>/subagents/` — their tokens were always
+//     counted (the walk recurses), but as phantom independent sessions;
+//   - compaction / branch_summary entries that carry `usage` are counted (Pi ≥0.83
+//     writes the summarization LLM spend there), attributed to the session's current
+//     provider/model since the entry does not store one;
+//   - all-zero-usage assistant turns (aborted/error) are skipped, matching Pi's own
+//     compaction accounting, so no-op turns don't inflate message/hour counts;
+//   - assistant messages emit a dedupKey from `message.responseId`, so /fork and
+//     /clone copies of the same API response are counted once (mirrors claude-code.ts);
+//   - `cacheWrite1h` is carried so the 1h cache-creation premium prices correctly;
+//   - a recorded cost is trusted only when > 0: a $0 total for real tokens means Pi
+//     had no rate for the model, and passing it through would short-circuit
+//     computeCost and its unpriced-model warning (same split as opencode.ts).
 import type { UsageEvent } from './types.ts';
 import { readJsonlLines } from './util.ts';
 import { walkJsonl, type WalkOptions } from './walk.ts';
+import { dedupeEvents } from './claude-code.ts';
 
 interface PiSessionLine {
   type: 'session';
@@ -13,15 +30,28 @@ interface PiUsage {
   output?: number;
   cacheRead?: number;
   cacheWrite?: number;
+  cacheWrite1h?: number;
   cost?: { total?: number };
 }
 interface PiMessageLine {
   type: 'message';
   timestamp: string;
   // Current Pi nests provider/model/usage inside `message`; older logs put them at the top level.
-  message?: { role?: string; provider?: string; model?: string; usage?: PiUsage };
+  message?: { role?: string; provider?: string; model?: string; usage?: PiUsage; responseId?: string };
   provider?: string;
   model?: string;
+  usage?: PiUsage;
+}
+interface PiModelChangeLine {
+  type: 'model_change';
+  provider?: string;
+  modelId?: string;
+}
+// CompactionEntry / BranchSummaryEntry: `usage` is the LLM spend of generating the
+// summary — "included in session token and cost totals" per Pi's session-format doc.
+interface PiSummaryLine {
+  type: 'compaction' | 'branch_summary';
+  timestamp: string;
   usage?: PiUsage;
 }
 
@@ -31,22 +61,115 @@ function isSession(v: unknown): v is PiSessionLine {
 function isMessage(v: unknown): v is PiMessageLine {
   return !!v && typeof v === 'object' && (v as { type?: unknown }).type === 'message';
 }
+function isModelChange(v: unknown): v is PiModelChangeLine {
+  return !!v && typeof v === 'object' && (v as { type?: unknown }).type === 'model_change';
+}
+function isSummary(v: unknown): v is PiSummaryLine {
+  if (!v || typeof v !== 'object') return false;
+  const t = (v as { type?: unknown }).type;
+  return t === 'compaction' || t === 'branch_summary';
+}
+
+/** The agent type used for Pi subagent runs. Pi does not record the dispatched
+ *  agent's name in the transcript path, so every dispatch shares this label. */
+export const PI_SUBAGENT_TYPE = 'subagent';
+
+// Pi writes dispatched subagent transcripts to
+// `<project>/<ts>_<parentSessionId>/<dispatchHash>/run-<n>/<file>.jsonl`.
+const UUID = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+const SUBAGENT_RUN = new RegExp(
+  `[/\\\\][^/\\\\]*_(${UUID})[/\\\\]([^/\\\\]+)[/\\\\](run-\\d+)[/\\\\][^/\\\\]+\\.jsonl$`,
+  'i',
+);
+
+const totalTokens = (u: PiUsage): number => (u.input ?? 0) + (u.output ?? 0) + (u.cacheRead ?? 0) + (u.cacheWrite ?? 0);
+const recordedCost = (u: PiUsage): number | undefined =>
+  typeof u.cost?.total === 'number' && u.cost.total > 0 ? u.cost.total : undefined;
+
+function toEvent(opts: {
+  provider: string;
+  model: string;
+  timestamp: string;
+  sessionId: string;
+  projectPath?: string;
+  usage: PiUsage;
+  dedupKey?: string;
+  agent?: { id: string; type: string };
+}): UsageEvent {
+  const { usage } = opts;
+  const cost = recordedCost(usage);
+  return {
+    tool: 'pi',
+    provider: opts.provider,
+    model: opts.model,
+    timestamp: opts.timestamp,
+    sessionId: opts.sessionId,
+    projectPath: opts.projectPath,
+    ...(opts.dedupKey ? { dedupKey: opts.dedupKey } : {}),
+    ...(opts.agent ? { agent: opts.agent } : {}),
+    tokens: {
+      input: usage.input ?? 0,
+      output: usage.output ?? 0,
+      cacheRead: usage.cacheRead ?? 0,
+      cacheWrite: usage.cacheWrite ?? 0,
+      cacheWrite1h: usage.cacheWrite1h ?? 0,
+    },
+    ...(cost !== undefined ? { costUSD: cost } : {}),
+  };
+}
 
 export async function parsePi(root: string, opts: WalkOptions = {}): Promise<UsageEvent[]> {
   const events: UsageEvent[] = [];
   for await (const path of walkJsonl(root, opts)) events.push(...(await parsePiFile(path)));
-  return events;
+  // Fork/clone copies the same responses into a new file, so dedup is cross-file.
+  // The cached path (extract.ts) runs its own dedupeEvents over all tools; this
+  // covers the direct path the same way parseClaudeCode covers its own.
+  return dedupeEvents(events);
 }
 
 /** Parse one session file. Self-contained (the session record is inside it), so
  *  the result is cacheable against the file's mtime. */
 export async function parsePiFile(path: string): Promise<UsageEvent[]> {
   const events: UsageEvent[] = [];
+  const run = SUBAGENT_RUN.exec(path);
+  // A subagent run is billed to the parent session so per-session facets group it
+  // under the work that dispatched it, and tagged so the subagents facet sees it.
+  const parentSessionId = run?.[1];
+  const agent = run ? { id: `${run[2]}/${run[3]}`, type: PI_SUBAGENT_TYPE } : undefined;
   {
     let session: PiSessionLine | null = null;
+    // Compaction/branch_summary entries do not store the model that generated the
+    // summary, so track the session's current provider/model while scanning.
+    let curProvider: string | undefined;
+    let curModel: string | undefined;
     for await (const line of readJsonlLines(path)) {
       if (isSession(line)) {
         session = line;
+        continue;
+      }
+      if (isModelChange(line)) {
+        if (line.provider) curProvider = line.provider;
+        if (line.modelId) curModel = line.modelId;
+        continue;
+      }
+      if (isSummary(line)) {
+        const usage = line.usage;
+        if (!usage || !curProvider || !curModel || !session) continue;
+        if (totalTokens(usage) === 0 && recordedCost(usage) === undefined) continue;
+        events.push(
+          toEvent({
+            provider: curProvider,
+            model: curModel,
+            timestamp: line.timestamp,
+            sessionId: parentSessionId ?? session.id,
+            projectPath: session.cwd,
+            usage,
+            // Fork/clone copies these entries verbatim (new entry id, same content),
+            // so the stable identity is the entry's own timestamp + usage signature.
+            dedupKey: `pi|${line.type}|${line.timestamp}|${totalTokens(usage)}|${usage.cost?.total ?? ''}`,
+            agent,
+          }),
+        );
         continue;
       }
       if (!isMessage(line)) continue;
@@ -57,21 +180,26 @@ export async function parsePiFile(path: string): Promise<UsageEvent[]> {
       const model = line.message?.model ?? line.model;
       const usage = line.message?.usage ?? line.usage;
       if (!usage || !provider || !model || !session) continue;
-      events.push({
-        tool: 'pi',
-        provider,
-        model,
-        timestamp: line.timestamp,
-        sessionId: session.id,
-        projectPath: session.cwd,
-        tokens: {
-          input: usage.input ?? 0,
-          output: usage.output ?? 0,
-          cacheRead: usage.cacheRead ?? 0,
-          cacheWrite: usage.cacheWrite ?? 0,
-        },
-        costUSD: usage.cost?.total,
-      });
+      curProvider = provider;
+      curModel = model;
+      // Aborted/error turns log all-zero usage (and $0); Pi's own accounting skips
+      // them, and counting them would inflate message/hour stats for free no-ops.
+      if (totalTokens(usage) === 0 && recordedCost(usage) === undefined) continue;
+      const responseId = line.message?.responseId;
+      events.push(
+        toEvent({
+          provider,
+          model,
+          timestamp: line.timestamp,
+          sessionId: parentSessionId ?? session.id,
+          projectPath: session.cwd,
+          usage,
+          // One key per API response; the tool prefix keeps Pi keys from ever
+          // colliding with claude-code's `${message.id}|${requestId}` keys.
+          ...(responseId ? { dedupKey: `pi|${responseId}` } : {}),
+          agent,
+        }),
+      );
     }
   }
   return events;

--- a/src/report/parsers/types.ts
+++ b/src/report/parsers/types.ts
@@ -20,7 +20,8 @@ export interface UsageEvent {
   costUSD?: number; // only set when source pre-computes (Pi); otherwise computed downstream
   /** Set when the event came from a dispatched subagent rather than the main loop.
    *  `id` is the dispatch id (one per Task/Agent invocation); `type` is the agent
-   *  type ('Explore', 'general-purpose', a plugin agent, …). Claude Code only. */
+   *  type ('Explore', 'general-purpose', a plugin agent, …) — Pi does not record
+   *  the dispatched agent's name, so its runs all carry the 'subagent' type. */
   agent?: { id: string; type: string };
   /** git branch recorded on the message, when the tool logs one. Claude Code only. */
   branch?: string;

--- a/src/report/pricing.test.ts
+++ b/src/report/pricing.test.ts
@@ -273,4 +273,27 @@ describe('family fallback', () => {
     computeCost('claude-opus-4-8', counts({ input: 1_000_000 }));
     expect(drainPricingWarnings()).toEqual([]);
   });
+
+  // Pi records bare OpenRouter model ids ('moonshotai/kimi-k3'); the snapshot
+  // keys those families with a provider prefix, so the fallback must draw
+  // candidates from the full map, not just BUILTIN_OVERRIDES.
+  test('an unreleased kimi is billed at the newest kimi rate, and flagged', () => {
+    expect(find('moonshotai/kimi-k3')).toBeUndefined();
+    const cost = computeCost('moonshotai/kimi-k3', counts({ input: 1_000_000 }));
+    expect(cost).toBeGreaterThan(0);
+    const [w] = drainPricingWarnings();
+    expect(w!.model).toBe('moonshotai/kimi-k3');
+    expect(w!.pricedAs).toMatch(/kimi-k2\.5/i);
+  });
+
+  test('an unreleased glm is billed at the newest glm rate', () => {
+    expect(find('z-ai/glm-5.2')).toBeUndefined();
+    expect(findFamily('z-ai/glm-5.2')?.key).toBe('openrouter/z-ai/glm-5.1');
+    expect(computeCost('z-ai/glm-5.2', counts({ input: 1_000_000 }))).toBeGreaterThan(0);
+  });
+
+  test('a prefixed stem only matches at a path-segment boundary', () => {
+    // 'kimi-k' must not match inside an unrelated id like 'fookimi-k3'.
+    expect(findFamily('fookimi-k3')).toBeUndefined();
+  });
 });

--- a/src/report/pricing.ts
+++ b/src/report/pricing.ts
@@ -310,9 +310,27 @@ interface FamilyMatch {
 
 const FAMILY_STEMS = ['claude-fable', 'claude-opus', 'claude-sonnet', 'claude-haiku', 'gpt-5'];
 
+// Families Pi reaches through OpenRouter (`moonshotai/kimi-k3`, `z-ai/glm-5.2`).
+// Their released versions live in the LiteLLM snapshot under provider-prefixed
+// keys (`openrouter/moonshotai/kimi-k2.5`), not in BUILTIN_OVERRIDES, so these
+// stems draw candidates from the full map instead. The stem must sit at a
+// path-segment boundary (start or right after `/`) so a stem like `glm-` can
+// never match inside an unrelated id.
+const PREFIXED_FAMILY_STEMS = ['kimi-k', 'glm-'];
+
+// Index of `stem` in `normalizedKey` where it begins a path segment, or -1.
+function stemIndexAtBoundary(normalizedKey: string, stem: string): number {
+  let from = 0;
+  for (;;) {
+    const idx = normalizedKey.indexOf(stem, from);
+    if (idx < 0) return -1;
+    if (idx === 0 || normalizedKey[idx - 1] === '/') return idx;
+    from = idx + 1;
+  }
+}
+
 // Trailing numeric segments after the stem, as numbers: `claude-opus-4-8` → [4,8].
-function versionSegments(normalizedKey: string, stem: string): number[] {
-  const rest = normalizedKey.slice(stem.length);
+function versionSegments(rest: string): number[] {
   const out: number[] = [];
   for (const part of rest.split('-')) {
     if (part.length === 0) continue;
@@ -334,13 +352,28 @@ function compareVersions(a: number[], b: number[]): number {
 function findFamilyUncached(modelId: string): FamilyMatch | undefined {
   const normalized = normalizedPricingKey(modelId);
   const stem = FAMILY_STEMS.find((s) => normalized.includes(s));
-  if (!stem) return undefined;
+  if (stem) return newestInFamily(stem, Object.keys(BUILTIN_OVERRIDES));
+  const prefixed = PREFIXED_FAMILY_STEMS.find((s) => stemIndexAtBoundary(normalized, s) >= 0);
+  if (prefixed) return newestInFamily(prefixed, Object.keys(PRICING_MAP));
+  return undefined;
+}
+
+function newestInFamily(stem: string, candidates: string[]): FamilyMatch | undefined {
   let best: { key: string; version: number[] } | undefined;
-  for (const key of Object.keys(BUILTIN_OVERRIDES)) {
+  for (const key of candidates) {
     const nk = normalizedPricingKey(key);
-    if (!nk.startsWith(stem)) continue;
-    const version = versionSegments(nk, stem);
-    if (!best || compareVersions(version, best.version) > 0) best = { key, version };
+    const idx = stemIndexAtBoundary(nk, stem);
+    if (idx < 0) continue;
+    const version = versionSegments(nk.slice(idx + stem.length));
+    // Later version wins; on a version tie the lexicographically smaller key does,
+    // so the winner is deterministic rather than map-order (mirrors findUncached).
+    if (
+      !best ||
+      compareVersions(version, best.version) > 0 ||
+      (compareVersions(version, best.version) === 0 && key < best.key)
+    ) {
+      best = { key, version };
+    }
   }
   // Resolve through the live map so a runtime price for the winning key is used
   // rather than the frozen override it was selected by.

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -7,10 +7,10 @@ import { extractSessionMetadata, getCwdFromSession, firstPrompt, contentMatches,
 import { cwdUnder } from './repo';
 import { discoverOpencodeSessions } from './opencode';
 import { readSessionLines } from './session-io';
+import { getPiSessionsDir } from './paths';
 
 const home = homedir();
 const CLAUDE_DIR = join(home, '.claude/projects');
-const PI_DIR = join(home, '.pi/agent/sessions');
 const CODEX_DIR = join(home, '.codex/sessions');
 
 async function processSession(
@@ -136,7 +136,10 @@ export async function scanSessions(
   }
   if (toolFilter === '' || toolFilter === 'pi') {
     const piPrefix = repoRoot ? `-${claudePrefix}-` : '--';
-    scans.push(scanDir(PI_DIR, piPrefix, 'pi', repoRoot, searchAll, normalizedQuery));
+    // Resolved per call (not frozen at import) via the shared resolver so the
+    // scanner honors the same SESSIONS_PI_DIR / PI_CODING_AGENT_* overrides as
+    // the index and the report.
+    scans.push(scanDir(getPiSessionsDir(), piPrefix, 'pi', repoRoot, searchAll, normalizedQuery));
   }
   if (toolFilter === '' || toolFilter === 'codex') {
     scans.push(scanDir(CODEX_DIR, '', 'codex', repoRoot, searchAll, normalizedQuery));


### PR DESCRIPTION
## Summary

Pi usage tracking was significantly under- and mis-reporting costs and tokens. This PR fixes the session-directory resolution, overhauls the Pi usage parser, and adds family-fallback pricing for Pi's OpenRouter models.

**What was broken:**

- **Fork/clone double counting** (`pi-fork-clone-usage-double-counted`, `pi-no-dedup-key`): forked Pi sessions clone their parent's events, and the parser had no dedup key, so the same usage was counted once per fork. Events now carry a content-derived dedup key so cloned history is counted exactly once.
- **Compaction usage ignored** (`pi-compaction-usage-ignored`): compaction events carry real API usage but were skipped entirely; they are now counted.
- **Zero-usage / aborted events** (`pi-zero-usage-aborted-events`): aborted turns with zero usage previously produced noise/skew; they are now handled explicitly.
- **Cost handling** (`pi-cost-zero-trusted`, `pi-pricing-fallback-zero`): a reported cost of `0` was trusted as authoritative, and models without a pricing entry silently priced to `$0`. Zero costs now fall through to computed pricing, and unpriced models use a family-based estimate instead of vanishing.
- **`cacheWrite1h` dropped** (`pi-cachewrite1h-dropped`): 1-hour cache-write tokens were discarded; they are now included in cache-write accounting.
- **Sessions dir resolution** (`pi-root-ignores-env-overrides`): the Pi sessions root was hardcoded, ignoring Pi's documented env overrides. The dir is now resolved once via a shared helper honoring those overrides.
- **Subagent attribution** (`pi-subagent-runs-not-attributed`, `pi-subagent-sessions-report-vs-index-inconsistency`): subagent runs weren't attributed to their parent project/session, and the report vs. index views disagreed about which sessions existed. Subagent sessions are now discovered and attributed consistently.
- **Unpriced Kimi/GLM models** (`kimi-glm-unpriced-family-gap`): Pi's OpenRouter `kimi-k*` and `glm-*` models had no pricing entries and reported `$0`. A family-stem fallback now prices them from the closest known family rates, with a loud `pricedAs` warning.
- **Provider labels** (`provider-label-missing-pi-providers`, `openrouter-provider-label-missing`): Pi-specific providers and OpenRouter lacked human-readable provider labels in facets/reports; labels are now emitted.

## Changes

- `src/paths.ts` / `src/paths.test.ts`: resolve the Pi sessions dir once, honoring Pi's documented env overrides (`cefd2b3`).
- `src/report/parsers/pi.ts`, `src/report/extract.ts`, `src/report/event-cache.ts`, `src/report/aggregate.ts`, `src/report/parsers/types.ts`, `src/scanner.ts`, `src/cache.ts`: parser overhaul — dedup keys for forked/cloned events, compaction usage counted, aborted/zero-usage events handled, `cacheWrite1h` included, subagent runs attributed to their parents (`9af43ec`).
- `src/report/pricing.ts`, `src/report/facets.ts`, `src/report/pricing.test.ts`: family-stem pricing fallback for `kimi-k*`/`glm-*`, zero-cost fallthrough to computed pricing, provider labels for Pi providers and OpenRouter (`96b26e1`).
- `src/report/parsers.test.ts`: extensive new parser coverage for the above.

## Testing

- `bun test` — all tests pass
- `bun typecheck` — passes
- `bun lint` — passes

## Intentionally skipped (low severity)

- **`kimi-glm-unpriced-family-gap` (BUILTIN_OVERRIDES part)**: fixed via the family-stem fallback (kimi-k/glm- stems drawing from the full pricing map) rather than adding hand-verified `BUILTIN_OVERRIDES` rates — no verifiable published rates were available to invent, and the family estimate path now covers these models with a loud `pricedAs` warning. `cacheStats` also now accepts a family match so kimi-k3/glm events contribute to `cache.savedUSD`.
