### PR TITLE
fix: preview pane shows bun parse errors instead of session content

### DIFF
--- a/src/select.test.ts
+++ b/src/select.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { previewArgv } from './select';
+
+describe('previewArgv', () => {
+  test('compiled binary: re-enters the binary itself, not bun', () => {
+    // In compiled binaries argv[0] is "bun" and argv[1] is the virtual
+    // /$bunfs/root/... entry path; execPath is the real binary on disk.
+    expect(previewArgv('/$bunfs/root/index', '/opt/homebrew/bin/sessions')).toEqual([
+      '/opt/homebrew/bin/sessions',
+      '--preview',
+    ]);
+  });
+
+  test('run from source: re-enters via the runtime and script', () => {
+    expect(previewArgv('/home/user/sessions/index.ts', '/usr/local/bin/bun')).toEqual([
+      '/usr/local/bin/bun',
+      '/home/user/sessions/index.ts',
+      '--preview',
+    ]);
+  });
+
+  test('extension-less script path is treated as compiled', () => {
+    expect(previewArgv('/usr/local/bin/sessions', '/usr/local/bin/sessions')).toEqual([
+      '/usr/local/bin/sessions',
+      '--preview',
+    ]);
+  });
+});

--- a/src/select.ts
+++ b/src/select.ts
@@ -48,11 +48,14 @@ async function selectWithFzf(lines: string[]): Promise<string | null> {
 }
 
 /** The argv prefix that re-enters this binary: `bun index.ts` when run from source,
- *  the compiled binary itself otherwise. fzf --preview runs it via `sh -c`. */
-function previewArgv(): string[] {
-  const script = process.argv[1] ?? '';
-  if (/\.(ts|js|mjs|cjs)$/.test(script)) return [process.argv[0]!, script, '--preview'];
-  return [process.argv[0]!, '--preview'];
+ *  the compiled binary itself otherwise. fzf --preview runs it via `sh -c`.
+ *  In a compiled binary argv[0] is literally "bun" and argv[1] is the virtual
+ *  /$bunfs/root/... entry path — process.execPath is the real binary. Using argv[0]
+ *  made the preview command `bun --preview <file>`, and bun then tried to run the
+ *  session's JSONL as a script, flooding the pane with parse errors. */
+export function previewArgv(script = process.argv[1] ?? '', exe = process.execPath): string[] {
+  const fromSource = !script.includes('$bunfs') && /\.(ts|js|mjs|cjs)$/.test(script);
+  return fromSource ? [exe, script, '--preview'] : [exe, '--preview'];
 }
 
 /** Preview command string for fzf `--preview`. {1} is fzf's field-1 placeholder —


### PR DESCRIPTION
Addresses https://github.com/nicknisi/sessions/issues/72#issuecomment-5205282268

## Problem

The compiled `sessions` binary's fzf preview pane fills with bun parse errors (`error: Expected ";" but found ":"`) instead of the session transcript.

**Root cause:** `previewArgv()` in `src/select.ts` reconstructed the re-entry command from `process.argv[0]`. In a bun-compiled binary, `argv[0]` is literally the string `"bun"` and `argv[1]` is the virtual `/$bunfs/root/...` entry path — so the fzf `--preview` command became:

```
bun --preview /Users/yanick/.codex/sessions/.../rollout-....jsonl
```

Bun then tried to *execute the session's JSONL as a script*, printing a parse error per line into the pane. Only affects the compiled (homebrew) binary; running from source worked because `argv[0]` is the real bun path and `argv[1]` is `index.ts`.

## Fix

Use `process.execPath` (the real binary on disk) and treat `$bunfs` virtual paths as compiled mode:

- compiled: `sessions --preview {1}`
- source: `bun index.ts --preview {1}`

## Verification

- Reproduced the exact reported error with `bun --preview <file>.jsonl`
- Built the compiled binary and confirmed `--preview` renders real transcripts for both claude and codex sessions (codex was the reporter's case)
- Added `src/select.test.ts` covering compiled / source / extension-less invocation shapes
- Full suite: 1046 tests pass, oxfmt clean