### PR TITLE
feat(site): cover the features shipped since the site launched

### DIFF
--- a/site/src/data/mcp.ts
+++ b/site/src/data/mcp.ts
@@ -35,7 +35,7 @@ const GROUPS: Group[] = [
       {
         name: 'search_sessions',
         blurb:
-          'Ranked search across every session, message-granular. Returns the matching messages, not just the sessions — and a ready-to-run resume command. Top-k, so it is fast and not exhaustive.',
+          'Ranked search across every session, message-granular. Returns the matching messages, not just the sessions — and a ready-to-run resume command. Top-k, so it is fast and not exhaustive. Pi sessions carry their /tree branch count and /fork parentage, so abandoned lines show before you open one.',
       },
       {
         name: 'grep_sessions',
@@ -56,7 +56,7 @@ const GROUPS: Group[] = [
       {
         name: 'get_session_messages',
         blurb:
-          'The exact exchange a search matched — pass the hit index straight through as the offset. Ask for tool calls too and you see what the agent actually did, which the prose usually leaves out.',
+          'The exact exchange a search matched — pass the hit index straight through as the offset. Ask for tool calls too and you see what the agent actually did, which the prose usually leaves out. Pi branch and fork markers ride along, so an abandoned line is visible in the reading.',
       },
     ],
   },

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -69,7 +69,11 @@ const REFUSALS = [
   },
   {
     title: 'Every MCP tool is read-only',
-    body: 'All eight are annotated read-only and none of them writes. Memory is the only thing that persists a decision, and it changes only when you triage a candidate yourself. A store nobody curates is just a log.',
+    body: `All ${toolCount} are annotated read-only and none of them writes. Memory is the only thing that persists a decision, and it changes only when you triage a candidate yourself. A store nobody curates is just a log.`,
+  },
+  {
+    title: 'Memory text is scanned at every boundary',
+    body: 'Secret material, prompt-injection phrasing, and invisible characters never enter the memory store or reach an agent — not from the mine, not from an import, not from another agent’s store. Withholding is loud: you are told what was refused and why, never silently filtered.',
   },
   {
     title: 'Estimates say they are estimates',
@@ -144,7 +148,8 @@ const lede = 'text-[15.5px] leading-[1.62] text-ink-2';
           <p class:list={[lede, 'mt-3 max-w-[58ch]']}>
             Four tools, four layouts, one timeline. This is the list <code
               class="font-mono text-[13.5px] text-ink">sessions</code
-            > pipes into fzf when you run it with no arguments.
+            > pipes into fzf when you run it with no arguments — and Ctrl-P previews the highlighted
+            session’s conversation as you move, so restoring is never a guess from a one-liner.
           </p>
         </SpineNode>
 
@@ -176,7 +181,7 @@ const lede = 'text-[15.5px] leading-[1.62] text-ink-2';
             <RecallFigure />
           </div>
 
-          <!-- The eight tools -->
+          <!-- The tool groups -->
           <div class="mt-14 grid gap-7">
             <h3 class:list={[h3]}>
               {toolCount} tools, grouped by what you are trying to do
@@ -239,8 +244,9 @@ const lede = 'text-[15.5px] leading-[1.62] text-ink-2';
             <p class:list={[lede, 'mt-3 max-w-[62ch]']}>
               Search answers “what happened”. Memory answers “what am I not supposed to have to say
               again” — build conventions, tooling constraints, the rules you have already stated.
-              Candidates are mined from your own transcripts; nothing becomes memory until you say
-              so.
+              Candidates are mined from your own transcripts — or imported from the memory stores
+              your <em>other</em> agents keep, so switching harnesses costs nothing. Either way,
+              nothing becomes memory until you say so.
             </p>
 
             <Panel class="mt-6">
@@ -267,9 +273,11 @@ const lede = 'text-[15.5px] leading-[1.62] text-ink-2';
             </Panel>
 
             <p class="meta-label mt-3 normal-case">
-              Approve with <code class="font-mono">--always-on</code> and a fact is returned for every
-              topic, first — so an agent that truncates drops the conditional tail, never the
-              invariants.
+              <code class="font-mono">memory import --from pi-hermes|claude</code> lands another
+              agent’s durable facts as candidates through the same gates. Approve with{' '}
+              <code class="font-mono">--always-on</code> and a fact is returned for every topic,
+              first — budgeted to 20 entries and 2,000 characters, so the invariants stay few enough
+              to always be read.
             </p>
           </div>
         </SpineNode>

--- a/site/src/pages/reference.astro
+++ b/site/src/pages/reference.astro
@@ -73,12 +73,14 @@ const WRAPPED_FLAGS = [
 const MEMORY_COMMANDS = [
   ['memory mine', 'Mine past sessions for durable facts. --repo scopes, --all mines everything, --since-last only what changed.'],
   ['memory pending', 'Count and preview the untriaged backlog. Reads the store only; never mines.'],
-  ['memory approve <id>', 'Keep a candidate. --always-on exempts it from topic filtering; --scope group:<name> or repo:<path> binds it.'],
+  ['memory documented', 'What is already binding here — CLAUDE.md, AGENTS.md, and Claude Code’s own memory store. Read, never written.'],
+  ['memory approve <id>', 'Keep a candidate. --always-on exempts it from topic filtering (budgeted: 20 entries, 2,000 chars); --scope group:<name> or repo:<path> binds it.'],
   ['memory reject <id>', 'Dismiss a candidate. It stops being emitted.'],
   ['memory snooze <id>', 'Hide a candidate without rejecting it.'],
   ['memory merge <id> <id>…', 'Fold paraphrases into the first id.'],
   ['memory export', 'Write approved memories as a portable bundle. No local paths leave the machine.'],
   ['memory import <path>', 'Merge another author’s bundle in as candidates. Never lands as approved.'],
+  ['memory import --from <source>', 'Import another agent’s memory store — pi-hermes, claude, or all — as candidates through the same gates. --repo sets the repo context.'],
 ];
 
 const cell = 'border-t border-line-soft px-4 py-2.5 align-top';


### PR DESCRIPTION
## What

Brings sessions.engineering current with the five features that shipped after the site launched (#68), plus one refusal that had gone stale.

## The audit

| Feature | PR | Was on the site? |
| --- | --- | --- |
| Cross-agent memory (`get_memory_sources`, `review_agent_memories`, `import --from`) | #79 | Tools listed (drift-guard fix on that PR), but the memory story stopped at "mined from your own transcripts" — the import concept and the CLI row were missing |
| Content scanning + always-on budget | #77 | `--always-on` mentioned, the 20-entry / 2,000-char budget not; scanning nowhere |
| CLI selector preview (Ctrl-P) | #75 | Not mentioned |
| Pi /tree + /fork lineage | #73 | Not mentioned |
| Shareable wrapped image, report card deck | #66, #64 | Already covered ✓ |
| `memory documented` | older | Missing from the reference memory table |
| **"All eight are annotated read-only"** | — | **Stale** — ten tools ship now |

## Changes

- **index.astro**
  - The read-only refusal now computes its count from the shipped tool list (`All ${toolCount}`) — same no-drift discipline as the rest of the page.
  - New fifth refusal card: memory text is scanned at every boundary (secrets, prompt-injection phrasing, invisible characters never enter the store or reach an agent; withholding is loud).
  - The memory section's story now includes importing from other agents' stores, and its closing note carries `import --from pi-hermes|claude` plus the always-on budget.
  - The fzf lede mentions Ctrl-P previews of the highlighted session.
  - The stale "The eight tools" comment no longer states a count.
- **reference.astro** — memory table gains `memory documented` and `memory import --from <source>` rows; the approve row notes the budget.
- **data/mcp.ts** — `search_sessions` blurb covers pi branch counts and /fork parentage; `get_session_messages` blurb covers fork markers.

Verified in the built HTML: every new string renders, `bun run build` and `bun run check` clean.
