### PR TITLE
fix(report): correct usage and cost accounting

### DIFF
--- a/src/report/aggregate.report.test.ts
+++ b/src/report/aggregate.report.test.ts
@@ -42,11 +42,11 @@ describe('aggregate (report mode)', () => {
   });
 
   test('summary totals', () => {
-    // Claude totalTokens = 1000+500+200 = 1700 (cacheRead excluded).
+    // Claude totalTokens = 1000+500+10000+200 = 11700.
     // Claude cost (per-token claude-opus-4-6: in 5e-6, out 25e-6, cacheRead 0.5e-6, cacheWrite 6.25e-6)
     //   = 1000*5e-6 + 500*25e-6 + 10000*0.5e-6 + 200*6.25e-6 = 0.02375 -> 0.02
     // Pi totalTokens = 3000, cost passthrough 0.12.
-    expect(data.summary.totalTokens).toBe(4700);
+    expect(data.summary.totalTokens).toBe(14700);
     expect(data.summary.totalCostUSD).toBe(0.14);
     expect(data.summary.sessions).toBe(2);
     expect(data.summary.messages).toBe(2);
@@ -57,10 +57,34 @@ describe('aggregate (report mode)', () => {
     expect(data.summary.favoriteModel.id).toBe('claude-opus-4-6');
   });
 
+  test('prices Fast mode through the aggregate path', () => {
+    const usage = { input: 1_000_000, output: 0, cacheRead: 0, cacheWrite: 0 };
+    const make = (speed?: 'fast') =>
+      aggregate({
+        events: [
+          {
+            tool: 'claude-code',
+            provider: 'anthropic',
+            model: 'claude-opus-4-8',
+            timestamp: '2026-06-01T14:30:00Z',
+            sessionId: 'fast',
+            tokens: usage,
+            speed,
+          },
+        ],
+        prs: [],
+        now: '2026-06-01T14:30:00Z',
+        tz: 'UTC',
+        exclude: new Set<string>(),
+        priorDaily: [],
+      });
+    expect(make('fast').summary.totalCostUSD).toBe(make().summary.totalCostUSD * 2);
+  });
+
   test('daily entries', () => {
     expect(data.daily.length).toBe(2);
     expect(data.daily[0]!.date).toBe('2026-06-01');
-    expect(data.daily[0]!.tokens).toBe(1700);
+    expect(data.daily[0]!.tokens).toBe(11700);
     expect(data.daily[0]!.costUSD).toBe(0.02);
     expect(data.daily[0]!.hourCounts[14]).toBe(1);
     expect(data.daily[1]!.date).toBe('2026-06-02');

--- a/src/report/aggregate.ts
+++ b/src/report/aggregate.ts
@@ -1,6 +1,6 @@
-// VENDORED from tokenmaxing/src/aggregate.ts (public contract: schemaVersion 2) with ONE local
-// divergence: the 'opencode' TOOL_LABEL entry is a sessions-owned extension — see the matching
-// note in ./types.ts. When re-syncing with upstream, preserve it. Do not edit other logic here.
+// VENDORED from tokenmaxing/src/aggregate.ts (public contract: schemaVersion 2) with two local
+// divergences: the 'opencode' TOOL_LABEL entry, and totalTokens includes cache reads so the report
+// reflects all processed tokens. When re-syncing with upstream, preserve both.
 import type {
   TokenmaxingData,
   ToolBreakdown,
@@ -65,14 +65,12 @@ interface EnrichedEvent {
 }
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
-// Excludes cache_read (replayed prior context — mostly free reuse, not "new work").
-// cache_creation (cacheWrite) IS counted because those are new tokens written to cache.
-const totalTokens = (t: UsageEvent['tokens']) => t.input + t.output + t.cacheWrite;
+const totalTokens = (t: UsageEvent['tokens']) => t.input + t.output + t.cacheRead + t.cacheWrite;
 
 function enrich(events: UsageEvent[], tz: string): EnrichedEvent[] {
   return events.map((e) => ({
     e,
-    cost: e.costUSD ?? computeCost(e.model, e.tokens),
+    cost: e.costUSD ?? computeCost(e.model, e.tokens, e.speed),
     date: localDate(e.timestamp, tz),
     hour: localHour(e.timestamp, tz),
     basename: resolveProject(e.projectPath),

--- a/src/report/event-cache.ts
+++ b/src/report/event-cache.ts
@@ -26,7 +26,8 @@ import type { AgentName } from './parsers/claude-code.ts';
 // v2: the Pi parser changed what it emits per file (dedupKeys, subagent-run
 // attribution, compaction usage, zero-usage skips) — a v1 pi parse served from
 // cache would silently miss all of it, so old caches are rebuilt.
-const SCHEMA_VERSION = 2;
+// v3: Claude events retain the Fast mode flag used for historical pricing.
+const SCHEMA_VERSION = 3;
 
 export function getEventCachePath(): string {
   return join(getCacheDir(), 'usage.db');

--- a/src/report/facets.ts
+++ b/src/report/facets.ts
@@ -134,8 +134,7 @@ export interface ReportFacets {
 export const TOP_DISPATCHES = 20;
 export const TOP_SESSIONS = 15;
 
-// Same convention as aggregate.ts: cache reads are replayed context, not new work.
-const billableTokens = (t: UsageEvent['tokens']) => t.input + t.output + t.cacheWrite;
+const processedTokens = (t: UsageEvent['tokens']) => t.input + t.output + t.cacheRead + t.cacheWrite;
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
 const round4 = (n: number) => Math.round(n * 10_000) / 10_000;
@@ -159,8 +158,8 @@ function cacheStats(events: UsageEvent[]): CacheStats {
       // Price the same tokens twice — once as cache reads, once as fresh input —
       // through the real pricing path, so tiering and per-model rates apply.
       const zero = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-      const asRead = computeCost(e.model, { ...zero, cacheRead: e.tokens.cacheRead });
-      const asInput = computeCost(e.model, { ...zero, input: e.tokens.cacheRead });
+      const asRead = computeCost(e.model, { ...zero, cacheRead: e.tokens.cacheRead }, e.speed);
+      const asInput = computeCost(e.model, { ...zero, input: e.tokens.cacheRead }, e.speed);
       saved += Math.max(0, asInput - asRead);
     }
   }
@@ -200,7 +199,7 @@ function subagentReport(events: UsageEvent[], costOf: (e: UsageEvent) => number,
     const cost = costOf(e);
     totalCost += cost;
     if (!e.agent) continue;
-    const tokens = billableTokens(e.tokens);
+    const tokens = processedTokens(e.tokens);
     subCost += cost;
     subTokens += tokens;
 
@@ -306,7 +305,7 @@ function sessionCosts(events: UsageEvent[], costOf: (e: UsageEvent) => number, t
       slots.set(key, s);
     }
     const cost = costOf(e);
-    s.tokens += billableTokens(e.tokens);
+    s.tokens += processedTokens(e.tokens);
     s.cost += cost;
     s.messages++;
     if (e.agent) s.subagentCost += cost;
@@ -432,7 +431,7 @@ export function computeBurn(
   period: { from: string; to: string; runsTo?: string | null },
   todayLocal: string,
 ): BurnStats {
-  const costOf = (e: UsageEvent) => e.costUSD ?? computeCost(e.model, e.tokens);
+  const costOf = (e: UsageEvent) => e.costUSD ?? computeCost(e.model, e.tokens, e.speed);
   const spent = inRange.reduce((t, e) => t + costOf(e), 0);
   // The period's own horizon, which for `--this-month` is the end of the month
   // rather than the last day that has data. Projecting against the reported range
@@ -457,7 +456,7 @@ export function computeBurn(
 }
 
 export function computeFacets(events: UsageEvent[], tz: string): ReportFacets {
-  const costOf = (e: UsageEvent) => e.costUSD ?? computeCost(e.model, e.tokens);
+  const costOf = (e: UsageEvent) => e.costUSD ?? computeCost(e.model, e.tokens, e.speed);
   const sessions = sessionCosts(events, costOf, tz);
   const mix = modelMix(events, costOf, tz);
   return {

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -258,8 +258,7 @@ function accentDecls(p: Palette): string {
 const GLOSSARY = {
   totalCost:
     'Estimated from public per-token list prices. If you are on a Pro or Max plan this is what the same usage would have cost through the API, not what you were billed.',
-  tokens:
-    'Input + output + cache writes. Cache reads are excluded: they are context replayed from cache, not new work. Cache volume has its own card below.',
+  tokens: 'Input + output, including prompt-cache reads and writes.',
   sessions:
     'Distinct sessions counted per day and summed, so a session running past midnight counts on each day it touched.',
   messages: 'Assistant responses — one per API response, after de-duplicating resumed and forked transcripts.',
@@ -272,7 +271,7 @@ const GLOSSARY = {
   perSession: 'Total estimated cost divided by the number of distinct sessions.',
   perActiveDay: 'Total estimated cost divided by the days with at least one message.',
   msgsPerDay: 'Assistant responses divided by the days with at least one message.',
-  tokensPerDay: 'Billable tokens divided by the days with at least one message.',
+  tokensPerDay: 'Processed tokens divided by the days with at least one message.',
   volume:
     'A rough equivalence, not a precise count: roughly 0.75 words per token against published word counts, or about 9 tokens per line for source trees. The unit is chosen from a pool of comparisons that land near your own magnitude, seeded on this period so it stays the same every time you open the report.',
   rhythm:
@@ -293,10 +292,8 @@ const GLOSSARY = {
     'What the prompt cache returned over the period: those cache reads priced at full input rates, minus what they actually cost. The one figure on this page that is money you did not spend.',
   hitRate:
     'Share of prompt-side tokens served from cache rather than re-sent. Higher is better; a falling rate means context is being rebuilt instead of reused.',
-  cacheRead:
-    'Tokens replayed from the prompt cache, billed at roughly a tenth of the input rate. Not included in the token total.',
-  cacheWrite:
-    'Tokens written into the prompt cache, billed at a premium over input. These are new work, so they ARE included in the token total.',
+  cacheRead: 'Tokens replayed from the prompt cache, billed at roughly a tenth of the input rate.',
+  cacheWrite: 'Tokens written into the prompt cache, billed at a premium over input.',
   burn: 'Spend so far against a straight-line projection to the end of the period, and against the equally long window immediately before it.',
   distribution:
     'The shape of session spend across every session in the period, not just the ones listed. A max far above the median means a few sessions carry the bill.',

--- a/src/report/index.test.ts
+++ b/src/report/index.test.ts
@@ -157,7 +157,7 @@ describe('runReport', () => {
     expect(report.generator).toBe('sessions');
     expect(report.version).toBe(1);
     expect(report.weeklyHighlights).toBeUndefined();
-    expect(report.summary.totalTokens).toBe(1700);
+    expect(report.summary.totalTokens).toBe(11700);
     expect(readFileSync(res.htmlPath!, 'utf8').startsWith('<!DOCTYPE html>')).toBe(true);
   });
 

--- a/src/report/parsers.test.ts
+++ b/src/report/parsers.test.ts
@@ -14,16 +14,21 @@ interface JsonObject {
   [key: string]: JsonValue;
 }
 
-function claudeLine(opts: { id?: string; requestId?: string; input?: number }): string {
-  const message: JsonObject = {
-    model: 'claude-opus-4-8',
-    usage: {
-      input_tokens: opts.input ?? 1000,
-      output_tokens: 500,
-      cache_creation_input_tokens: 200,
-      cache_read_input_tokens: 10000,
-    },
+function claudeLine(opts: {
+  id?: string;
+  requestId?: string;
+  input?: number;
+  output?: number;
+  speed?: 'standard' | 'fast';
+}): string {
+  const usage: JsonObject = {
+    input_tokens: opts.input ?? 1000,
+    output_tokens: opts.output ?? 500,
+    cache_creation_input_tokens: 200,
+    cache_read_input_tokens: 10000,
   };
+  if (opts.speed) usage.speed = opts.speed;
+  const message: JsonObject = { model: 'claude-opus-4-8', usage };
   if (opts.id !== undefined) message.id = opts.id;
   const line: JsonObject = {
     type: 'assistant',
@@ -45,6 +50,20 @@ describe('parseClaudeCode dedup', () => {
     writeFileSync(join(root, 'proj', 'b.jsonl'), claudeLine({ id: 'msg_1', requestId: 'req_1' }));
     const events = await parseClaudeCode(root);
     expect(events.length).toBe(1);
+  });
+
+  test('keeps the complete usage from streamed records sharing one response id', async () => {
+    const root = join(tmp, 'claude-streamed');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'a.jsonl'),
+      claudeLine({ id: 'msg_stream', requestId: 'req_stream', output: 5, speed: 'fast' }) +
+        claudeLine({ id: 'msg_stream', requestId: 'req_stream', output: 500, speed: 'fast' }),
+    );
+    const events = await parseClaudeCode(root);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.tokens.output).toBe(500);
+    expect(events[0]!.speed).toBe('fast');
   });
 
   test('keeps distinct message.id events', async () => {

--- a/src/report/parsers/claude-code.ts
+++ b/src/report/parsers/claude-code.ts
@@ -40,6 +40,7 @@ const claudeAssistantLineSchema = z.object({
           output_tokens: z.number().optional(),
           cache_creation_input_tokens: z.number().optional(),
           cache_read_input_tokens: z.number().optional(),
+          speed: z.enum(['standard', 'fast']).optional().catch(undefined),
           cache_creation: z
             .object({
               ephemeral_5m_input_tokens: z.number().optional(),
@@ -164,6 +165,7 @@ export async function parseClaudeCodeFile(path: string): Promise<ParsedFile> {
       },
     };
     if (assistant.gitBranch) event.branch = assistant.gitBranch;
+    if (u.speed) event.speed = u.speed;
     // The same API response is rewritten into every resumed/forked session
     // file; this key lets the merge count it once. Absent when the record has
     // no message id, in which case it cannot be deduped.
@@ -186,16 +188,30 @@ export function resolveAgentTypes(events: UsageEvent[], agentTypes: Record<strin
   }
 }
 
-/** Drop repeats of the same API response, keeping the first occurrence. */
+/** Drop repeats of the same API response, keeping its most complete usage record. */
 export function dedupeEvents(events: UsageEvent[]): UsageEvent[] {
-  const seen = new Set<string>();
+  const positions = new Map<string, number>();
   const out: UsageEvent[] = [];
+  const volume = (e: UsageEvent) => e.tokens.input + e.tokens.output + e.tokens.cacheRead + e.tokens.cacheWrite;
   for (const e of events) {
-    if (e.dedupKey) {
-      if (seen.has(e.dedupKey)) continue;
-      seen.add(e.dedupKey);
+    if (!e.dedupKey) {
+      out.push(e);
+      continue;
     }
-    out.push(e);
+    const position = positions.get(e.dedupKey);
+    if (position === undefined) {
+      positions.set(e.dedupKey, out.length);
+      out.push(e);
+      continue;
+    }
+    const current = out[position]!;
+    if (
+      volume(e) > volume(current) ||
+      (volume(e) === volume(current) && (e.costUSD ?? 0) > (current.costUSD ?? 0)) ||
+      (volume(e) === volume(current) && e.speed === 'fast' && current.speed !== 'fast')
+    ) {
+      out[position] = e;
+    }
   }
   return out;
 }

--- a/src/report/parsers/types.ts
+++ b/src/report/parsers/types.ts
@@ -18,6 +18,8 @@ export interface UsageEvent {
     cacheWrite1h?: number; // subset of cacheWrite written to the 1h cache (billed at input×2)
   };
   costUSD?: number; // only set when source pre-computes (Pi); otherwise computed downstream
+  /** Anthropic Fast mode charges a 2× premium for supported Opus models. */
+  speed?: 'standard' | 'fast';
   /** Set when the event came from a dispatched subagent rather than the main loop.
    *  `id` is the dispatch id (one per Task/Agent invocation); `type` is the agent
    *  type ('Explore', 'general-purpose', a plugin agent, …) — Pi does not record

--- a/src/report/pricing.test.ts
+++ b/src/report/pricing.test.ts
@@ -106,6 +106,14 @@ describe('computeCost arithmetic', () => {
     expect(cost).toBeCloseTo(expected, 12);
   });
 
+  test('Fast mode doubles Opus 4.8 and Opus 5 pricing', () => {
+    const usage = counts({ input: 1000, output: 2000, cacheRead: 4000, cacheWrite: 800 });
+    for (const model of ['claude-opus-4-8', 'claude-opus-5']) {
+      expect(computeCost(model, usage, 'fast')).toBeCloseTo(computeCost(model, usage) * 2, 12);
+    }
+    expect(computeCost('claude-fable-5', usage, 'fast')).toBeCloseTo(computeCost('claude-fable-5', usage), 12);
+  });
+
   test('1h cache-creation is priced at input×2 (5m stays at the cache_create rate)', () => {
     // opus-4-8: input 5e-6 → 1h rate 10e-6; cacheWrite (5m) rate 6.25e-6.
     const all1h = computeCost('claude-opus-4-8', counts({ cacheWrite: 1000, cacheWrite1h: 1000 }));

--- a/src/report/pricing.ts
+++ b/src/report/pricing.ts
@@ -432,9 +432,20 @@ export function resetPricingWarnings(): void {
   warnings = [];
 }
 
-export function computeCost(modelId: string, usage: UsageCounts): number {
+// Fast mode doubles Opus 4.8/5 base rates; prompt-cache multipliers stack on top.
+// https://platform.claude.com/docs/en/about-claude/pricing#fast-mode-pricing
+const FAST_MODE_MODELS = ['claude-opus-4-8', 'claude-opus-5'] as const;
+
+function fastModeMultiplier(modelId: string, speed: 'standard' | 'fast' | undefined): number {
+  if (speed !== 'fast') return 1;
+  const normalized = normalizedPricingKey(modelId);
+  return FAST_MODE_MODELS.some((model) => containsPricingKey(normalized, model)) ? 2 : 1;
+}
+
+export function computeCost(modelId: string, usage: UsageCounts, speed?: 'standard' | 'fast'): number {
+  const multiplier = fastModeMultiplier(modelId, speed);
   const p = find(modelId);
-  if (p) return priceWith(p, usage);
+  if (p) return priceWith(p, usage) * multiplier;
 
   const total = usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
   const family = findFamily(modelId);
@@ -443,7 +454,7 @@ export function computeCost(modelId: string, usage: UsageCounts): number {
     return 0;
   }
   if (total > 0) warnings.push({ model: modelId, tokens: total, pricedAs: family.key });
-  return priceWith(family.pricing, usage);
+  return priceWith(family.pricing, usage) * multiplier;
 }
 
 function priceWith(p: ModelPricing, usage: UsageCounts): number {

--- a/src/report/text.ts
+++ b/src/report/text.ts
@@ -58,7 +58,7 @@ export function renderText(r: UsageReport): string {
   out += rule('=');
 
   out += row('Total cost', fmtUSD(s.totalCostUSD));
-  out += row('Billable tokens', fmtTokens(s.totalTokens));
+  out += row('Tokens processed', fmtTokens(s.totalTokens));
   out += row('Sessions / messages', `${s.sessions.toLocaleString('en-US')} / ${s.messages.toLocaleString('en-US')}`);
   out += row('Active days', `${s.activeDays} (streak ${s.currentStreakDays}, longest ${s.longestStreakDays})`);
   out += row('Peak hour', hourLabel(s.peakHourLocal));

--- a/src/wrapped/index.test.ts
+++ b/src/wrapped/index.test.ts
@@ -176,8 +176,8 @@ describe('runWrapped', () => {
     // 03:30 UTC lands in the small-hours census.
     expect(data.rhythm.nightsPastMidnight).toBe(1);
     expect(data.rhythm.latestNight.clock).toContain('3:30');
-    // Token rule matches the report: input + output + cacheWrite, cacheRead excluded.
-    expect(data.totals.tokens).toBe(5 * (1000 + 500 + 200));
+    // Token rule matches the report: all processed input and output, including cache traffic.
+    expect(data.totals.tokens).toBe(5 * (1000 + 500 + 10000 + 200));
     // Per-tool sessions are distinct (s1 spans June 1 + June 22 — aggregate's
     // sum-of-daily would say 3; the headline total and tools[] must agree).
     expect(data.tools[0].sessions).toBe(2);

--- a/src/wrapped/types.ts
+++ b/src/wrapped/types.ts
@@ -8,7 +8,7 @@ import type { ToolId } from '../report/types.ts';
 import type { PricingWarning } from '../report/schema.ts';
 
 export interface WrappedTotals {
-  /** input + output + cacheWrite — same rule as `sessions report` (cacheRead excluded). */
+  /** All processed input and output, including cache reads and writes. */
   tokens: number;
   cacheReadTokens: number;
   costUSD: number;


### PR DESCRIPTION
## What changed

- keep the most complete usage record when Claude Code writes partial and final records for one response
- capture Claude's `speed` field and apply the documented 2x Fast mode pricing for Opus 4.8 and Opus 5
- include prompt-cache reads in processed-token totals and update report labels
- bump the usage-cache schema so existing cached events rebuild with the new speed field

## Why

The report kept partial streamed usage, discarded Fast mode metadata, and excluded cache reads from the token headline. Together these substantially understated historical cost and token volume.

This remains a local-session report. It does not add ingestion for Cowork or Claude Design.

## Verification

- `SESSIONS_OLLAMA_URL=http://127.0.0.1:1 bun test` (1,185 passed, 9 skipped)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- cold and warm July report runs produced identical corrected totals
