### PR TITLE
fix(setup): install skills for pi, list them dynamically

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -14,7 +14,7 @@ import {
 } from './cache';
 import { formatResult, buildResumeCommand } from './search-format';
 import { getSessionMessages, type PiForkMarker } from './parser';
-import { asJsonObject, asJsonString, type JsonValue } from './extract-util';
+import { splitFrontmatter, frontmatterDescription } from './skill-frontmatter';
 import { buildSessionDigest, clip, renderDigestMarkdown } from './digest';
 import { resolveRepo } from './repo';
 import { readSessionLines } from './session-io';
@@ -950,43 +950,6 @@ const PROMPT_SKILLS = {
 } as const;
 
 type PromptName = keyof typeof PROMPT_SKILLS;
-
-/**
- * Split a leading `---`-delimited YAML frontmatter block off a skill body. Returns the whole
- * input as `body` when there is none, so a skill that loses its frontmatter still serves.
- */
-interface FrontmatterSplit {
-  frontmatter: string;
-  body: string;
-}
-
-function splitFrontmatter(raw: string): FrontmatterSplit {
-  if (!raw.startsWith('---\n')) return { frontmatter: '', body: raw };
-  // Search from 3 so an empty block (`---\n---\n`) still terminates.
-  const end = raw.indexOf('\n---\n', 3);
-  if (end === -1) return { frontmatter: '', body: raw };
-  return { frontmatter: raw.slice(4, end + 1), body: raw.slice(end + 5) };
-}
-
-/** The skill's own `description`, lifted out of its frontmatter — a prompt carries it in its
- *  own field, and leaving it in the body would open every message with YAML noise. */
-function frontmatterDescription(frontmatter: string): string {
-  try {
-    // SAFETY: YAML is a JSON superset at the values we write here — simple
-    // `key: value` frontmatter lines parse into the JSON domain.
-    const parsed = asJsonObject(Bun.YAML.parse(frontmatter) as JsonValue);
-    const description = asJsonString(parsed?.description);
-    if (description !== undefined) {
-      // Folded scalars (`description: >-`) arrive with hard newlines; a prompt description
-      // is a single sentence in a picker.
-      return description.replace(/\s+/g, ' ').trim();
-    }
-  } catch {
-    // A malformed block is not worth refusing to serve the prompt over — the body is what
-    // matters, and the description falls back to the registration-site sentence.
-  }
-  return '';
-}
 
 /**
  * Read one skill out of the generated embed, frontmatter removed.

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, lstatSync, readlinkSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { linkPiSkills, unlinkPiSkills, installedSkills } from './setup';
+
+let tmp: string;
+let pluginSkills: string;
+let piSkills: string;
+
+function writeSkill(dir: string, name: string, description: string): void {
+  const d = join(dir, name);
+  mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, 'SKILL.md'), `---\nname: ${name}\n${description}\n---\n\n# ${name}\n`);
+}
+
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'sessions-setup-'));
+  pluginSkills = join(tmp, 'plugin', 'skills');
+  piSkills = join(tmp, 'pi', 'skills');
+  writeSkill(pluginSkills, 'why', 'description: >-\n  Explain why code exists.\n  More trigger text follows.');
+  writeSkill(pluginSkills, 'recall', 'description: Recall past sessions.');
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('linkPiSkills', () => {
+  test('links every plugin skill into the pi skills dir', () => {
+    const results = linkPiSkills(piSkills, pluginSkills);
+    expect(results.map((r) => [r.name, r.status])).toEqual([
+      ['recall', 'linked'],
+      ['why', 'linked'],
+    ]);
+    for (const name of ['why', 'recall']) {
+      const dest = join(piSkills, name);
+      expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(dest)).toBe(join(pluginSkills, name));
+    }
+  });
+
+  test('is idempotent and refuses to clobber a hand-written skill', () => {
+    // Second run: our own links report unchanged.
+    expect(linkPiSkills(piSkills, pluginSkills).every((r) => r.status === 'unchanged')).toBe(true);
+
+    // A real directory with a colliding name is refused, not replaced.
+    mkdirSync(join(piSkills, 'memory'), { recursive: true });
+    writeFileSync(join(piSkills, 'memory', 'SKILL.md'), 'mine');
+    writeSkill(pluginSkills, 'memory', 'description: ours.');
+    const results = linkPiSkills(piSkills, pluginSkills);
+    expect(results.find((r) => r.name === 'memory')?.status).toBe('refused');
+    expect(lstatSync(join(piSkills, 'memory')).isSymbolicLink()).toBe(false);
+  });
+});
+
+describe('unlinkPiSkills', () => {
+  test('removes only links that point into the plugin skills dir', () => {
+    const removed = unlinkPiSkills(piSkills, pluginSkills);
+    expect(removed.sort()).toEqual(['recall', 'why']);
+    expect(existsSync(join(piSkills, 'why'))).toBe(false);
+    // The refused hand-written skill survives uninstall.
+    expect(existsSync(join(piSkills, 'memory', 'SKILL.md'))).toBe(true);
+  });
+});
+
+describe('installedSkills', () => {
+  test('reads every skill from disk with the first sentence of its description', () => {
+    const skills = installedSkills(pluginSkills);
+    const why = skills.find((s) => s.name === 'why');
+    // Folded scalar collapses to one line; only the first sentence is kept.
+    expect(why?.description).toBe('Explain why code exists.');
+    // A skill the old hardcoded list forgot still appears.
+    expect(skills.map((s) => s.name)).toContain('recall');
+  });
+});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,9 +1,22 @@
-import { existsSync, mkdirSync, writeFileSync, cpSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+  cpSync,
+} from 'node:fs';
+import { join, dirname, sep } from 'node:path';
 import { C } from './colors';
 import { PLUGIN_FILES } from './plugin-files';
 import { enableSessionHook, disableSessionHook } from './hooks';
-import { getDataDir } from './paths';
+import { getDataDir, getHome } from './paths';
+import { splitFrontmatter, frontmatterDescription } from './skill-frontmatter';
 import {
   cleanDeadConfigs,
   codexManualBlock,
@@ -100,6 +113,97 @@ function installPlugin(): boolean {
   const ok = source ? installPluginFromDisk(source) : installPluginFromEmbed();
   if (ok) writeMarketplaceJson();
   return ok;
+}
+
+// ——— Pi skills ———
+//
+// Pi has no plugin marketplace: it discovers skills as <skillsDir>/<name>/SKILL.md and
+// its MCP list in mcp.json. Setup wired only the MCP entry, so Pi got the tools without
+// the skills that carry their procedures. The bridge is one symlink per skill into Pi's
+// skills dir — links, not copies, so an upgraded plugin never leaves stale skills behind.
+
+function piSkillsDir(): string {
+  return join(getHome(), '.pi', 'agent', 'skills');
+}
+
+export interface SkillLink {
+  name: string;
+  status: 'linked' | 'unchanged' | 'refused';
+}
+
+interface InstalledSkill {
+  name: string;
+  description: string;
+}
+
+/** The description's first sentence, folded — enough for a list; the rest is trigger text. */
+function firstSentence(description: string): string {
+  const m = /^.+?\.(?=\s|$)/.exec(description);
+  return m ? m[0] : description;
+}
+
+/** Every skill the plugin ships, read from the just-installed copy with its frontmatter
+ *  description — the SKILL.md set is the source of truth, so a new skill appears here
+ *  without a setup.ts edit. */
+export function installedSkills(skillsRoot = join(pluginDest(), 'skills')): InstalledSkill[] {
+  if (!existsSync(skillsRoot)) return [];
+  const out: InstalledSkill[] = [];
+  for (const name of readdirSync(skillsRoot).sort()) {
+    try {
+      if (!statSync(join(skillsRoot, name)).isDirectory()) continue;
+      const raw = readFileSync(join(skillsRoot, name, 'SKILL.md'), 'utf8');
+      const { frontmatter } = splitFrontmatter(raw);
+      out.push({ name, description: firstSentence(frontmatterDescription(frontmatter)) });
+    } catch {
+      out.push({ name, description: '' });
+    }
+  }
+  return out;
+}
+
+function isOurLink(dest: string, source: string): boolean {
+  try {
+    return lstatSync(dest).isSymbolicLink() && readlinkSync(dest) === source;
+  } catch {
+    return false;
+  }
+}
+
+/** Link each plugin skill into Pi's skills dir. An existing entry that is not already
+ *  our link (a hand-written skill with the same name) is refused, never clobbered. */
+export function linkPiSkills(skillsDir = piSkillsDir(), pluginSkills = join(pluginDest(), 'skills')): SkillLink[] {
+  if (!existsSync(pluginSkills)) return [];
+  mkdirSync(skillsDir, { recursive: true });
+  const results: SkillLink[] = [];
+  for (const name of readdirSync(pluginSkills).sort()) {
+    const source = join(pluginSkills, name);
+    if (!statSync(source).isDirectory()) continue;
+    const dest = join(skillsDir, name);
+    if (lstatSync(dest, { throwIfNoEntry: false })) {
+      results.push({ name, status: isOurLink(dest, source) ? 'unchanged' : 'refused' });
+      continue;
+    }
+    symlinkSync(source, dest, 'dir');
+    results.push({ name, status: 'linked' });
+  }
+  return results;
+}
+
+/** Remove only links that point into our plugin skills dir; anything else stays. */
+export function unlinkPiSkills(skillsDir = piSkillsDir(), pluginSkills = join(pluginDest(), 'skills')): string[] {
+  if (!existsSync(skillsDir)) return [];
+  const removed: string[] = [];
+  for (const name of readdirSync(skillsDir).sort()) {
+    const dest = join(skillsDir, name);
+    try {
+      if (!lstatSync(dest).isSymbolicLink()) continue;
+      const target = readlinkSync(dest);
+      if (target !== join(pluginSkills, name) && !target.startsWith(pluginSkills + sep)) continue;
+      rmSync(dest);
+      removed.push(name);
+    } catch {}
+  }
+  return removed;
 }
 
 function sessionsCommand(): string {
@@ -236,6 +340,23 @@ export function runSetup(opts: SetupOptions = {}): void {
         w(`  ${C.dim}ℹ${C.reset} Plugin already installed in ${C.dim}${tool.name}${C.reset}\n`);
       }
     }
+
+    if (tool.id === 'pi') {
+      const links = linkPiSkills();
+      const linked = links.filter((l) => l.status === 'linked').length;
+      if (linked) {
+        w(
+          `  ${C.green}✓${C.reset} ${linked} skill${linked === 1 ? '' : 's'} linked into ${C.dim}Pi${C.reset} ${C.dim}(${piSkillsDir()})${C.reset}\n`,
+        );
+      } else if (links.length && links.every((l) => l.status === 'unchanged')) {
+        w(`  ${C.dim}ℹ${C.reset} Skills already linked for ${C.dim}Pi${C.reset}\n`);
+      }
+      for (const r of links.filter((l) => l.status === 'refused')) {
+        w(
+          `  ${C.yellow}!${C.reset} Left ${C.dim}${join(piSkillsDir(), r.name)}${C.reset} alone — not a sessions link\n`,
+        );
+      }
+    }
   }
 
   // SessionStart auto-injection hook — opt-in, Claude Code only for now.
@@ -250,14 +371,19 @@ export function runSetup(opts: SetupOptions = {}): void {
     w(`  ${C.dim}  Disable any time with \`sessions uninstall\`.${C.reset}\n`);
   }
 
-  w(`\n  ${C.bold}Skills available:${C.reset}\n`);
-  w(`    ${C.cyan}/context${C.reset}           Context primer for the current repo\n`);
-  w(`    ${C.cyan}/weekly-summary${C.reset}    Summarize your past week's AI sessions\n`);
-  w(`    ${C.cyan}/standup${C.reset}           Yesterday + today activity for standups\n`);
-  w(`    ${C.cyan}/recall${C.reset}            What did I do on a specific project?\n`);
-  w(`    ${C.cyan}/session-metrics${C.reset}   Usage dashboard with tool breakdown\n`);
-  w(`    ${C.cyan}/memory${C.reset}            Triage durable facts mined from past sessions\n`);
-  w(`\n  ${C.dim}Run \`sessions setup\` again after upgrading to update skills.${C.reset}\n\n`);
+  // Only Claude Code (plugin) and Pi (symlinks) actually receive the skills; printing
+  // this list to a Cursor/Codex-only user advertises skills they never got. The list is
+  // read from the just-installed skills, not hardcoded — the hardcoded version already
+  // shipped without /why once.
+  const skills = installedSkills();
+  if (detected.some((t) => t.id === 'claude' || t.id === 'pi') && skills.length) {
+    w(`\n  ${C.bold}Skills available:${C.reset}\n`);
+    const width = Math.max(...skills.map((s) => s.name.length));
+    for (const s of skills) {
+      w(`    ${C.cyan}/${s.name.padEnd(width)}${C.reset}  ${C.dim}${s.description}${C.reset}\n`);
+    }
+    w(`\n  ${C.dim}Run \`sessions setup\` again after upgrading to update skills.${C.reset}\n\n`);
+  }
 }
 
 export function runUninstall(): void {
@@ -284,6 +410,15 @@ export function runUninstall(): void {
       const res = disableSessionHook('claude');
       if (res.changed) {
         w(`  ${C.green}✓${C.reset} Removed SessionStart auto-injection from ${C.dim}${tool.name}${C.reset}\n`);
+      }
+    }
+
+    if (tool.id === 'pi') {
+      const removed = unlinkPiSkills();
+      if (removed.length) {
+        w(
+          `  ${C.green}✓${C.reset} Removed ${removed.length} skill link${removed.length === 1 ? '' : 's'} from ${C.dim}Pi${C.reset}\n`,
+        );
       }
     }
   }

--- a/src/skill-frontmatter.ts
+++ b/src/skill-frontmatter.ts
@@ -1,0 +1,37 @@
+import { asJsonObject, asJsonString, type JsonValue } from './extract-util';
+
+/**
+ * Split a leading `---`-delimited YAML frontmatter block off a skill body. Returns the whole
+ * input as `body` when there is none, so a skill that loses its frontmatter still serves.
+ */
+export interface FrontmatterSplit {
+  frontmatter: string;
+  body: string;
+}
+
+export function splitFrontmatter(raw: string): FrontmatterSplit {
+  if (!raw.startsWith('---\n')) return { frontmatter: '', body: raw };
+  // Search from 3 so an empty block (`---\n---\n`) still terminates.
+  const end = raw.indexOf('\n---\n', 3);
+  if (end === -1) return { frontmatter: '', body: raw };
+  return { frontmatter: raw.slice(4, end + 1), body: raw.slice(end + 5) };
+}
+
+/** The skill's own `description`, lifted out of its frontmatter and folded to one line. */
+export function frontmatterDescription(frontmatter: string): string {
+  try {
+    // SAFETY: YAML is a JSON superset at the values we write here — simple
+    // `key: value` frontmatter lines parse into the JSON domain.
+    const parsed = asJsonObject(Bun.YAML.parse(frontmatter) as JsonValue);
+    const description = asJsonString(parsed?.description);
+    if (description !== undefined) {
+      // Folded scalars (`description: >-`) arrive with hard newlines; a prompt description
+      // is a single sentence in a picker.
+      return description.replace(/\s+/g, ' ').trim();
+    }
+  } catch {
+    // A malformed block is not worth refusing to serve the prompt over — the body is what
+    // matters, and the description falls back to the registration-site sentence.
+  }
+  return '';
+}


### PR DESCRIPTION
## Problem

`sessions setup` wires Pi's MCP entry into `~/.pi/agent/mcp.json` but never installs the skills: plugin marketplace registration is Claude-only, and nothing links the skills into `~/.pi/agent/skills/`, the only place Pi discovers them. Pi users got the tools (`why_did_this_change`, `search_sessions`, …) without the skills that carry the procedures making them reliable — when to use them, how to weigh confidence, the `gh search prs --state closed` cross-check.

While in there: the closing "Skills available" printout was a hardcoded list that had already drifted (missing `/why`) and printed even for Cursor/Codex-only users, who receive no skills at all.

## Changes

- **Pi skill install.** `setup` symlinks each `plugin/skills/*` directory into `~/.pi/agent/skills/`. Links, not copies, so `sessions setup` after an upgrade never leaves stale skills behind. An existing entry that isn't already our link (a hand-written skill with the same name) is refused and reported, never clobbered.
- **Uninstall.** Removes only links that point into the sessions plugin skills dir; anything else stays.
- **Dynamic skills list.** The printout is read from the just-installed `SKILL.md` set — first sentence of each frontmatter description, via a parser shared with `mcp.ts` (extracted to `src/skill-frontmatter.ts`) — so a new skill appears without a setup.ts edit. It only prints for clients that actually receive skills (Claude, Pi).

## Test plan

- New `src/setup.test.ts`: link creation, idempotent relink, refuse-to-clobber, scoped unlink, dynamic list (folded description → first sentence; includes skills the old list forgot).
- End-to-end against a sandboxed `SESSIONS_HOME`: 7 skills linked, dynamic list prints all 7.
- Full suite: the only failures are 10 pre-existing search/eval tests that fail on `main` too whenever a local Ollama is running (they assert lexical-only behavior; the semantic lane changes results). Test-isolation issue worth its own fix, out of scope here.
