### PR TITLE
fix(release): publish Linux ARM64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           - os: ubuntu-latest
             target: bun-linux-x64
             artifact: sessions-linux-x86_64
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: sessions-linux-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -440,13 +440,14 @@ Search ranking is gated by a frozen golden eval fixture (`src/eval/`): recall@5,
 
 ### Cross-compilation
 
-The release workflow compiles binaries for three platforms:
+The release workflow compiles binaries for four platforms:
 
 | Target                    | Artifact                 |
 | ------------------------- | ------------------------ |
 | macOS ARM (Apple Silicon) | `sessions-darwin-arm64`  |
 | macOS x86_64 (Intel)      | `sessions-darwin-x86_64` |
 | Linux x86_64              | `sessions-linux-x86_64`  |
+| Linux ARM64 (aarch64)     | `sessions-linux-arm64`   |
 
 Binaries are compiled with `bun build --compile --minify` and distributed as `.tar.gz` archives attached to GitHub Releases.
 

--- a/src/release-matrix.test.ts
+++ b/src/release-matrix.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+// Guards the release build matrix so a target or artifact name can never
+// silently drop or drift. mise's `github:` backend selects an asset by the
+// os/arch tokens in its filename, so every compile target must ship a tarball
+// named `sessions-<os>-<arch>` with the tokens mise recognizes.
+const workflow = readFileSync(join(import.meta.dir, '..', '.github', 'workflows', 'release.yml'), 'utf8');
+
+// (bun compile target, published artifact base name)
+const EXPECTED: ReadonlyArray<readonly [string, string]> = [
+  ['bun-darwin-arm64', 'sessions-darwin-arm64'],
+  ['bun-darwin-x64', 'sessions-darwin-x86_64'],
+  ['bun-linux-x64', 'sessions-linux-x86_64'],
+  ['bun-linux-arm64', 'sessions-linux-arm64'],
+];
+
+describe('release matrix', () => {
+  for (const [target, artifact] of EXPECTED) {
+    test(`${target} -> ${artifact}`, () => {
+      expect(workflow).toContain(`target: ${target}`);
+      expect(workflow).toContain(`artifact: ${artifact}`);
+    });
+  }
+
+  test('every matrix target has exactly one artifact', () => {
+    const targets = [...workflow.matchAll(/^\s*target: (\S+)/gm)].map((m) => m[1]);
+    const artifacts = [...workflow.matchAll(/^\s*artifact: (\S+)/gm)].map((m) => m[1]);
+    expect(targets.sort()).toEqual(EXPECTED.map(([t]) => t).sort());
+    expect(artifacts.sort()).toEqual(EXPECTED.map(([, a]) => a).sort());
+  });
+
+  test('linux arm64 counterpart matches x86_64 naming convention', () => {
+    const linux = EXPECTED.filter(([, a]) => a.startsWith('sessions-linux-'));
+    expect(linux.map(([, a]) => a).sort()).toEqual(['sessions-linux-arm64', 'sessions-linux-x86_64']);
+  });
+});


### PR DESCRIPTION
## Summary
The release pipeline built macOS arm64/x86_64 and Linux x86_64, but no Linux ARM64 artifact, so aarch64 Linux users had no installable binary.

- Add a `bun-linux-arm64` entry to the release build matrix (`.github/workflows/release.yml`), producing `sessions-linux-arm64.tar.gz`. bun cross-compiles this on the existing `ubuntu-latest` runner, no extra toolchain needed.
- The artifact keeps the existing `sessions-<os>-<arch>` convention (matching `sessions-darwin-arm64`), which mise's `github:` backend resolves for aarch64 Linux.
- Add `src/release-matrix.test.ts` pinning the target/artifact set so a dropped platform or a naming drift fails CI instead of silently shipping.
- Update the README cross-compilation table (three to four platforms).

No application behavior or unrelated files changed. The Homebrew tap update step is left untouched (macOS-only).

## Test evidence
- `bun run lint` — 0 warnings, 0 errors
- `bun run format:check` — all files correctly formatted
- `bun run typecheck` (tsc 5.9.3) — clean
- `bun run test` — 1068 pass, 8 skip, 0 fail (includes new release-matrix suite: 6 pass)
- Local cross-compile: `bun build --compile --minify --target=bun-linux-arm64 index.ts` then `file` reports `ELF 64-bit LSB executable, ARM aarch64 ... for GNU/Linux`
