### PR TITLE
feat: gate search ranking with a golden eval fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,10 @@ bun run typecheck            # Type-check with tsc
 bun run lint                 # Lint with oxlint
 bun run format               # Format with oxfmt
 bun run format:check         # Check formatting without writing
+bun run eval                 # Search ranking eval against the golden fixture
 ```
+
+Search ranking is gated by a frozen golden eval fixture (`src/eval/`): recall@5, MRR, and negative-abstention thresholds run in CI, and the ranking constants in `cache.ts` move only against that fixture. See [docs/EVAL.md](docs/EVAL.md) for the discipline and how to log a real miss as a new golden.
 
 ### Cross-compilation
 

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -1,0 +1,55 @@
+# Search eval
+
+Search ranking is governed by a **golden eval fixture**, not by vibes. The fixture
+lives in `src/eval/` and runs as part of `bun test` (so CI enforces it); run it on
+its own while tuning:
+
+```sh
+bun run eval
+```
+
+## Layout
+
+| File                    | Role                                                                                                                    |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `src/eval/corpus.ts`    | The frozen corpus: ~14 fixture sessions (Claude + pi) with deliberately isolated vocabulary.                            |
+| `src/eval/golden.ts`    | The golden queries (`GOLDEN`), the gates (`GATES`), and the fixture version (`EVAL_V`).                                 |
+| `src/eval/eval.test.ts` | The runner: seeds the corpus, plays every golden through the real `searchSessions`, prints a report, asserts the gates. |
+
+Golden classes: **lexical** (error strings, paths, commands — the cues people
+re-find sessions by), **natural-language** (the LLM/MCP caller's long OR-recall
+queries), **ranking** (two sessions share a term; the _order_ is the expectation),
+**filter** (tool/project/errored/files narrowing), and **negative** (no lexical
+overlap with the corpus — must return zero results. A lexical engine's abstention
+is "no signal, no answer", and a regression there means noise ranked).
+
+Gates: `recall@5 ≥ 0.9`, `MRR ≥ 0.7`, negatives abstain `100%` (hard).
+
+## The discipline
+
+Adapted from the ctx project's retrieval eval (`../ctx`), minus the embeddings —
+sessions re-finds work by concrete cues, which is a lexical problem (see
+`docs/superpowers/specs/2026-06-27-search-faster-better-design.md`).
+
+1. **The fixture is frozen.** Do not edit an expectation to match whatever the
+   ranker currently does. If a golden fails, either the code regressed or the
+   golden was wrong about _documented_ behavior — say which in the commit.
+2. **Weights move only against the fixture, in coarse steps.** The tunables are
+   named constants in `src/cache.ts`: `SESSION_FTS_COLUMN_WEIGHTS`,
+   `MESSAGE_FTS_COLUMN_WEIGHTS`, `USER_HIT_BOOST`. Change one, run `bun run eval`,
+   keep the change only if a real miss got fixed and the gates stay green.
+3. **The fixture grows by logging real misses.** When search fails you in real
+   use, add a session + golden that reproduces the miss, then fix the ranker. The
+   corpus's vocabulary-isolation rule: before adding a session, grep `corpus.ts`
+   for every term its goldens query — two sessions may share a term only when a
+   ranking golden pins the intended order between them.
+4. **Version the fixture with the config.** Any change to the corpus, the goldens,
+   or the gates bumps `EVAL_V`, so a report line always names the exact fixture it
+   measured.
+
+## Reading a failure
+
+The aggregate test prints per-class recall, the three gate metrics, and a
+`misses:` list naming each failing golden with the ranking it actually got. Fix
+the smallest thing that turns it green — a corpus fix, a golden correction, or a
+weight move, in that order of preference.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:check": "oxfmt --check . '!plugin/**/plugin.json'",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
+    "eval": "bun test src/eval/",
     "site:dev": "cd site && bun run dev",
     "site:build": "cd site && bun install --frozen-lockfile && bun run build",
     "site:check": "cd site && bun run check",

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -381,7 +381,9 @@ const lede = 'text-[15.5px] leading-[1.62] text-ink-2';
             <p>
               The index is SQLite with FTS5, built on first use and updated incrementally by
               modification time. Hits are message-granular, so a match localizes to the exact message
-              rather than the session that contained it.
+              rather than the session that contained it. Ranking is held to a frozen golden-query
+              fixture — recall@5, MRR, and negative-abstention gates run in CI, so a weight change
+              that degrades results fails the build.
             </p>
           </SectionHead>
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -614,6 +614,24 @@ function rowLimit(value: number | undefined, fallback: number): number {
   return Math.max(1, Math.floor(value));
 }
 
+// Ranking knobs — the eval fixture's tuning surface (src/eval/, docs/EVAL.md).
+// These move ONLY against the golden fixture, in coarse steps: change a value,
+// run `bun run eval`, and keep the change only if the gate stays green because a
+// real miss got fixed. The fixture is versioned with the values; grow it (log
+// real misses as new goldens) before giving the knobs another pass.
+//
+// bm25 column weights map to session_fts columns in declaration order:
+// file_path, headline, commands, paths, context_text, thinking. Headline,
+// commands, and paths carry the concrete cues people re-find sessions by;
+// verbose thinking adds recall without dominating (message text ranks via
+// message_fts below).
+export const SESSION_FTS_COLUMN_WEIGHTS = [0.0, 10.0, 6.0, 5.0, 2.0, 0.5] as const;
+// message_fts: file_path, msg_index, role, text — only the text column ranks.
+export const MESSAGE_FTS_COLUMN_WEIGHTS = [0.0, 0.0, 0.0, 1.0] as const;
+// bm25 can't weight by row, so user-turn ranks are boosted in JS instead (bm25
+// is more-negative-is-better; multiplying a negative rank improves it).
+export const USER_HIT_BOOST = 1.5;
+
 export interface SearchOptions {
   tool?: Tool | '';
   project?: string;
@@ -697,11 +715,7 @@ export async function searchSessions(query: string, opts: SearchOptions = {}): P
     // match) and message_fts aggregated by file_path (content match). Fetch both,
     // join in JS on file_path, combine ranks, sort, slice to limit.
 
-    // bm25 weights map to session_fts columns in declaration order:
-    // file_path, headline, commands, paths, context_text, thinking.
-    // Favor headline/commands/paths; de-emphasize verbose thinking so it adds
-    // recall without dominating. Message text ranks via message_fts below.
-    const SESSION_RANK = 'bm25(session_fts, 0.0, 10.0, 6.0, 5.0, 2.0, 0.5)';
+    const SESSION_RANK = `bm25(session_fts, ${SESSION_FTS_COLUMN_WEIGHTS.join(', ')})`;
     interface SessionHitRow {
       file_path: string;
       srank: number;
@@ -724,16 +738,14 @@ export async function searchSessions(query: string, opts: SearchOptions = {}): P
     const messageRows = db
       .query<MessageHitRow, [string]>(`
       SELECT file_path, msg_index, role,
-             bm25(message_fts, 0.0, 0.0, 0.0, 1.0) AS mrank,
+             bm25(message_fts, ${MESSAGE_FTS_COLUMN_WEIGHTS.join(', ')}) AS mrank,
              snippet(message_fts, 3, '', '', '…', 32) AS msnippet
       FROM message_fts WHERE message_fts MATCH ?
     `)
       .all(ftsQuery);
 
     // Role weighting replaces the old user_content 3.0 / assistant_content 2.0
-    // column weights: bm25 can't weight by row, so boost user-turn ranks 1.5× in JS
-    // (bm25 is more-negative-is-better; multiplying a negative rank improves it).
-    const USER_HIT_BOOST = 1.5;
+    // column weights (see USER_HIT_BOOST above).
     interface MessageAgg {
       best: number; // best (most negative) weighted rank across the session's hits
       hits: { hit: MessageHit; rank: number }[];

--- a/src/eval/corpus.ts
+++ b/src/eval/corpus.ts
@@ -1,0 +1,213 @@
+// The eval corpus: a FROZEN set of fixture sessions that golden.ts's queries run
+// against. Discipline (docs/EVAL.md):
+//  - The corpus changes only deliberately, and every change bumps EVAL_V.
+//  - It grows by logging REAL misses as new sessions + goldens, never by editing
+//    an expectation to match whatever the ranker currently does.
+//  - Vocabulary isolation is the corpus's load-bearing property: before adding a
+//    session, grep this file for every term its goldens query. Two sessions share
+//    a term only when a golden exists to pin the intended ranking between them
+//    (the auth-*/"middleware" pair and the "cache" pair are the examples).
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type Rec = Record<string, unknown>;
+const j = (o: unknown): string => JSON.stringify(o);
+
+// Claude Code record helpers. Only the fields the extractors read are set.
+const user = (text: string, t: string): Rec => ({
+  type: 'user',
+  timestamp: t,
+  message: { role: 'user', content: [{ type: 'text', text }] },
+  promptSource: 'typed',
+});
+const asst = (text: string, t: string): Rec => ({
+  type: 'assistant',
+  timestamp: t,
+  message: { role: 'assistant', content: [{ type: 'text', text }] },
+});
+const bash = (command: string, t: string): Rec => ({
+  type: 'assistant',
+  timestamp: t,
+  message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Bash', input: { command } }] },
+});
+const edit = (file_path: string, t: string): Rec => ({
+  type: 'assistant',
+  timestamp: t,
+  message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Edit', input: { file_path } }] },
+});
+const read = (file_path: string, t: string): Rec => ({
+  type: 'assistant',
+  timestamp: t,
+  message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Read', input: { file_path } }] },
+});
+const think = (thinking: string, t: string): Rec => ({
+  type: 'assistant',
+  timestamp: t,
+  message: { role: 'assistant', content: [{ type: 'thinking', thinking }] },
+});
+// Tool-result errors are not turns: extractErrors carries their text into
+// session_fts.context_text, and message_fts never sees them.
+const toolError = (content: string, t: string): Rec => ({
+  type: 'user',
+  timestamp: t,
+  message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't', is_error: true, content }] },
+});
+
+const at = (day: number, minute: number): string =>
+  `2026-06-${String(day).padStart(2, '0')}T10:${String(minute).padStart(2, '0')}:00Z`;
+
+interface Fixture {
+  id: string;
+  cwd: string;
+  records: Rec[];
+}
+
+const CLAUDE_FIXTURES: Fixture[] = [
+  {
+    id: 'auth-jwt',
+    cwd: '/repo/authapi',
+    records: [
+      user('add JWT authentication middleware to the express app', at(1, 0)),
+      edit('/repo/authapi/src/auth/middleware.ts', at(1, 1)),
+      bash('pnpm test auth', at(1, 2)),
+      think('token rotation and expiry strategy', at(1, 3)),
+    ],
+  },
+  {
+    id: 'auth-oauth',
+    cwd: '/repo/authapi',
+    records: [
+      user('debug the oauth callback loop', at(8, 0)),
+      toolError('invalid_redirect_uri', at(8, 1)),
+      read('/repo/authapi/src/auth/middleware.ts', at(8, 2)),
+      asst('the redirect allowlist was missing the callback url', at(8, 3)),
+    ],
+  },
+  {
+    id: 'docker-dev',
+    cwd: '/repo/shop',
+    records: [
+      user('set up containers for local development', at(2, 0)),
+      bash('docker compose up', at(2, 1)),
+      toolError('ECONNREFUSED 127.0.0.1:5432', at(2, 2)),
+      asst('the postgres container was still starting', at(2, 3)),
+    ],
+  },
+  {
+    id: 'css-navbar',
+    cwd: '/repo/shop',
+    records: [
+      user('fix the navbar layout on mobile', at(3, 0)),
+      edit('/repo/shop/src/styles.css', at(3, 1)),
+      asst('switched the navbar to flexbox with a wrapping row', at(3, 2)),
+    ],
+  },
+  {
+    id: 'perf-planner',
+    cwd: '/repo/shop',
+    records: [
+      user('memoize the query planner', at(4, 0)),
+      think('an lru cache with size-based eviction should be enough', at(4, 1)),
+      bash('bun test planner', at(4, 2)),
+    ],
+  },
+  {
+    id: 'db-migration',
+    cwd: '/repo/shop',
+    records: [
+      user('write the schema migration for orders', at(5, 0)),
+      bash('psql -f migrations/0042_orders.sql', at(5, 1)),
+      toolError('relation "orders" does not exist', at(5, 2)),
+    ],
+  },
+  {
+    id: 'flaky-test',
+    cwd: '/repo/shop',
+    records: [
+      user('fix the flaky test hang in ci', at(6, 0)),
+      edit('/repo/shop/vitest.config.ts', at(6, 1)),
+      asst('increased testTimeout and stubbed the clock', at(6, 2)),
+    ],
+  },
+  {
+    id: 'release-14',
+    cwd: '/repo/shop',
+    records: [user('cut the 1.4.0 release', at(7, 0)), bash('gh release create v1.4.0', at(7, 1))],
+  },
+  {
+    id: 'react-upgrade',
+    cwd: '/repo/shop',
+    records: [
+      user('upgrade react to version 19', at(9, 0)),
+      bash('npm install react@19', at(9, 1)),
+      toolError('ERESOLVE unable to resolve dependency tree', at(9, 2)),
+    ],
+  },
+  {
+    id: 'logging',
+    cwd: '/repo/shop',
+    records: [user('add structured logging to the worker', at(10, 0)), edit('/repo/shop/src/logger.ts', at(10, 1))],
+  },
+  {
+    id: 'rank-tune',
+    cwd: '/repo/sessions',
+    records: [
+      user('tune the bm25 column weights', at(11, 0)),
+      edit('/repo/sessions/src/cache.ts', at(11, 1)),
+      asst('recall looked better with paths weighted up', at(11, 2)),
+    ],
+  },
+  {
+    // Noise floor: a session with no distinctive vocabulary. Goldens use it to
+    // prove filters don't pull in generic chatter.
+    id: 'chatter',
+    cwd: '/repo/shop',
+    records: [user('thanks, that worked perfectly', at(12, 0)), asst('glad to hear it', at(12, 1))],
+  },
+  {
+    id: 'golang-api',
+    cwd: '/repo/api',
+    records: [
+      user('add pagination to the handlers', at(14, 0)),
+      bash('go test ./...', at(14, 1)),
+      asst('the cursor token encodes the last id', at(14, 2)),
+    ],
+  },
+];
+
+function writeClaude(claudeDir: string, f: Fixture): void {
+  const dir = join(claudeDir, 'proj');
+  mkdirSync(dir, { recursive: true });
+  const lines = f.records.map((r) => j({ ...r, cwd: f.cwd })).join('\n');
+  writeFileSync(join(dir, `${f.id}.jsonl`), lines);
+}
+
+function writePi(piDir: string): void {
+  const dir = join(piDir, 'proj');
+  mkdirSync(dir, { recursive: true });
+  const records: Rec[] = [
+    { type: 'session', id: 'pi-flag', timestamp: '2026-06-13T17:00:00.000Z', cwd: '/repo/cli' },
+    { type: 'model_change', id: 'm1', parentId: null, timestamp: '2026-06-13T17:00:01.000Z' },
+    {
+      type: 'message',
+      id: 'u1',
+      parentId: 'm1',
+      timestamp: '2026-06-13T17:01:00.000Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'rename the --all flag to --everywhere' }] },
+    },
+    {
+      type: 'message',
+      id: 'a1',
+      parentId: 'u1',
+      timestamp: '2026-06-13T17:02:00.000Z',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'updated the help output and completions' }] },
+    },
+  ];
+  writeFileSync(join(dir, 'pi-flag.jsonl'), records.map(j).join('\n'));
+}
+
+export function seedEvalCorpus(dirs: { claudeDir: string; piDir: string }): void {
+  for (const f of CLAUDE_FIXTURES) writeClaude(dirs.claudeDir, f);
+  writePi(dirs.piDir);
+}

--- a/src/eval/eval.test.ts
+++ b/src/eval/eval.test.ts
@@ -1,0 +1,145 @@
+// The eval runner: seeds the frozen corpus, plays every golden query through the
+// real search engine, and gates on the metrics (docs/EVAL.md). Runs as part of
+// `bun test` so CI enforces it; `bun run eval` runs just this file for tuning.
+//
+// Every golden query is executed ONCE in beforeAll and materialized into plain
+// data — the tests below assert over outcomes, so they don't care about DB env
+// state the way cache-importing suites do.
+
+import { test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { seedEvalCorpus } from './corpus';
+import { EVAL_V, GATES, GOLDEN, RECALL_K, type GoldenClass, type GoldenQuery } from './golden';
+
+interface Outcome {
+  golden: GoldenQuery;
+  /** Result session ids, in rank order. */
+  ids: string[];
+}
+
+let tmp: string;
+let outcomes: Outcome[];
+
+beforeAll(async () => {
+  tmp = mkdtempSync(join(tmpdir(), 'sessions-eval-'));
+  process.env.SESSIONS_CACHE_DIR = join(tmp, 'cache');
+  process.env.SESSIONS_CLAUDE_DIR = join(tmp, 'claude');
+  process.env.SESSIONS_PI_DIR = join(tmp, 'pi');
+  process.env.SESSIONS_CODEX_DIR = join(tmp, 'codex');
+  process.env.SESSIONS_OPENCODE_DB = join(tmp, 'opencode.db'); // absent → no OpenCode sessions leak in
+  mkdirSync(join(tmp, 'claude'), { recursive: true });
+  mkdirSync(join(tmp, 'pi'), { recursive: true });
+  mkdirSync(join(tmp, 'codex'), { recursive: true });
+  seedEvalCorpus({ claudeDir: join(tmp, 'claude'), piDir: join(tmp, 'pi') });
+
+  const cache = await import('../cache');
+  cache.closeDb(); // drop any connection a prior test file opened on the shared module
+  await cache.refreshIndex();
+
+  outcomes = [];
+  for (const golden of GOLDEN) {
+    const results = await cache.searchSessions(golden.query, golden.opts ?? {});
+    outcomes.push({ golden, ids: results.map((r) => r.sessionId) });
+  }
+  cache.closeDb(); // release the handle; tests below read only `outcomes`
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+const outcomeFor = (id: string): Outcome => outcomes.find((o) => o.golden.id === id)!;
+
+/** Expected ids for a positive golden: top ∪ first, deduped, order irrelevant. */
+function expectedIds(g: GoldenQuery): string[] {
+  return [...new Set([...(g.top ?? []), ...(g.first ? [g.first] : [])])];
+}
+
+// ——— individual conditions (the failure message names the golden) ———
+
+for (const g of GOLDEN.filter((g) => g.negative)) {
+  test(`[${g.class}] ${g.id} abstains: "${g.query}" returns zero results`, () => {
+    expect(outcomeFor(g.id).ids).toEqual([]);
+  });
+}
+
+for (const g of GOLDEN.filter((g) => g.first || g.absent?.length)) {
+  test(`[${g.class}] ${g.id} hard conditions: "${g.query}"`, () => {
+    const { ids } = outcomeFor(g.id);
+    if (g.first) expect(ids[0]).toBe(g.first);
+    for (const absent of g.absent ?? []) expect(ids).not.toContain(absent);
+  });
+}
+
+// ——— aggregate gates ———
+
+interface Metrics {
+  recallAtK: number;
+  mrr: number;
+  negativePass: number;
+  perClass: Map<GoldenClass, { found: number; expected: number }>;
+  misses: string[];
+}
+
+function computeMetrics(): Metrics {
+  const positives = outcomes.filter((o) => expectedIds(o.golden).length > 0);
+  const perClass = new Map<GoldenClass, { found: number; expected: number }>();
+  const misses: string[] = [];
+  let found = 0;
+  let expected = 0;
+  const reciprocalRanks: number[] = [];
+
+  for (const { golden, ids } of positives) {
+    const expectedFor = expectedIds(golden);
+    const cls = perClass.get(golden.class) ?? { found: 0, expected: 0 };
+    perClass.set(golden.class, cls);
+    let bestRank = -1;
+    for (const id of expectedFor) {
+      const rank = ids.indexOf(id);
+      expected++;
+      cls.expected++;
+      if (rank >= 0 && rank < RECALL_K) {
+        found++;
+        cls.found++;
+      } else {
+        misses.push(
+          `${golden.id}: "${golden.query}" — expected ${id} in top ${RECALL_K}, got [${ids.join(', ') || '∅'}]`,
+        );
+      }
+      if (rank >= 0 && (bestRank < 0 || rank < bestRank)) bestRank = rank;
+    }
+    reciprocalRanks.push(bestRank >= 0 ? 1 / (bestRank + 1) : 0);
+  }
+
+  const negatives = outcomes.filter((o) => o.golden.negative);
+  const negativePass = negatives.filter((o) => o.ids.length === 0).length / negatives.length;
+
+  return {
+    recallAtK: found / expected,
+    mrr: reciprocalRanks.reduce((a, b) => a + b, 0) / reciprocalRanks.length,
+    negativePass,
+    perClass,
+    misses,
+  };
+}
+
+test(`aggregate gates (${EVAL_V}): recall@${RECALL_K}, MRR, negative abstention`, () => {
+  const m = computeMetrics();
+
+  // The report is the tuning artifact: when a gate fails this is what you read.
+  const lines = [
+    `\n——— search eval ${EVAL_V} ———`,
+    ...[...m.perClass.entries()].map(([cls, c]) => `  ${cls.padEnd(17)} recall@${RECALL_K} ${c.found}/${c.expected}`),
+    `  ${'OVERALL'.padEnd(17)} recall@${RECALL_K} ${m.recallAtK.toFixed(3)} (gate ≥ ${GATES.recallAtK})`,
+    `  ${''.padEnd(17)} MRR ${m.mrr.toFixed(3)} (gate ≥ ${GATES.mrr})`,
+    `  ${''.padEnd(17)} negatives ${(m.negativePass * 100).toFixed(0)}% abstain (gate = ${GATES.negatives * 100}%)`,
+    ...(m.misses.length > 0 ? ['  misses:', ...m.misses.map((s) => `    ${s}`)] : []),
+  ];
+  console.log(lines.join('\n'));
+
+  expect(m.recallAtK).toBeGreaterThanOrEqual(GATES.recallAtK);
+  expect(m.mrr).toBeGreaterThanOrEqual(GATES.mrr);
+  expect(m.negativePass).toBe(GATES.negatives);
+});

--- a/src/eval/golden.ts
+++ b/src/eval/golden.ts
@@ -1,0 +1,165 @@
+// The golden fixture: the queries search ranking is held to, the gates they must
+// pass, and the version that ties them to the corpus. Discipline in docs/EVAL.md.
+//
+// Classes:
+//  - lexical          concrete cues: error strings, paths, commands, identifiers
+//  - natural-language the LLM/MCP caller's long OR-recall queries
+//  - ranking          two sessions share the term; the ORDER is the expectation
+//  - filter           tool/project/errored/files narrowing (pass/fail, not metric)
+//  - negative         no lexical overlap with the corpus; must return ZERO results
+//                     (a lexical engine's abstention: no signal, no answer)
+
+import type { SearchOptions } from '../cache';
+
+export const EVAL_V = 'golden-v1';
+
+/** Recall is measured at this depth, matching the MCP caller's typical ask. */
+export const RECALL_K = 5;
+
+/** Hard gates. recall/mrr are floors across the positive goldens; negatives is a
+ *  pass rate and must stay perfect — a regression there means noise ranked. */
+export const GATES = { recallAtK: 0.9, mrr: 0.7, negatives: 1.0 } as const;
+
+export type GoldenClass = 'lexical' | 'natural-language' | 'ranking' | 'filter' | 'negative';
+
+export interface GoldenQuery {
+  id: string;
+  class: GoldenClass;
+  query: string;
+  opts?: SearchOptions;
+  /** Sessions that must appear in the top RECALL_K results (recall numerator). */
+  top?: string[];
+  /** Session that must be the #1 result — asserted individually, not just metric. */
+  first?: string;
+  /** Sessions that must not appear in the results at all. */
+  absent?: string[];
+  /** The query must return zero results. */
+  negative?: boolean;
+  /** Why this golden exists — the fixture's memory of what it guards. */
+  note?: string;
+}
+
+export const GOLDEN: GoldenQuery[] = [
+  // ——— lexical ———
+  { id: 'error-string', class: 'lexical', query: 'ECONNREFUSED', top: ['docker-dev'], first: 'docker-dev' },
+  { id: 'error-token', class: 'lexical', query: 'invalid_redirect_uri', top: ['auth-oauth'], first: 'auth-oauth' },
+  { id: 'error-code', class: 'lexical', query: 'ERESOLVE', top: ['react-upgrade'], first: 'react-upgrade' },
+  {
+    id: 'shared-path',
+    class: 'lexical',
+    query: 'middleware.ts',
+    top: ['auth-jwt', 'auth-oauth'],
+    note: 'Both auth sessions reference the file (edit vs read); order deliberately unpinned.',
+  },
+  { id: 'command-phrase', class: 'lexical', query: 'docker compose up', top: ['docker-dev'], first: 'docker-dev' },
+  { id: 'filename', class: 'lexical', query: 'vitest.config', top: ['flaky-test'], first: 'flaky-test' },
+  { id: 'command-flag', class: 'lexical', query: 'react@19', top: ['react-upgrade'], first: 'react-upgrade' },
+  { id: 'other-lang-command', class: 'lexical', query: 'go test', top: ['golang-api'], first: 'golang-api' },
+  { id: 'migration-file', class: 'lexical', query: '0042_orders.sql', top: ['db-migration'], first: 'db-migration' },
+  {
+    id: 'user-turn-term',
+    class: 'lexical',
+    query: 'memoize',
+    top: ['perf-planner'],
+    first: 'perf-planner',
+    note: 'Term lives only in a genuine user turn — exercises message_fts recall.',
+  },
+
+  // ——— natural language (LLM/MCP caller shape) ———
+  {
+    id: 'nl-containers',
+    class: 'natural-language',
+    query: 'set up containers for local development',
+    top: ['docker-dev'],
+    first: 'docker-dev',
+  },
+  {
+    id: 'nl-hang',
+    class: 'natural-language',
+    query: 'why does the test hang in ci',
+    top: ['flaky-test'],
+    first: 'flaky-test',
+    note: 'OR-recall: common terms (the/test) match widely; rare terms (hang/ci) must dominate.',
+  },
+  {
+    id: 'nl-deps',
+    class: 'natural-language',
+    query: 'upgrade dependencies',
+    top: ['react-upgrade'],
+    first: 'react-upgrade',
+  },
+  {
+    id: 'nl-pagination',
+    class: 'natural-language',
+    query: 'add pagination handlers',
+    top: ['golang-api'],
+    first: 'golang-api',
+  },
+  {
+    id: 'nl-cross-tool',
+    class: 'natural-language',
+    query: 'rename cli flag',
+    top: ['pi-flag'],
+    first: 'pi-flag',
+    note: 'A pi session must be findable through the same engine.',
+  },
+
+  // ——— ranking (order is the expectation) ———
+  {
+    id: 'rank-auth',
+    class: 'ranking',
+    query: 'auth middleware',
+    top: ['auth-jwt', 'auth-oauth'],
+    first: 'auth-jwt',
+    note: 'Headline + command + edit beats a read-only mention of the same path.',
+  },
+  {
+    id: 'rank-column-weights',
+    class: 'ranking',
+    query: 'cache',
+    top: ['rank-tune', 'perf-planner'],
+    first: 'rank-tune',
+    note: 'A paths-column hit (weight 5.0) must outrank a thinking-only hit (weight 0.5).',
+  },
+
+  // ——— filter ———
+  {
+    id: 'filter-errored',
+    class: 'filter',
+    query: '',
+    opts: { errored: true },
+    top: ['docker-dev', 'auth-oauth', 'db-migration', 'react-upgrade'],
+    absent: ['chatter', 'css-navbar'],
+  },
+  {
+    id: 'filter-files',
+    class: 'filter',
+    query: '',
+    opts: { files: ['src/logger.ts'] },
+    top: ['logging'],
+    absent: ['auth-jwt', 'rank-tune'],
+  },
+  {
+    id: 'filter-project',
+    class: 'filter',
+    query: 'middleware',
+    opts: { project: '/repo/authapi' },
+    top: ['auth-jwt', 'auth-oauth'],
+    absent: ['rank-tune'],
+    note: 'rank-tune also matches the term but lives in /repo/sessions.',
+  },
+  { id: 'filter-tool-pi', class: 'filter', query: 'rename', opts: { tool: 'pi' }, top: ['pi-flag'] },
+  {
+    id: 'filter-tool-claude',
+    class: 'filter',
+    query: 'rename',
+    opts: { tool: 'claude' },
+    negative: true,
+    note: 'The only rename session is pi; a claude-scoped query must come back empty.',
+  },
+
+  // ——— negative (must abstain: zero results) ———
+  { id: 'neg-infra', class: 'negative', query: 'kubernetes pod autoscaling', negative: true },
+  { id: 'neg-lang', class: 'negative', query: 'borrow checker lifetime', negative: true },
+  { id: 'neg-gibberish', class: 'negative', query: 'zxqwv plugh', negative: true },
+];


### PR DESCRIPTION
## Why

Search ranking had unit tests but no retrieval-*quality* gate — a weight change could silently degrade result ordering with every check green. This ports the eval discipline from the ctx project (`golden.jsonl` + recall@k + abstention gates), minus the embeddings: sessions re-finds work by concrete cues (paths, error strings, commands), which stays a lexical problem per the search design spec.

## What

- **`src/eval/corpus.ts`** — frozen corpus: 14 fixture sessions (Claude + pi) with deliberately isolated vocabulary; shared terms exist only where a ranking golden pins the intended order.
- **`src/eval/golden.ts`** — 26 golden queries in 5 classes (lexical / natural-language / ranking / filter / negative), hard gates (recall@5 ≥ 0.9, MRR ≥ 0.7, negatives abstain 100%), and `EVAL_V` versioning.
- **`src/eval/eval.test.ts`** — runner: seeds the corpus, plays every golden through the real `searchSessions`, prints a per-class report, asserts the gates. Runs in `bun test` so CI enforces it; `bun run eval` for tuning loops.
- **`src/cache.ts`** — ranking knobs lifted to named exported constants (`SESSION_FTS_COLUMN_WEIGHTS`, `MESSAGE_FTS_COLUMN_WEIGHTS`, `USER_HIT_BOOST`) with the tuning discipline attached. Values unchanged.
- **`docs/EVAL.md`** — the discipline: fixture frozen, weights move only against it in coarse steps, real misses get logged as new goldens, `EVAL_V` bumps with any fixture change.

## Verification

- `bun test`: 1062 pass, 0 fail (24 new eval tests)
- `typecheck` / `lint` / `format:check` green
- Gate sensitivity proven: zeroing the paths column weight fails the `rank-column-weights` golden (paths hit must outrank thinking-only hit), revert restores green
- Real-corpus smoke: `searchSessions` against the live index returns sensible results and the correct sessions for a paraphrase-ish query

Current fixture: recall@5 1.000, MRR 1.000, negatives 100% abstain.