### PR TITLE
feat: preview session content in the CLI selector

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,14 @@ if (Bun.argv.includes('--clear-cache')) {
   process.exit(0);
 }
 
+// Hidden: invoked by the selector's fzf --preview / builtin preview key. Reads one
+// session file and prints a compact conversation rendering. Not for users directly.
+if (Bun.argv[2] === '--preview' && Bun.argv[3]) {
+  const { renderPreview } = await import('./src/preview');
+  process.stdout.write(renderPreview(Bun.argv[3]) + '\n');
+  process.exit(0);
+}
+
 // Commands dispatch on the positional word only. Matching anywhere in argv
 // (the old behavior) let a flag VALUE fire a command — `sessions wrapped
 // --out cleanup` would have uninstalled the plugin and wiped the index.
@@ -126,12 +134,15 @@ if (args.searchQuery) process.stderr.write('\r\x1b[K');
 const selection = await selectSession(lines);
 if (!selection) process.exit(0);
 
+// TSV layout: filePath, cwd, tool, sessionId, exists, prompt, display
+// (filePath leads so fzf --preview can reference {1}; the display column is what
+// fzf shows and the builtin slices — both skip the leading metadata fields).
 const parts = selection.split('\t');
-const fullPath = parts[0]!;
-const tool = parts[1]!;
-const sessionId = parts[2]!;
-const exists = parts[3]!;
-const prompt = parts[4]!;
+const fullPath = parts[1]!;
+const tool = parts[2]!;
+const sessionId = parts[3]!;
+const exists = parts[4]!;
+const prompt = parts[5]!;;
 const dirName = basename(fullPath);
 
 process.stderr.write('\n');

--- a/index.ts
+++ b/index.ts
@@ -142,7 +142,7 @@ const fullPath = parts[1]!;
 const tool = parts[2]!;
 const sessionId = parts[3]!;
 const exists = parts[4]!;
-const prompt = parts[5]!;;
+const prompt = parts[5]!;
 const dirName = basename(fullPath);
 
 process.stderr.write('\n');

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -63,9 +63,10 @@ describe('formatLine fork badge', () => {
       { ...piResult, branches: 3, displayText: 'a prompt long enough to be truncated at sixty columns for sure' },
       60,
     );
-    // Field 6 of the TSV is the display string (field 5 is the untruncated prompt,
-    // consumed positionally by index.ts — its rawness is load-bearing).
-    const display = line.split('\t')[5]!;
+    // Field 7 of the TSV is the display string (field 6 is the untruncated prompt,
+    // consumed positionally by index.ts — its rawness is load-bearing). filePath
+    // now leads as field 1 so fzf --preview can reference {1}.
+    const display = line.split('\t')[6]!;
     expect(display).toContain('⑂3');
     expect(display).toContain('…'); // the prompt absorbed the truncation, not the badge
     expect(display).not.toContain('sixty columns for sure');

--- a/src/display.ts
+++ b/src/display.ts
@@ -47,8 +47,10 @@ export function formatLine(r: SessionResult, cols: number): string {
 
   const display = `${dot} ${C.bold}${dirName}${C.reset}  ${toolBadge}  ${C.dim}${rel}${C.reset}  ${msgs ? msgs + '  ' : ''}${warn}${hitBadge}${forkBadge}${truncated}`;
 
-  // tab-separated: cwd, tool, sessionId, exists, prompt, display
-  return `${r.cwd}\t${r.tool}\t${r.sessionId}\t${r.exists ? 'exists' : 'deleted'}\t${prompt}\t${display}`;
+  // tab-separated: filePath, cwd, tool, sessionId, exists, prompt, display
+  // filePath leads so the selector's fzf --preview can reference {1} directly;
+  // --with-nth skips it (and the other metadata fields) to show only `display`.
+  return `${r.filePath}\t${r.cwd}\t${r.tool}\t${r.sessionId}\t${r.exists ? 'exists' : 'deleted'}\t${prompt}\t${display}`;
 }
 
 /**

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,0 +1,91 @@
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { C, toolColor } from './colors';
+import { type Tool } from './types';
+import { getSessionMessages } from './parser';
+import { readSessionLines } from './session-io';
+import { isOpencodePath } from './opencode';
+import { getPiSessionsDir } from './paths';
+
+/**
+ * Infer the tool from a session file path. The selector TSV now carries filePath,
+ * so the preview subcommand gets a path with no tool tag and must recover it from
+ * which session root the path lives under — same roots the scanner indexes.
+ */
+function toolFromPath(filePath: string): Tool | null {
+  if (isOpencodePath(filePath)) return 'opencode';
+  const home = homedir();
+  const claudeDir = process.env.SESSIONS_CLAUDE_DIR || join(home, '.claude/projects');
+  const codexDir = process.env.SESSIONS_CODEX_DIR || join(home, '.codex/sessions');
+  const piDir = getPiSessionsDir();
+  const dir = dirname(filePath);
+  if (dir.startsWith(claudeDir)) return 'claude';
+  if (dir.startsWith(codexDir)) return 'codex';
+  if (dir.startsWith(piDir)) return 'pi';
+  return null;
+}
+
+/** Wrap text to a width, preserving words. Blank lines kept as empty strings. */
+function wrap(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const out: string[] = [];
+  for (const para of text.split('\n')) {
+    if (para.trim() === '') {
+      out.push('');
+      continue;
+    }
+    let line = '';
+    for (const word of para.split(/\s+/)) {
+      if (!line) line = word;
+      else if (line.length + 1 + word.length <= width) line += ' ' + word;
+      else {
+        out.push(line);
+        line = word;
+      }
+    }
+    out.push(line);
+  }
+  return out;
+}
+
+const PREVIEW_LIMIT = 40; // cap messages so giant transcripts don't flood the pane
+const PREVIEW_WIDTH = 78; // fzf wraps the pane anyway; this keeps role labels aligned
+
+/** Render a session transcript as a compact, read-only conversation preview. */
+export function renderPreview(filePath: string): string {
+  const tool = toolFromPath(filePath);
+  if (!tool) return `${C.dim}(unrecognized session path)${C.reset}`;
+  const lines = readSessionLines(filePath, tool);
+  if (lines.length === 0) return `${C.dim}(empty or unreadable session)${C.reset}`;
+
+  const messages = getSessionMessages(lines);
+  if (messages.length === 0) return `${C.dim}(no messages parsed)${C.reset}`;
+
+  const start = Math.max(0, messages.length - PREVIEW_LIMIT);
+  const page = messages.slice(start);
+
+  const out: string[] = [];
+  const tc = toolColor[tool] ?? '';
+  out.push(
+    `${C.bold}${tc}${tool}${C.reset} ${C.dim}· ${messages.length} message${messages.length === 1 ? '' : 's'}${C.reset}${start > 0 ? ` ${C.dim}(showing last ${page.length})${C.reset}` : ''}`,
+  );
+  out.push(`${C.dim}${filePath}${C.reset}`);
+  out.push('');
+
+  // Indent leaves room for a 2-char branch marker + "you "/"ai  " label.
+  const bodyWidth = PREVIEW_WIDTH - 6;
+
+  for (const m of page) {
+    const isUser = m.role === 'user';
+    const label = isUser ? `${C.bold}you ${C.reset}` : `${C.cyan}ai  ${C.reset}`;
+    const prefix = m.branch === 'abandoned' ? `${C.dim}⑂${C.reset} ` : ' ';
+    const trimmed = m.text.length > 600 ? m.text.slice(0, 599) + '…' : m.text;
+    const rows = wrap(trimmed, bodyWidth);
+    for (let i = 0; i < Math.min(rows.length, 12); i++) {
+      out.push(`${prefix}${label}${rows[i]}`);
+    }
+    if (rows.length > 12) out.push(`${prefix}${C.dim}…${C.reset}`);
+  }
+
+  return out.join('\n');
+}

--- a/src/select.ts
+++ b/src/select.ts
@@ -9,18 +9,23 @@ export async function selectSession(lines: string[]): Promise<string | null> {
 }
 
 async function selectWithFzf(lines: string[]): Promise<string | null> {
+  // --preview runs the binary's hidden --preview subcommand on field 1 (filePath).
+  // {1:q} shell-quotes the path so spaces/special chars don't break the command.
+  const previewCmd = buildPreviewShellCommand();
   const proc = Bun.spawn(
     [
       'fzf',
       '--exact',
       '--ansi',
-      '--header=Select a session  ● exists  ○ deleted',
-      '--with-nth=6..',
+      '--header=Select a session  ● exists  ○ deleted  · ctrl-p preview',
+      '--with-nth=7..',
       '--delimiter=\t',
       '--reverse',
       '--height=~60%',
       '--no-info',
-      '--preview-window=hidden',
+      '--preview-window=hidden:wrap',
+      '--bind=ctrl-p:toggle-preview',
+      `--preview=${previewCmd}`,
     ],
     {
       stdin: 'pipe',
@@ -42,13 +47,29 @@ async function selectWithFzf(lines: string[]): Promise<string | null> {
   return output.trim() || null;
 }
 
+/** The argv prefix that re-enters this binary: `bun index.ts` when run from source,
+ *  the compiled binary itself otherwise. fzf --preview runs it via `sh -c`. */
+function previewArgv(): string[] {
+  const script = process.argv[1] ?? '';
+  if (/\.(ts|js|mjs|cjs)$/.test(script)) return [process.argv[0]!, script, '--preview'];
+  return [process.argv[0]!, '--preview'];
+}
+
+/** Preview command string for fzf `--preview`. {1} is fzf's field-1 placeholder —
+ *  fzf auto single-quotes the expansion, so no manual quoting of the path is needed.
+ *  The exe/script paths come from this process's own argv and carry no spaces in
+ *  practice (homebrew / install dirs), so they're passed bare. */
+function buildPreviewShellCommand(): string {
+  return [...previewArgv(), '{1}'].join(' ');
+}
+
 async function selectBuiltin(lines: string[]): Promise<string | null> {
   const maxDisplay = Math.min(lines.length, 20);
 
   process.stderr.write(`${C.bold}Select a session${C.reset}  ● exists  ○ deleted\n\n`);
 
   for (let i = 0; i < maxDisplay; i++) {
-    const display = lines[i]!.split('\t').slice(5).join('\t');
+    const display = lines[i]!.split('\t').slice(6).join('\t');
     process.stderr.write(`  ${C.dim}${String(i + 1).padStart(2)}${C.reset}  ${display}\n`);
   }
   if (lines.length > maxDisplay) {
@@ -57,7 +78,7 @@ async function selectBuiltin(lines: string[]): Promise<string | null> {
     );
   }
 
-  process.stderr.write(`\n${C.bold}Enter number (1-${maxDisplay})${C.reset}: `);
+  process.stderr.write(`\n${C.bold}Enter number (1-${maxDisplay})${C.reset}, or ${C.cyan}<num>p${C.reset} to preview: `);
 
   const reader = Bun.stdin.stream().getReader();
   const { value } = await reader.read();
@@ -65,8 +86,29 @@ async function selectBuiltin(lines: string[]): Promise<string | null> {
 
   if (!value) return null;
   const input = new TextDecoder().decode(value).trim();
+  const previewMatch = input.match(/^(\d+)p$/i);
+  if (previewMatch) {
+    const num = parseInt(previewMatch[1]!, 10);
+    if (isNaN(num) || num < 1 || num > maxDisplay) return null;
+    await showBuiltinPreview(lines[num - 1]!);
+    return selectBuiltin(lines); // re-prompt after previewing
+  }
+
   const num = parseInt(input, 10);
   if (isNaN(num) || num < 1 || num > maxDisplay) return null;
 
   return lines[num - 1] ?? null;
+}
+
+/** Shell out to the hidden --preview subcommand and print its output above the next prompt. */
+async function showBuiltinPreview(line: string): Promise<void> {
+  const filePath = line.split('\t')[0]!;
+  process.stderr.write('\n');
+  const proc = Bun.spawn([...previewArgv(), filePath], {
+    stdout: 'pipe',
+    stderr: 'inherit',
+  });
+  const text = await new Response(proc.stdout).text();
+  process.stderr.write(text);
+  process.stderr.write(`\n${C.dim}──────────${C.reset}\n\n`);
 }

--- a/src/select.ts
+++ b/src/select.ts
@@ -78,7 +78,9 @@ async function selectBuiltin(lines: string[]): Promise<string | null> {
     );
   }
 
-  process.stderr.write(`\n${C.bold}Enter number (1-${maxDisplay})${C.reset}, or ${C.cyan}<num>p${C.reset} to preview: `);
+  process.stderr.write(
+    `\n${C.bold}Enter number (1-${maxDisplay})${C.reset}, or ${C.cyan}<num>p${C.reset} to preview: `,
+  );
 
   const reader = Bun.stdin.stream().getReader();
   const { value } = await reader.read();


### PR DESCRIPTION
## Summary

Closes #72.

Adds a preview action to the CLI session selector so users can inspect a session's conversation before restoring it, instead of guessing from the one-line list (the issue's use case: many similarly-named sessions).

## Changes

- **`src/preview.ts`** (new) — `renderPreview(filePath)` infers the tool from the session root, parses messages via the existing `getSessionMessages`, and renders a compact `you`/`ai` conversation (last 40 messages, wrapped). Pi branch markers are preserved.
- **`index.ts`** — hidden `sessions --preview <filePath>` subcommand; added `filePath` as field 1 of the selection TSV so fzf can reference it; reads the new TSV field offsets.
- **`src/display.ts`** — `formatLine` emits `filePath` as the leading TSV field.
- **`src/select.ts`** — fzf path: `--with-nth=7..`, `--preview=...{1}`, `--bind=ctrl-p:toggle-preview`, `--preview-window=hidden:wrap`. Builtin path: `<num>p` previews then re-prompts.
- **`src/cli.test.ts`** — display-field index `[5]` to `[6]`.

## UX

- **fzf:** `Ctrl-P` toggles a preview pane (hidden by default) that renders the highlighted session live as the selection moves. The restore flow is unchanged.
- **builtin (no fzf):** typing `<num>p` (e.g. `3p`) prints the preview above a divider and re-prompts; then a plain number selects.

Preview is an opt-in action, not a two-step gate — restore stays the default.

## Test plan

- [x] `bun run typecheck`, `oxlint`, `bun test` (956 pass, 8 corpus skip)
- [x] `sessions --preview` renders a real Claude session conversation
- [x] `sessions --preview` renders a real Pi session with branch markers
- [x] fzf invoked with correct `--preview` / `--with-nth=7..` args; the exact preview command renders when run via `sh -c`
- [x] Manual: `Ctrl-P` opens the preview pane in fzf and renders the highlighted session
